### PR TITLE
Sweep brand + add iteration scaffolding (template, authoring loop, backlog)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # thinking-framework-skills - agent guide
 
-An evidence-graded library of agent-executable thinking-method skills, for AI agents and the humans who work with them. The plugin installs as `thinking-framework-skills`. Skill IDs are namespaced `thinking-framework-skills.<method>`, and installable skill names carry a `tfs-` prefix (for example `tfs-premortem`) to avoid cross-plugin collisions. Sibling to `pm-skills`, no technical coupling: `thinking-tools` helps decide *what* to work on and *why* it is sound; `pm-skills` helps execute *how*.
+An evidence-graded library of agent-executable thinking-method skills, for AI agents and the humans who work with them. The plugin installs as `thinking-framework-skills`. Skill IDs are namespaced `thinking-framework-skills.<method>`, and installable skill names carry a `tfs-` prefix (for example `tfs-premortem`) to avoid cross-plugin collisions. Sibling to `pm-skills`, no technical coupling: `thinking-framework-skills` helps decide *what* to work on and *why* it is sound; `pm-skills` helps execute *how*.
 
 ## What makes a skill here different
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **A curated, evidence-graded library of thinking tools for AI agents and the humans who work with them.**
 
-> Most "thinking framework" collections are catalogs of named rituals. This one is built the other way around: every method is reduced to its working mechanism, graded by how strong its evidence actually is, and shipped as an agent-executable skill that produces a concrete artifact. Working concept name: `thinking-tools`.
+> Most "thinking framework" collections are catalogs of named rituals. This one is built the other way around: every method is reduced to its working mechanism, graded by how strong its evidence actually is, and shipped as an agent-executable skill that produces a concrete artifact. Library and plugin name: `thinking-framework-skills`; skills install with a `tfs-` prefix (for example `tfs-premortem`).
 
 > Status: early and aspirational. This README documents the vision, the candidate library, and the proposed conventions. Almost nothing here is locked yet, and the catalog below is a candidate universe ("will, or could, be included"), not a shipped product.
 
@@ -41,7 +41,7 @@ That honesty is the product. A method graded "weak evidence, useful anyway, here
 | Composable into multi-step workflows | A pile of unrelated one-offs |
 | Designed for solo-plus-AI first, teams second | A facilitator-only workshop kit |
 
-**Relationship to `pm-skills`:** sibling library, no technical coupling. A useful one-line split: `thinking-tools` helps decide *what* to work on and *why* it is sound; `pm-skills` helps execute *how*. They are designed to compose, not to depend on each other.
+**Relationship to `pm-skills`:** sibling library, no technical coupling. A useful one-line split: `thinking-framework-skills` helps decide *what* to work on and *why* it is sound; `pm-skills` helps execute *how*. They are designed to compose, not to depend on each other.
 
 <details>
 <summary><strong>Honesty commitments we intend to keep (expand)</strong></summary>
@@ -335,16 +335,19 @@ A layered metadata model is proposed so that each concern has one clean home: a 
 
 ```yaml
 ---
-name: premortem
+name: tfs-premortem
 description: >
-  Stress-test a planned decision by imagining it has already failed, surfacing
-  the likely causes, and proposing mitigations. Use before a launch, hire,
-  investment, or any risky commitment.
+  Generates a ranked risk register that stress-tests a planned decision by imagining
+  it has already failed, surfacing the likely causes and pairing each with a
+  mitigation, tripwire, and kill criterion. Use when about to commit to a launch,
+  hire, investment, migration, or any risky, hard-to-reverse decision.
 license: Apache-2.0
 metadata:
-  thinking-tools.id: thinking-tools.premortem
-  thinking-tools.family: risk-and-resilience
-  thinking-tools.evidence-tier: S
+  id: thinking-framework-skills.premortem
+  family: risk-and-resilience
+  evidence-tier: "S/M"
+  version: 0.1.0
+  standard: "0.8"
 ---
 ```
 
@@ -362,7 +365,7 @@ metadata:
 <details>
 <summary><strong>Taxonomy building blocks (expand)</strong></summary>
 
-- **IDs:** human-readable namespace-dot syntax (`thinking-tools.premortem`), not opaque UUIDs, so relationship references stay legible.
+- **IDs:** human-readable namespace-dot syntax (`thinking-framework-skills.premortem`), not opaque UUIDs, so relationship references stay legible. The installable skill name additionally carries the `tfs-` prefix (`tfs-premortem`).
 - **Families:** the eleven cognitive-operation buckets above are the candidate `family` values; a method may carry one primary and several secondary families.
 - **Evidence tiers:** the seven-tier model (S strong, M moderate, P practitioner, V vendor, A anecdotal, C conceptually plausible, X poor or contradictory). The V-versus-P and A-versus-C distinctions are deliberate: they separate "has a book and case studies but no independent validation" from "long-standing practice," and "popular but unrigorous" from "sound but under-tested."
 - **Risk flags:** binary overrides for trademark exposure, cargo-cult risk, and "popular but evidence-X," surfaced in metadata and honored by the quality gate.

--- a/docs/internal/AUTHORING.md
+++ b/docs/internal/AUTHORING.md
@@ -1,0 +1,67 @@
+# Authoring a skill - the repeatable loop
+
+This is the lean, self-executing process for adding a skill to `thinking-framework-skills`. It is reverse-engineered from the first shipped skill (`tfs-premortem`), which is the reference example. Follow it per skill; do not re-design it.
+
+The discipline: **ship one complete skill at a time, validated, before starting the next.** WIP = 1. The [BACKLOG](release-plans/plan_v0.1.0/BACKLOG.md) always names the single "Now" skill.
+
+---
+
+## Conventions (the contract every skill meets)
+
+**Naming**
+- Installable skill `name` = directory name = `tfs-<method>` (the `tfs-` prefix avoids cross-plugin collisions and is declared as `prefix` in `library.json`).
+- Canonical `metadata.id` = `thinking-framework-skills.<method>` (no `tfs-` in the id; the namespace already conveys the library).
+- `<method>` is the bare, descriptive, kebab-case method name (mechanism over trademark, e.g. `premortem`, `problem-restatement`, `parallel-perspectives-review`).
+
+**The four commitments (what makes a skill best-in-class here)**
+1. **Mechanism over ritual** - implement the durable cognitive move, named descriptively, not a brand.
+2. **Honest evidence grading** - every skill carries an `evidence-tier` and an `evidence/dossier.md` that states what the research does and does NOT support, and flags evidence transferred from human studies (not AI-validated). No laundered statistics.
+3. **Artifact, not prose** - every skill emits a named, structured, reusable artifact (risk register, option matrix, assumption ledger, perspective review).
+4. **Explicit "When NOT to Use"** - every skill states where it misleads, to guard against cargo-cult execution.
+
+**Evidence tiers:** S strong, M moderate, P practitioner, V vendor, A anecdotal, C conceptually plausible, X poor/contradictory. Grade honestly; "P, useful anyway, here is when not to use it" is more trustworthy than a dressed-up "S".
+
+**Skill anatomy** (mirror `skills/tfs-premortem/`):
+```
+skills/tfs-<method>/
+  SKILL.md                 # procedure + frontmatter; what the agent reads
+  references/TEMPLATE.md   # the artifact structure
+  references/EXAMPLE.md    # a worked example (use the shared Northwind scenario)
+  evidence/dossier.md      # graded evidence; the single source of truth
+  skill.meta.yml           # rich sidecar (draft)
+```
+
+**Shared example scenario (for cross-skill coherence):** use **Northwind**, a B2B SaaS weighing a self-serve free-tier launch, as the recurring scenario across `EXAMPLE.md` files where it fits, so the library reads as one product (a lightweight version of pm-skills' "threads").
+
+---
+
+## The per-skill loop
+
+1. **Pick the "Now" skill** from the [BACKLOG](release-plans/plan_v0.1.0/BACKLOG.md). One at a time.
+2. **Gather evidence** for that method from the discovery corpus (committed under `docs/internal/research/` once relocated, or on the `backup/discovery-corpus-2026-05-31` branch): lineage, evidence tier, what the evidence does/does-not show, failure modes, citations. Be honest; flag transferred evidence.
+3. **Scaffold** from the template: copy `templates/skill/` to `skills/tfs-<method>/`.
+4. **Write `evidence/dossier.md` FIRST** (the source of truth). Everything else derives from it.
+5. **Write `SKILL.md`** from the dossier: `tfs-<method>` name (must match the directory), a description that leads with an action verb + a "Use when ..." trigger clause (under 1024 chars, no first person - it is the activation trigger), the four commitments, a bounded procedure, and a quality checklist drawn from the dossier's failure modes.
+6. **Write `references/TEMPLATE.md` and `references/EXAMPLE.md`** (the artifact structure, and a worked example on the Northwind scenario).
+7. **Fill `skill.meta.yml`** (id, family, relationships, failure modes) from the dossier.
+8. **Register** the skill: add the component to `library.json` (`name: tfs-<method>`, `path: skills/tfs-<method>/SKILL.md`).
+9. **Validate to zero errors at Bronze** (the gate):
+   ```
+   node "E:/Projects/product-on-purpose/agent-skills-toolkit/scripts/evaluate.mjs" "E:/Projects/product-on-purpose/thinking-framework-skills"
+   ```
+   Require `Tier: universal`, `0 error(s), 0 warning(s)`. Fix anything flagged. (Silver/Gold items in the burndown are deferred.)
+10. **Commit** on a branch, open a PR, merge. Then update the BACKLOG (mark the skill done, move the "Now" pointer to the next skill).
+
+---
+
+## Guardrails (do not reproduce the stall)
+
+- A working session is not "done" unless it changed a file under `skills/` or committed product. Design-only sessions end by naming the single next build action, not a new decision.
+- Reject any proposal to add a meta-skill pipeline, schema enforcement, catalog generators, CI, or more governance until a concrete pain from a shipped skill demands it. The template + this loop + the evaluator are the whole system for now.
+- Open questions (license confirmation, MVP weighting, the Silver climb, going public) are parallel/later, never gates on the next skill.
+
+---
+
+## Windows note
+
+If you write any helper script, pass explicit UTF-8 encoding. The default cp1252 will silently corrupt content. Prefer no scripts; the loop above needs none beyond the evaluator.

--- a/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
+++ b/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
@@ -1,0 +1,46 @@
+# MVP backlog and build order
+
+The single source of "what to build next." WIP = 1: build the **Now** skill end to end (per [AUTHORING.md](../../AUTHORING.md)), ship it, then move the pointer. Roster is from the audit (Appendix B canonical roster); names use the `tfs-` prefix and `thinking-framework-skills.<method>` ids.
+
+## Now
+
+> **`tfs-problem-restatement`** - the "gateway" reframing skill. Build this next.
+
+## Build order
+
+Statuses: `done` | `now` | `next` | `later`. The two `wk3` rows are the strong-evidence additions that keep the "evidence-graded" brand honest (the consensus roster skews to practitioner-tier methods).
+
+| # | Skill (`tfs-<method>`) | Family | Evidence (provisional) | Wave | Status |
+|---|---|---|---|---|---|
+| 1 | `tfs-premortem` | risk-and-resilience | S/M | showcase | **done (v0.1.0)** |
+| 2 | `tfs-problem-restatement` | problem-framing | M/P | showcase | **now** |
+| 3 | `tfs-evidence-vs-inference-sort` | assumptions | P | showcase | next |
+| 4 | `tfs-what-would-have-to-be-true` | decision | P | showcase | next |
+| 5 | `tfs-scamper` | ideation | P | showcase | next |
+| 6 | `tfs-ladder-of-inference-check` | assumptions | P | mvp | later |
+| 7 | `tfs-parallel-perspectives-review` | perspective | P | mvp | later |
+| 8 | `tfs-question-burst` | ideation | P | mvp | later |
+| 9 | `tfs-futures-wheel` (sub: second-order-effects) | systems | P | mvp | later |
+| 10 | `tfs-decision-option-review` | decision | P | mvp | later |
+| 11 | `tfs-assumption-reversal` | assumptions | P | mvp | later |
+| 12 | `tfs-red-team-light` | assumptions | P | mvp | later |
+| 13 | `tfs-brainwriting` (6-3-5 / NGT) | ideation | **S** | mvp (wk3) | later |
+| 14 | `tfs-reference-class-forecasting` | risk-and-resilience | **S** | mvp (wk3) | later |
+
+## Milestones
+
+- **Showcase (`v0.1.0` -> public preview):** skills 1-5 + 1-2 recipes. Going public also requires making the repo public and re-pinning the held `agent-plugins` listing (branch `stage/thinking-framework-skills-listing`). See the audit, section 6.4 and 6.5 (the demand probe).
+- **Full MVP (`v0.2.0`):** skills 6-14 + the four recipes below.
+
+## Recipes (after 2+ composable skills exist; thin command files)
+
+- `/think:reframe-problem` - problem-restatement -> evidence-vs-inference-sort -> parallel-perspectives-review
+- `/think:expand-options` - problem-restatement -> scamper -> assumption-reversal
+- `/think:stress-test-decision` (marquee) - decision-option-review -> what-would-have-to-be-true -> premortem -> futures-wheel
+- `/think:audit-reasoning` - evidence-vs-inference-sort -> ladder-of-inference-check -> parallel-perspectives-review
+
+## Parallel / later (not gates on the Now skill)
+
+- Relocate the discovery corpus into committed `docs/internal/research/` (secret-scan first); rename `_LOCAL` -> `_local`.
+- Add `eval/` cases per skill (incl. a run vs a frontier model doing the method unaided).
+- Confirm license (Apache-2.0); decide the Silver climb; the go-public flip at the showcase.

--- a/library.json
+++ b/library.json
@@ -8,7 +8,7 @@
   "agent-targets": ["claude"],
   "author": { "name": "product-on-purpose" },
   "license": "Apache-2.0",
-  "keywords": ["thinking-tools", "skills", "claude-code", "decision-making", "premortem", "reasoning", "evidence-graded"],
+  "keywords": ["thinking-frameworks", "skills", "claude-code", "decision-making", "premortem", "reasoning", "evidence-graded"],
   "components": {
     "skills": [
       { "name": "tfs-premortem", "path": "skills/tfs-premortem/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }

--- a/skills/tfs-premortem/SKILL.md
+++ b/skills/tfs-premortem/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   version: 0.1.0
   standard: "0.8"
 ---
-<!-- thinking-tools | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
 # Premortem
 
 A premortem stress-tests a plan by assuming it has *already failed* and reasoning backward to explain why, then converting each cause into a mitigation, a tripwire, and a kill criterion. The shift from "what might go wrong?" to "it went wrong, why?" is what does the work: it licenses dissent, surfaces more and more specific causes than ordinary risk review, and turns vague worry into pre-committed action while you can still change course. The output is a **risk register**, not a discussion.

--- a/templates/skill/SKILL.md
+++ b/templates/skill/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: tfs-REPLACE-method
+description: REPLACE with one sentence. Lead with an action verb (Generates / Produces / Evaluates / Audits / Checks), name the artifact it produces, and include a "Use when ..." clause with concrete trigger words. Third person. Do NOT use first person ("you can", "you should", "we "). Keep under 1024 characters. This text is the activation trigger and is scored by the toolkit (U5).
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.REPLACE-method
+  family: REPLACE-family
+  evidence-tier: "REPLACE"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# REPLACE Display Name
+
+REPLACE: one paragraph. State the durable cognitive MECHANISM (not the trademarked ritual) and the concrete ARTIFACT this skill produces. Make clear the output is a structured artifact, not prose.
+
+## When to Use
+
+- REPLACE: concrete situations that should trigger this skill.
+
+## When NOT to Use
+
+- REPLACE: where this misleads, or is the wrong tool (point to the right one). Pull these from the dossier's failure modes; this section guards against cargo-cult execution.
+
+## Instructions
+
+When asked to REPLACE, follow these steps:
+
+1. **REPLACE step (bold lead-in).** Imperative, bounded, concrete.
+2. **REPLACE step.**
+3. **REPLACE step.** Include the step that converts raw output into the artifact.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the filled artifact plus a short summary, not a prose essay.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] REPLACE checks, derived from the dossier's documented failure modes.
+- [ ] The output is the artifact, not prose.
+- [ ] No overclaiming: claims match what `evidence/dossier.md` actually supports.
+
+## Evidence
+
+Tier **REPLACE**. REPLACE: one or two sentences, honest about what the evidence does and does not show, and noting that it is transferred from human studies (not AI-validated). Full grading, sources, and caveats: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed run.

--- a/templates/skill/evidence/dossier.md
+++ b/templates/skill/evidence/dossier.md
@@ -1,0 +1,45 @@
+# Evidence Dossier: REPLACE Method
+
+> The single source of truth for the `REPLACE` skill. The `SKILL.md`, the sidecar,
+> and the eval cases all derive from this file. If a claim is not here, it does not
+> belong in the skill. Author this FIRST.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.REPLACE-method` (installable name `tfs-REPLACE-method`) |
+| **Family** | REPLACE-family |
+| **Evidence tier** | **REPLACE** (S/M/P/V/A/C/X; be honest, note if contested) |
+| **Confidence** | REPLACE |
+| **Status** | draft (authored YYYY-MM-DD from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+REPLACE: the durable cognitive move, reduced to its working mechanism. Separate the mechanism from the brandable ritual.
+
+## 2. Lineage
+
+REPLACE: where the method comes from, with citations. Note any trademark (and how the descriptive name avoids it).
+
+## 3. What the evidence shows, and what it does NOT show
+
+REPLACE. This is the honest core. State plainly what is supported and what is overclaimed in popular usage. Do not launder statistics (name what a cited number actually measured).
+
+## 4. Transferred-evidence flag (required honesty)
+
+REPLACE. If the evidence is from human subjects rather than AI-augmented use, say so explicitly, and state what the AI value actually is (e.g. makes the mechanism cheap to run, enforces structure, produces a durable artifact).
+
+## 5. When it works / when it fails (drives the eval negative cases and "When NOT to Use")
+
+**Works best when:** REPLACE.
+
+**Fails or misleads when (poor-fit / anti-patterns):** REPLACE. These become the SKILL.md "When NOT to Use" bullets and the eval anti-triggers.
+
+## 6. Output artifact
+
+REPLACE: the named, structured artifact this skill must emit (not prose).
+
+## 7. Sources
+
+1. REPLACE.
+
+> **Verification status:** REPLACE. Note which citations are primary-source-verified vs drawn from secondary synthesis and still need confirmation before any public claim.

--- a/templates/skill/references/EXAMPLE.md
+++ b/templates/skill/references/EXAMPLE.md
@@ -1,0 +1,13 @@
+# REPLACE Artifact - Worked Example
+
+A completed run of the `tfs-REPLACE-method` skill on a real decision. This is the quality bar a generated output should meet.
+
+> Use the shared recurring scenario (Northwind, a B2B SaaS weighing a self-serve free-tier launch) so examples across skills read as one coherent product. See `docs/internal/AUTHORING.md`.
+
+---
+
+[REPLACE: a full, filled-in instance of the artifact from TEMPLATE.md, applied to the Northwind scenario. It should be concrete and realistic enough that a reader sees exactly what "good" looks like.]
+
+---
+
+*Note: REPLACE with the one sentence that captures what makes this artifact valuable (the move a naive prompt would miss).*

--- a/templates/skill/references/TEMPLATE.md
+++ b/templates/skill/references/TEMPLATE.md
@@ -1,0 +1,21 @@
+# REPLACE Artifact - Template
+
+Fill this in. The deliverable is the structured artifact plus the summary above it, not prose.
+
+---
+
+## Subject
+
+- **REPLACE input field:** [what the skill operates on]
+
+## Summary (top of the artifact)
+
+[REPLACE: 3-5 sentences a reader can stop at and still get the headline result.]
+
+## REPLACE artifact body (table or structured block)
+
+| REPLACE col | REPLACE col | REPLACE col |
+|---|---|---|
+| | | |
+
+**Column notes:** REPLACE: define any column whose meaning is not obvious, so the artifact is self-explaining.

--- a/templates/skill/skill.meta.yml
+++ b/templates/skill/skill.meta.yml
@@ -1,0 +1,67 @@
+# Rich sidecar for the tfs-REPLACE-method skill.
+# DRAFT shape; reconciles with agent-skills-toolkit conventions later.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+#
+# Naming: id = thinking-framework-skills.<method>; slug = bare method;
+# installable name = tfs-<method> (matches the skill directory).
+
+identity:
+  id: thinking-framework-skills.REPLACE-method
+  slug: REPLACE-method
+  name: tfs-REPLACE-method
+  display_name: REPLACE
+  version: 0.1.0
+  status: draft        # draft | experimental | active | deprecated | archived
+  maturity: alpha
+
+classification:
+  primary_family: REPLACE-family
+  secondary_families: []
+  thinking_modes: []          # e.g. critical, divergent, systems, counterfactual
+  problem_contexts: []        # e.g. high-stakes, high-ambiguity, high-complexity
+  use_cases:
+    - REPLACE
+  poor_fit_cases:
+    - REPLACE (from dossier section 5)
+
+interface:
+  required_inputs:
+    - REPLACE
+  optional_inputs: []
+  primary_artifact_type: REPLACE      # e.g. risk-register, option-matrix, perspective-review
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions: []               # thinking-framework-skills.<method>
+
+relationships:
+  often_follows: []
+  often_precedes: []
+  complements: []
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - REPLACE (from dossier section 5)
+
+evidence:
+  evidence_tier: "REPLACE"
+  confidence: REPLACE
+  transferred_evidence: true
+  lineage:
+    derived_from: [REPLACE]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-REPLACE-method/SKILL.md
+  references_path: skills/tfs-REPLACE-method/references/
+  evidence_path: skills/tfs-REPLACE-method/evidence/dossier.md
+  evals_path: skills/tfs-REPLACE-method/eval/


### PR DESCRIPTION
Two things:

1. **Sweep** the residual `thinking-tools` working-brand references to `thinking-framework-skills` across README, `library.json` keyword, the `SKILL.md` provenance comment, and AGENTS.md. The README frontmatter example is updated to the actually-shipped convention (`tfs-` name, `thinking-framework-skills.<method>` id).
2. **Iteration scaffolding** so the remaining MVP skills are copy-fill-validate, not reinvent:
   - `templates/skill/` - copy-to-start scaffold for all five skill files.
   - `docs/internal/AUTHORING.md` - the repeatable per-skill loop + conventions + the four commitments + the Bronze evaluator gate, reverse-engineered from `tfs-premortem`.
   - `docs/internal/release-plans/plan_v0.1.0/BACKLOG.md` - the canonical 14-skill roster with a single WIP=1 "Now" pointer (Now = `tfs-problem-restatement`).

Deliberately lean: a template + a loop + the evaluator, not a meta-skill pipeline or CI (those wait until a shipped skill demands them).

Evaluator unchanged: `Tier: universal`, 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)