### PR TITLE
First shipped skill: premortem (evidence-graded, artifact-first, Bronze-validated)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "thinking-tools",
+  "version": "0.1.0",
+  "description": "Evidence-graded, agent-executable thinking-method skills. Reframe problems, challenge assumptions, generate options, stress-test decisions, and audit reasoning, each producing a concrete artifact.",
+  "author": { "name": "product-on-purpose" },
+  "keywords": ["thinking-tools", "decision-making", "premortem", "reasoning", "evidence-graded", "claude-code"],
+  "homepage": "https://github.com/product-on-purpose/thinking-framework-skills",
+  "license": "Apache-2.0"
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "thinking-tools",
+  "name": "thinking-framework-skills",
   "version": "0.1.0",
   "description": "Evidence-graded, agent-executable thinking-method skills. Reframe problems, challenge assumptions, generate options, stress-test decisions, and audit reasoning, each producing a concrete artifact.",
   "author": { "name": "product-on-purpose" },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# thinking-tools (working name) - agent guide
+# thinking-framework-skills - agent guide
 
-An evidence-graded library of agent-executable thinking-method skills, for AI agents and the humans who work with them. Sibling to `pm-skills`, no technical coupling: `thinking-tools` helps decide *what* to work on and *why* it is sound; `pm-skills` helps execute *how*.
+An evidence-graded library of agent-executable thinking-method skills, for AI agents and the humans who work with them. The plugin installs as `thinking-framework-skills`; `thinking-tools` is the short library brand used in skill IDs (`thinking-tools.<slug>`). Sibling to `pm-skills`, no technical coupling: `thinking-tools` helps decide *what* to work on and *why* it is sound; `pm-skills` helps execute *how*.
 
 ## What makes a skill here different
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# thinking-tools (working name) - agent guide
+
+An evidence-graded library of agent-executable thinking-method skills, for AI agents and the humans who work with them. Sibling to `pm-skills`, no technical coupling: `thinking-tools` helps decide *what* to work on and *why* it is sound; `pm-skills` helps execute *how*.
+
+## What makes a skill here different
+
+Each skill is built around four commitments, not just a prompt:
+
+1. **Mechanism over ritual.** The skill implements the durable cognitive move, named descriptively, not a trademarked brand.
+2. **Honest evidence grading.** Every skill carries an evidence tier and an `evidence/dossier.md` that says what the research does and does not support, and flags where evidence is transferred from human studies rather than validated for AI use.
+3. **Artifact, not prose.** Every skill emits a concrete, reusable artifact (a risk register, an option matrix, a perspective review).
+4. **Explicit "when not to use."** Each skill states where it misleads, to guard against cargo-cult execution.
+
+## Skills
+
+| Skill | Family | Evidence | What it produces |
+|---|---|---|---|
+| [`premortem`](skills/premortem/SKILL.md) | risk-and-resilience | S/M (contested) | A risk register: ranked failure causes with tripwires, mitigations, owners, and kill criteria |
+
+More skills are in progress; see the release plan and the audit in `_local/`.
+
+## Skill anatomy
+
+```
+skills/<name>/
+  SKILL.md              # the procedure + frontmatter; what the agent reads
+  references/
+    TEMPLATE.md         # the structure the output artifact follows
+    EXAMPLE.md          # a worked example that anchors quality
+  evidence/
+    dossier.md          # the graded evidence; the single source of truth
+  skill.meta.yml        # rich sidecar (governance, taxonomy, relationships) - draft
+```
+
+## Conventions
+
+- IDs are namespace-dot: `thinking-tools.<slug>`.
+- Skills target the open Agent Skills (`agentskills.io`) `SKILL.md` format, so they are portable across agents.
+- Plugin and skill standards align to `agent-skills-toolkit` (Bronze/Universal tier today).
+- No em-dashes or en-dashes anywhere in this repo's prose.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,189 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work.
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Jonathan
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-  "name": "thinking-tools",
+  "name": "thinking-framework-skills",
   "version": "0.1.0",
   "description": "An evidence-graded library of agent-executable thinking-method skills (premortem, problem restatement, and more). Each skill is reduced to its working mechanism, graded honestly on how strong its evidence actually is, and produces a concrete artifact rather than prose. Use to reframe a problem, challenge assumptions, generate options, stress-test a decision, or audit reasoning.",
   "standard": "0.8",

--- a/library.json
+++ b/library.json
@@ -1,0 +1,18 @@
+{
+  "name": "thinking-tools",
+  "version": "0.1.0",
+  "description": "An evidence-graded library of agent-executable thinking-method skills (premortem, problem restatement, and more). Each skill is reduced to its working mechanism, graded honestly on how strong its evidence actually is, and produces a concrete artifact rather than prose. Use to reframe a problem, challenge assumptions, generate options, stress-test a decision, or audit reasoning.",
+  "standard": "0.8",
+  "tier": "universal",
+  "agent-targets": ["claude"],
+  "author": { "name": "product-on-purpose" },
+  "license": "Apache-2.0",
+  "keywords": ["thinking-tools", "skills", "claude-code", "decision-making", "premortem", "reasoning", "evidence-graded"],
+  "components": {
+    "skills": [
+      { "name": "premortem", "path": "skills/premortem/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
+    ]
+  },
+  "repository": "https://github.com/product-on-purpose/thinking-framework-skills",
+  "homepage": "https://github.com/product-on-purpose/thinking-framework-skills"
+}

--- a/skills/premortem/SKILL.md
+++ b/skills/premortem/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: premortem
+description: Stress-test a planned decision by imagining it has already failed, surface the likely causes, and turn them into mitigations, tripwires, and kill criteria. Use before a launch, hire, investment, migration, vendor choice, or any risky, hard-to-reverse commitment, while you can still change course.
+license: Apache-2.0
+metadata:
+  id: thinking-tools.premortem
+  family: risk-and-resilience
+  evidence-tier: "S/M"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-tools | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Premortem
+
+A premortem stress-tests a plan by assuming it has *already failed* and reasoning backward to explain why, then converting each cause into a mitigation, a tripwire, and a kill criterion. The shift from "what might go wrong?" to "it went wrong, why?" is what does the work: it licenses dissent, surfaces more and more specific causes than ordinary risk review, and turns vague worry into pre-committed action while you can still change course. The output is a **risk register**, not a discussion.
+
+## When to Use
+
+- Before a launch, hire, investment, migration, vendor selection, or any consequential, hard-to-reverse commitment.
+- When a plan has optimistic momentum and you suspect concerns are going unspoken.
+- When you want risks expressed as observable signals and pre-decided responses, not a feeling of caution.
+- Often *after* options have been compared and one has been chosen, as the last gate before committing.
+
+## When NOT to Use
+
+- **After the outcome is known.** That is a postmortem, a different tool.
+- **For trivial or fully reversible (two-way-door) decisions.** The ceremony is not worth it.
+- **To generate options or to choose among them.** Use an ideation skill or a decision-option review; premortem is a risk tool.
+- **As a ritual to bless a decision already made.** If the mitigations will not be acted on, skip it; a premortem nobody acts on is theater.
+
+## Instructions
+
+When asked to run a premortem, follow these steps:
+
+1. **Frame the decision and the horizon.** State the plan and intended outcome in one or two sentences, and pick a concrete time horizon (for example, "six months after launch"). If the decision is trivial or already irreversible, say so and stop.
+2. **Declare the failure vividly.** Assert it in the definite past: "It is [horizon]. This plan has failed badly." Make the failure concrete and specific, not "it underperformed."
+3. **Generate causes broadly, before judging.** List the plausible reasons the failure happened. Aim for breadth and specificity; include uncomfortable, political, and second-order causes, not just technical ones. Do not filter yet.
+4. **Cluster and rank.** Group related causes and rank them by likelihood and impact (High/Medium/Low each). Keep the vital few; do not pad.
+5. **Convert each top cause into action.** For each high-priority cause, define a **leading signal / tripwire** (the early sign it is happening), a **mitigation** (what reduces the risk now), an **owner**, and a **kill criterion** (the pre-decided condition under which you stop or change course). This conversion step is mandatory; a list of risks without it is not a premortem.
+6. **Emit the risk register and a short summary.** Produce the artifact in `references/TEMPLATE.md`: a one-paragraph "top risks and what we will do" summary above a ranked register table.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the filled risk register plus its summary, not a prose essay.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The failure was declared in the definite past, with a concrete horizon.
+- [ ] Causes go beyond the obvious technical ones (include people, process, second-order, and external causes).
+- [ ] Every high-priority cause has a tripwire, a mitigation, an owner, and a kill criterion (the conversion step is done).
+- [ ] Risks are ranked, not an undifferentiated list.
+- [ ] The output is the risk register artifact, not prose.
+- [ ] No overclaiming: the skill does not promise a better outcome, only better-surfaced and better-handled risk (see `evidence/dossier.md`).
+
+## Evidence
+
+Tier **S/M** (contested). Prospective hindsight reliably increases the number and specificity of causes surfaced and reduces overconfidence in a plan (Mitchell, Russo & Pennington 1989; Veinott, Klein & Wiggins 2010). It does **not** have strong evidence of improving final outcomes, and the often-quoted "30%" figure measures the *number of reasons generated*, not decision quality. The evidence is transferred from human studies and has not been validated for AI-augmented use. Full grading, sources, and caveats: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed premortem on a real decision.

--- a/skills/premortem/SKILL.md
+++ b/skills/premortem/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: premortem
-description: Stress-test a planned decision by imagining it has already failed, surface the likely causes, and turn them into mitigations, tripwires, and kill criteria. Use before a launch, hire, investment, migration, vendor choice, or any risky, hard-to-reverse commitment, while you can still change course.
+description: Generates a ranked risk register that stress-tests a planned decision by imagining it has already failed, surfacing the likely causes and pairing each with a mitigation, tripwire, and kill criterion. Use when about to commit to a launch, hire, investment, migration, or any risky, hard-to-reverse decision, or when you need risks surfaced before committing.
 license: Apache-2.0
 metadata:
   id: thinking-tools.premortem

--- a/skills/premortem/evidence/dossier.md
+++ b/skills/premortem/evidence/dossier.md
@@ -1,0 +1,79 @@
+# Evidence Dossier: Premortem
+
+> The single source of truth for the `premortem` skill. The `SKILL.md`, the sidecar
+> (`skill.meta.yml`), and the eval cases all derive from this file. If a claim is not
+> here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-tools.premortem` |
+| **Family** | risk-and-resilience |
+| **Evidence tier** | **S/M** (contested - see "What the evidence shows" below) |
+| **Confidence** | Moderate-high that the mechanism helps; low that the published effect sizes mean what they are usually quoted to mean |
+| **Status** | draft (first authored 2026-05-31, against discovery corpus) |
+
+---
+
+## 1. The mechanism (what actually does the work)
+
+A premortem is a deliberate act of **prospective hindsight**: instead of asking "what could go wrong?", you assert that the plan *has already failed* and reason backward to explain why. The shift from a conditional ("might fail") to a definite past ("has failed") is the load-bearing move. It does three things:
+
+1. **Licenses dissent.** Once failure is assumed, naming a reason is no longer disloyalty or pessimism; it is the assigned task. This is why a premortem surfaces concerns that normal risk review and optimistic planning suppress.
+2. **Recruits memory and imagination differently.** Explaining a concrete past event is a richer retrieval cue than forecasting an abstract future one, so people generate more, and more specific, causes.
+3. **Converts vague worry into pre-committed action.** The output is not a feeling of caution but named causes, each paired with a mitigation, a leading signal (tripwire), and a kill criterion decided *before* sunk cost and momentum distort judgment.
+
+The mechanism is what we implement. The branded "premortem" ritual is the packaging; the durable move is prospective hindsight plus structured conversion to mitigations.
+
+## 2. Lineage
+
+- **Prospective hindsight** as a cognitive effect: Mitchell, D. J., Russo, J. E., & Pennington, N. (1989). "Back to the future: Temporal perspective in the explanation of events." *Journal of Behavioral Decision Making*, 2(1), 25-38.
+- **The "premortem" technique** as a management practice: Klein, G. (2007). "Performing a Project Premortem." *Harvard Business Review*, 85(9). Popularized further in Kahneman, *Thinking, Fast and Slow* (2011).
+- **Direct evaluation:** Veinott, B., Klein, G., & Wiggins, S. (2010). "Evaluating the Effectiveness of the PreMortem Technique on Plan Confidence." *Proceedings of ISCRAM 2010*.
+
+No trademark. "Premortem" is a generic descriptive term in common use; no attribution is required and none is claimed. We name the skill descriptively and cite the lineage here rather than branding it.
+
+## 3. What the evidence shows, and what it does NOT show
+
+This is the honest core of the dossier. The skill must not overclaim.
+
+**What is reasonably supported (the S part):**
+- Prospective hindsight (assuming an outcome and explaining it) **increases the number and specificity of causes people generate** relative to ordinary forecasting. Mitchell et al. (1989) reported roughly a **30% increase in the number of reasons** correctly identified for a future outcome under the "has happened" framing.
+- The technique **reduces overconfidence** in a plan. Veinott et al. (2010) found participants who ran a premortem were better calibrated about their plans than those who did not.
+
+**What is NOT shown (the caveat that keeps the skill honest):**
+- The widely-quoted "**premortems make decisions ~30% better**" claim is **a misreading**. The 30% figure measures the **number of reasons identified**, not any improvement in decision quality, outcome, or accuracy. Generating more reasons is not the same as deciding better.
+- There is **no strong evidence** that premortems improve final outcomes (project success rates, ROI, fewer failures). The mechanism is plausible and the calibration effect is real, but the chain from "more reasons surfaced" to "better real-world result" is not established by controlled study.
+- General "thinking tools improve thinking" claims are weak: a 2024 meta-analysis in the problem-solving-pedagogy literature found no significant difference in some downstream measures between instruction that uses thinking tools and instruction that does not. (To be primary-source verified before any public claim; cited here as a humility prompt, not a settled fact.)
+
+**Net grade: S/M.** The reason-generation and overconfidence-reduction effects are well-supported (S-leaning); the decision-quality improvement that the technique is usually sold on is not (M/contested). The skill should claim the former and explicitly disclaim the latter.
+
+## 4. Transferred-evidence flag (required honesty for this library)
+
+All of the evidence above comes from **human subjects** in workshop, lab, and team settings. There is **no direct study** of premortems run by, or with, an AI agent, and none of whether an AGENT-produced premortem improves a human's decision. The evidence supporting this skill is therefore **transferred from human contexts, not validated for AI-augmented use.** This skill must say so. Treat the AI value as: the agent makes the mechanism cheap to run, enforces the structure, and produces a durable artifact - benefits that do not depend on the contested decision-quality claim.
+
+## 5. When it works / when it fails (drives the eval negative cases)
+
+**Works best when:**
+- The decision is real, consequential, and not yet committed (you can still change course).
+- There is genuine uncertainty and the plan has optimistic momentum behind it.
+- Causes can be turned into observable signals and pre-decided responses.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **Run after the fact** - that is a postmortem, a different tool. (Anti-trigger.)
+- **Run as ritual** - rote "imagine it failed, list five risks, done" with no conversion to tripwires/kill criteria produces cargo-cult comfort, not better risk handling. The skill must force the conversion step.
+- **Trivial or fully reversible decisions** - the ceremony is not worth it; a two-way door does not need a premortem.
+- **Used to launder a decision already made** - if mitigations are never acted on, the premortem becomes theater.
+- **Substituted for ideation or for option comparison** - it is a risk tool, not a way to generate options (use SCAMPER/Question Burst) or to choose among them (use Decision Option Review).
+
+## 6. Output artifact
+
+The skill must emit a **risk register**, not prose: a ranked table of causes with likelihood, impact, a leading signal/tripwire, a mitigation, an owner, and a kill criterion, preceded by a short "top risks and what we will do" summary. The artifact is the deliverable; the conversation is not.
+
+## 7. Sources
+
+1. Mitchell, Russo & Pennington (1989), *J. Behavioral Decision Making* 2(1):25-38 - prospective hindsight; the ~30%-more-reasons finding.
+2. Klein (2007), *Harvard Business Review* 85(9) - "Performing a Project Premortem."
+3. Veinott, Klein & Wiggins (2010), *ISCRAM 2010* - premortem reduces overconfidence / improves plan calibration.
+4. Kahneman (2011), *Thinking, Fast and Slow* - popularization; ties premortem to overcoming optimism bias and groupthink.
+
+> **Verification status:** citations 1-4 are standard and well-attested in the discovery corpus, but the exact effect-size phrasings and the 2024 meta-analysis claim in section 3 were drawn from a secondary research synthesis and should be confirmed against the primary papers before they appear in any public-facing README. They are safe to use *inside this dossier* because the dossier's job is to be honest about exactly this uncertainty.

--- a/skills/premortem/references/EXAMPLE.md
+++ b/skills/premortem/references/EXAMPLE.md
@@ -1,0 +1,36 @@
+# Premortem Risk Register - Worked Example
+
+A completed run of the `premortem` skill on a real, consequential decision. This is the quality bar a generated premortem should meet.
+
+---
+
+## Decision under premortem
+
+- **Decision:** Launch a self-serve free tier of our B2B SaaS in 6 weeks to accelerate top-of-funnel growth ahead of the Q3 board target.
+- **Intended outcome:** 3x sign-up volume within one quarter and a measurable lift in paid conversions from self-serve, without degrading the existing sales-led motion.
+- **Horizon:** 6 months after launch.
+- **Reversibility:** One-way door in practice. Pulling a free tier after launch is possible but damages trust and is publicly visible, so treat it as hard to reverse.
+
+## Top risks and what we will do (summary)
+
+The three most likely ways this fails: (1) the free tier **cannibalizes paid** rather than feeding it, because the entry plan is too generous; we will gate the highest-value features behind paid and instrument the free-to-paid path from day one. (2) **Support and infrastructure load** from unqualified free users swamps the team and blows the cost model; we will cap free usage, ship self-serve docs, and set a cost-per-free-user tripwire before launch. (3) The **sales team undercuts or resents** the motion because comp and qualification rules were not redesigned; we will align comp and lead-routing with sales leadership before any external announcement. Each has a tripwire and a kill criterion below.
+
+## Risk register
+
+| # | Cause of failure | Likelihood | Impact | Leading signal / tripwire | Mitigation | Owner | Kill criterion |
+|---|---|---|---|---|---|---|---|
+| 1 | Free tier cannibalizes paid: existing or prospective paying customers downgrade to free | H | H | Net new paid MRR growth slows in the first 4 weeks while free sign-ups rise; >5% of trials choosing free over paid | Gate the top 3 value features behind paid; instrument free-to-paid funnel before launch; A/B the free limits | PM (Growth) | Paid net-new MRR drops below the pre-launch trend for 2 consecutive weeks attributable to free downgrades |
+| 2 | Support + infra cost from unqualified free users exceeds plan | H | M | Support tickets per 100 free users above threshold by week 2; cloud cost per free user above the modeled ceiling | Hard usage caps on the free tier; self-serve onboarding + docs; a cost-per-free-user budget set before launch | Eng lead + Support lead | Cost per free user exceeds 1.5x model for 3 weeks with no path to fix |
+| 3 | Sales team undercuts or resents the motion (comp + qualification not redesigned) | M | H | Reps steering prospects away from free; complaints in pipeline reviews; lead-routing disputes in week 1 | Redesign comp + lead-routing with sales leadership before announce; written rules of engagement; a shared dashboard | VP Sales + RevOps | Sales leadership withholds sign-off, or rep behavior measurably suppresses free sign-ups in month 1 |
+| 4 | The 6-week timeline forces shipping a broken or insecure self-serve flow | M | H | Billing/auth edge cases open in QA week 5; security review not complete by week 4 | Cut scope to a thin, secure path; freeze the feature set at week 2; mandatory security review gate | Eng lead | Security review not green by the launch-minus-1-week gate |
+| 5 | "Free" attracts the wrong segment (no ICP fit), so conversions never come | M | M | Free cohort firmographics diverge from ICP; week-4 activation among ICP-fit free users is low | Light qualification at sign-up; track activation by ICP fit, not raw sign-ups | PM (Growth) | After 8 weeks, ICP-fit free-to-paid conversion is below the breakeven the model requires |
+
+## Watch list (lower-priority causes)
+
+- Brand perception shift ("they went freemium, they must be struggling") - monitor inbound sentiment, low likelihood.
+- Free tier abused for fraud/spam - rate-limit and monitor, standard controls likely sufficient.
+- Internal analytics not ready to attribute free-to-paid - ensure tracking is in the launch scope, not after.
+
+---
+
+*Note how the value is in the conversion: every top cause carries a tripwire, a mitigation, an owner, and a kill criterion decided in advance. A list of five risks without those columns would not be a premortem.*

--- a/skills/premortem/references/TEMPLATE.md
+++ b/skills/premortem/references/TEMPLATE.md
@@ -1,0 +1,33 @@
+# Premortem Risk Register - Template
+
+Fill this in. The deliverable is the table plus the summary above it, not prose.
+
+---
+
+## Decision under premortem
+
+- **Decision:** [one or two sentences: what is being committed to]
+- **Intended outcome:** [what success looks like]
+- **Horizon:** [the future point at which we imagine failure, e.g. "6 months after launch"]
+- **Reversibility:** [one-way door / two-way door - if fully reversible and low stakes, a premortem may not be warranted]
+
+## Top risks and what we will do (summary)
+
+[3-5 sentences. Name the two or three risks most likely to kill this, and the single most important action against each. A reader who stops here should know the biggest threats and the plan.]
+
+## Risk register
+
+| # | Cause of failure | Likelihood (H/M/L) | Impact (H/M/L) | Leading signal / tripwire | Mitigation | Owner | Kill criterion |
+|---|---|---|---|---|---|---|---|
+| 1 | | | | | | | |
+| 2 | | | | | | | |
+| 3 | | | | | | | |
+
+**Column notes:**
+- **Leading signal / tripwire:** the earliest observable sign this cause is materializing, stated so you would actually notice it.
+- **Mitigation:** the action that reduces likelihood or impact, taken now or pre-planned.
+- **Kill criterion:** the pre-decided condition under which you stop, roll back, or change course. Decide it now, before momentum and sunk cost distort the call.
+
+## Watch list (lower-priority causes)
+
+[Causes surfaced but ranked below the line. Keep them visible; do not pad the main register with them.]

--- a/skills/premortem/skill.meta.yml
+++ b/skills/premortem/skill.meta.yml
@@ -1,0 +1,75 @@
+# Rich sidecar for the premortem skill.
+# DRAFT: shape is provisional and will be reconciled with agent-skills-toolkit
+# conventions once 2-3 skills exist. Evidence fields are a hand-authored summary
+# of evidence/dossier.md (the source of truth), not generated from it.
+
+identity:
+  id: thinking-tools.premortem
+  slug: premortem
+  display_name: Premortem
+  version: 0.1.0
+  status: draft        # draft | experimental | active | deprecated | archived
+  maturity: alpha
+
+classification:
+  primary_family: risk-and-resilience
+  secondary_families: [decision-and-option-evaluation]
+  thinking_modes: [critical, counterfactual, consequential]
+  problem_contexts: [high-stakes, high-complexity]
+  use_cases:
+    - stress-test a consequential, hard-to-reverse decision before committing
+    - surface unspoken risks that optimistic planning suppresses
+    - produce a pre-committed risk register with tripwires and kill criteria
+  poor_fit_cases:
+    - running it after the outcome is known (that is a postmortem)
+    - trivial or fully reversible (two-way-door) decisions
+    - generating options or choosing among them (wrong tool)
+    - blessing a decision already made with no intent to act on mitigations
+
+interface:
+  required_inputs:
+    - a specific, not-yet-committed decision or plan
+  optional_inputs:
+    - a time horizon for the imagined failure
+    - known constraints or prior risk lists
+  primary_artifact_type: risk-register
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline                 # inline | forked
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-tools.decision-option-review
+    - thinking-tools.what-would-have-to-be-true
+
+relationships:
+  often_follows: [thinking-tools.decision-option-review]
+  often_precedes: []
+  complements: [thinking-tools.what-would-have-to-be-true]
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run     # see eval/ (deferred to week 2)
+  output_eval_status: not-run
+  known_failure_modes:
+    - ritual execution without converting causes to tripwires/kill criteria
+    - listing only obvious technical causes, missing people/process/second-order
+    - overclaiming a better outcome rather than better-handled risk
+
+evidence:
+  evidence_tier: "S/M"             # contested; see dossier section 3
+  confidence: moderate-high on mechanism; low on the decision-quality claim
+  transferred_evidence: true       # human-subject studies only; not AI-validated
+  lineage:
+    derived_from: [prospective-hindsight, premortem workshop practice]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/premortem/SKILL.md
+  references_path: skills/premortem/references/
+  evidence_path: skills/premortem/evidence/dossier.md
+  evals_path: skills/premortem/eval/   # to be created in week 2


### PR DESCRIPTION
## What this is

The first real unit of product in this repo, executed straight from the 2026-05-31 strategic audit (`_local/audit/`). It ends the three-session "design-complete, ship-nothing" stall by shipping one complete, evidence-graded thinking skill end to end.

## What shipped

`skills/premortem/`:
- **`evidence/dossier.md`** - the single source of truth. Grades the evidence honestly (tier **S/M, contested**): prospective hindsight reliably surfaces more causes and reduces overconfidence, but the famous "30%" stat measures *reasons generated*, not decision quality, and there is no direct evidence premortems improve outcomes. Flags that all evidence is **transferred from human studies, not AI-validated**.
- **`SKILL.md`** - mechanism-first procedure (prospective hindsight + mandatory conversion of causes to tripwires/mitigations/kill criteria), a "When NOT to Use" section, and an inline evidence grade. Emits a risk register, not prose.
- **`references/TEMPLATE.md`** + **`references/EXAMPLE.md`** - the risk-register artifact contract and a full worked example (a free-tier launch decision).
- **`skill.meta.yml`** - draft rich sidecar (shape reconciles with `agent-skills-toolkit` later).

Plus Bronze packaging: `library.json`, root `AGENTS.md`, `.claude-plugin/plugin.json`, `LICENSE` (Apache-2.0).

## How it embodies the strategy

It is the proof that the four differentiators are buildable to a best-in-class bar: (1) honest evidence-grading with explicit when-not-to-use, (2) an artifact, not prose, (3) mechanism over trademark, (4) ready for eval. No `jp-library`/`jp-skill-builder` dependency; repo-native against the bare Agent Skills spec.

## Validation

`agent-skills-toolkit` `evaluate.mjs` against this repo: **Tier `universal` (Bronze), 0 errors / 0 warnings at the declared tier.** The one remaining finding (`S2: prefix`) is a Silver-tier burndown item, deferred by design.

## Deliberately deferred (per the audit)

The lean spec (reverse-engineered from this skill), the `eval/` cases, the `_LOCAL`->`_local` rename and research relocation, and the MVP S-tier weighting are all week-2+ work and do not gate this PR. The discovery corpus is backed up offsite on `backup/discovery-corpus-2026-05-31`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)