### PR TITLE
Complete the v0.1.0 showcase: skills 3-5 (evidence-sort, WWHTBT, SCAMPER)

### DIFF
--- a/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
+++ b/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
@@ -4,7 +4,7 @@ The single source of "what to build next." WIP = 1: build the **Now** skill end 
 
 ## Now
 
-> **`tfs-evidence-vs-inference-sort`** - separate verified facts from inference/assumption. Build this next.
+> **`tfs-ladder-of-inference-check`** - trace the jump from data to conclusion to catch silent leaps. Build this next. (Showcase slice 1-5 is complete; this begins the full-MVP tranche.)
 
 ## Build order
 
@@ -14,10 +14,10 @@ Statuses: `done` | `now` | `next` | `later`. The two `wk3` rows are the strong-e
 |---|---|---|---|---|---|
 | 1 | `tfs-premortem` | risk-and-resilience | S/M | showcase | **done (v0.1.0)** |
 | 2 | `tfs-problem-restatement` | problem-framing | M/P | showcase | **done (v0.1.0)** |
-| 3 | `tfs-evidence-vs-inference-sort` | assumptions | P | showcase | **now** |
-| 4 | `tfs-what-would-have-to-be-true` | decision | P | showcase | next |
-| 5 | `tfs-scamper` | ideation | P | showcase | next |
-| 6 | `tfs-ladder-of-inference-check` | assumptions | P | mvp | later |
+| 3 | `tfs-evidence-vs-inference-sort` | reasoning-clarity | P | showcase | **done (v0.1.0)** |
+| 4 | `tfs-what-would-have-to-be-true` | decision | P | showcase | **done (v0.1.0)** |
+| 5 | `tfs-scamper` | divergent-ideation | P | showcase | **done (v0.1.0)** |
+| 6 | `tfs-ladder-of-inference-check` | assumptions | P | mvp | **now** |
 | 7 | `tfs-parallel-perspectives-review` | perspective | P | mvp | later |
 | 8 | `tfs-question-burst` | ideation | P | mvp | later |
 | 9 | `tfs-futures-wheel` (sub: second-order-effects) | systems | P | mvp | later |

--- a/library.json
+++ b/library.json
@@ -12,7 +12,10 @@
   "components": {
     "skills": [
       { "name": "tfs-premortem", "path": "skills/tfs-premortem/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
-      { "name": "tfs-problem-restatement", "path": "skills/tfs-problem-restatement/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
+      { "name": "tfs-problem-restatement", "path": "skills/tfs-problem-restatement/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-evidence-vs-inference-sort", "path": "skills/tfs-evidence-vs-inference-sort/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-what-would-have-to-be-true", "path": "skills/tfs-what-would-have-to-be-true/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-scamper", "path": "skills/tfs-scamper/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
     ]
   },
   "repository": "https://github.com/product-on-purpose/thinking-framework-skills",

--- a/skills/tfs-evidence-vs-inference-sort/SKILL.md
+++ b/skills/tfs-evidence-vs-inference-sort/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: tfs-evidence-vs-inference-sort
+description: Produces an evidence/inference ledger by sorting the claims in a prompt, document, or proposed conclusion into evidence, inference, and assumption, attaching a confidence level to each inference and flagging anything uncited. Use when a recommendation must be trusted, or when you need to audit the reasoning behind a conclusion in a high-stakes context.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.evidence-vs-inference-sort
+  family: reasoning-clarity
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Evidence vs Inference Sort
+
+Reasoning degrades when evidence (what is actually observed or verifiable) is blended with inference (what is deduced) and assumption (an unstated premise). Models are especially prone to this: they present fluent inference in the same confident register as fact. This skill separates them: it labels each claim in a body of text as evidence, inference, or assumption, records the basis for each, attaches a confidence level to inferences, and flags anything uncited. The output is an **evidence/inference ledger**. Note the boundary: this classifies claim *type*; it does not verify that the evidence is *true* (that is a separate, fact-checking job).
+
+## When to Use
+
+- A recommendation, plan, or conclusion must be trusted before it is acted on.
+- High-stakes contexts: legal, medical, financial, safety, architecture and planning.
+- Auditing the reasoning behind a conclusion, including the agent's own.
+- As a step in a reasoning-audit workflow.
+
+## When NOT to Use
+
+- As a fact-checker. It labels what *kind* of claim something is, not whether it is true.
+- On creative or exploratory work where rigor is not the point.
+- On trivial claims, where sorting produces only noise.
+- When the claims are already well-sourced and the leaps are already explicit.
+
+## Instructions
+
+When asked to sort evidence from inference, follow these steps:
+
+1. **Collect the claims.** Break the prompt, document, or proposed conclusion into discrete claims. Keep each to one assertion.
+2. **Label each claim.** Mark it **Evidence** (observed or verifiable, with a source), **Inference** (deduced from other claims), or **Assumption** (an unstated premise it depends on).
+3. **Record the basis.** For evidence, name the source or observation. For inference, name what it is inferred from. For assumption, state the premise plainly.
+4. **Rate inference confidence.** For each inference, assign high / medium / low and say why. Do not treat plausibility as verification.
+5. **Flag the gaps.** Mark anything presented as fact but uncited, and any load-bearing assumption that is unexamined.
+6. **Surface the load-bearing unknowns.** List the few unsupported claims that most need verification before the conclusion is trusted.
+7. **Emit the ledger** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the ledger plus the load-bearing-unknowns list, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] Every claim is labeled evidence, inference, or assumption.
+- [ ] No confident inference is mislabeled as evidence.
+- [ ] Inferences carry a confidence level with a reason.
+- [ ] Uncited "facts" and unexamined assumptions are flagged.
+- [ ] The output does not claim to have verified truth, only sorted claim type.
+- [ ] The output is the ledger artifact, not prose.
+
+## Evidence
+
+Tier **P**. The evidence/inference distinction is a foundational critical-thinking competence (Facione, Delphi Report 1990), and explicit critical-thinking instruction shows moderate gains broadly (strongest for argument mapping, an adjacent technique). This specific "sort into a ledger" method is practitioner-grade, evidence is transferred from human contexts, and the skill verifies claim type, not truth. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed ledger.

--- a/skills/tfs-evidence-vs-inference-sort/evidence/dossier.md
+++ b/skills/tfs-evidence-vs-inference-sort/evidence/dossier.md
@@ -1,0 +1,56 @@
+# Evidence Dossier: Evidence vs Inference Sort
+
+> Single source of truth for the `evidence-vs-inference-sort` skill. The SKILL.md, sidecar, and evals derive from this. If a claim is not here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.evidence-vs-inference-sort` (installable name `tfs-evidence-vs-inference-sort`) |
+| **Family** | reasoning-clarity |
+| **Evidence tier** | **P** (practitioner; the underlying critical-thinking competence has broader support) |
+| **Confidence** | High that the distinction matters; the specific sort is a practitioner technique |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+Reasoning degrades when **evidence** (what is actually observed or verifiable) is silently blended with **inference** (what is deduced) and **assumption** (an unstated premise taken for granted). Language models are especially prone to this: they are probabilistic generators that present fluent inference in the same confident register as fact. The skill forces a separation: take a body of claims (a prompt, a document, or a proposed conclusion) and label each unit as evidence, inference, or assumption, record the basis for each, attach a confidence level to inferences, and flag uncited or unsupported claims. The work is done by making the leaps visible, so they can be challenged before they are built on.
+
+Important boundary: this skill classifies *claim type*, it does not verify that the evidence is *true*. It separates "this is presented as fact" from "this is a deduction"; confirming the facts is a different job.
+
+## 2. Lineage
+
+- Facione's critical-thinking consensus (the 1990 Delphi Report) defines **evaluation** (judging the credibility of statements and the strength of inferential relationships) and **inference** (drawing reasonable conclusions from evidence) as distinct core skills. This skill operationalizes that distinction.
+- The intelligence-analysis tradition (structured analytic techniques) similarly insists on separating evidence from judgment and surfacing assumptions.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Supported:** distinguishing evidence from inference is a foundational critical-thinking competence, and explicit critical-thinking instruction shows moderate gains in reasoning broadly (the strongest related result is for argument mapping, effect sizes around 0.7-0.85; that is adjacent, not this exact technique).
+
+**NOT shown:** there is no controlled evidence that this specific "sort into a ledger" technique improves decisions or that an AI performing it improves a human's judgment. Grade the *technique* as practitioner, not as a proven intervention. Do not imply the sort verifies truth.
+
+## 4. Transferred-evidence flag
+
+Evidence is from human critical-thinking and analysis contexts, not AI-augmented use. Transferred, not AI-validated. The AI value is concrete: a model blends fact and inference by default, so an explicit sort is a direct counter, and the ledger is an inspectable artifact a reviewer can challenge.
+
+## 5. When it works / when it fails
+
+**Works best when:** a conclusion or proposal needs to be trusted; in legal, medical, financial, safety, or architecture-planning contexts; when auditing the reasoning behind a recommendation (this skill's own or another's).
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- The reader mistakes it for fact-checking. It labels claim *type*; it does not confirm the evidence is true.
+- Applied to creative or exploratory work where rigor is not the point.
+- Over-applied to trivial claims, producing noise.
+- Confident inference is mislabeled as evidence (the central failure mode), or plausibility is treated as verification.
+
+## 6. Output artifact
+
+An **evidence / inference ledger**: a table where each claim is tagged Evidence | Inference | Assumption, with its basis or source, a confidence level for inferences, and a flag for anything uncited or unsupported, followed by a short list of the load-bearing unsupported claims that most need verification.
+
+## 7. Sources
+
+1. Facione, P. A. (1990). *Critical Thinking: A Statement of Expert Consensus* (the Delphi Report) - evaluation vs inference as distinct skills.
+2. Structured analytic techniques literature (intelligence analysis) - separating evidence from judgment; key-assumptions checks.
+3. (Adjacent) van Gelder and others on argument mapping effect sizes - supports the broader critical-thinking competence, not this exact technique.
+
+> **Verification status:** the Facione/Delphi distinction is well-attested. The argument-mapping effect sizes are adjacent evidence and should not be presented as evidence *for this technique* in any public claim; they support the family, not the sort.

--- a/skills/tfs-evidence-vs-inference-sort/references/EXAMPLE.md
+++ b/skills/tfs-evidence-vs-inference-sort/references/EXAMPLE.md
@@ -1,0 +1,31 @@
+# Evidence / Inference Ledger - Worked Example
+
+A completed run of `tfs-evidence-vs-inference-sort`, on the shared Northwind scenario. This is the quality bar a generated ledger should meet.
+
+> Northwind is a B2B SaaS weighing a self-serve free-tier launch. Here the skill audits the reasoning in the proposal that argues for it.
+
+---
+
+## Subject
+
+- **What was sorted:** the proposal "We should build a free tier: our competitors all have one, it will triple signups, and more signups means more revenue, so it pays for itself."
+
+## Ledger
+
+| # | Claim | Type | Basis or source | Confidence (inferences) | Flag |
+|---|---|---|---|---|---|
+| 1 | Our competitors all have a free tier | Evidence (claimed) | None given | - | uncited - presented as fact, not sourced |
+| 2 | A free tier will triple signups | Inference | Extrapolated from competitor presence | low - no comparable baseline or test cited | - |
+| 3 | More signups means more revenue | Assumption | Depends on free-to-paid conversion holding | - | unexamined - the load-bearing premise |
+| 4 | The free tier "pays for itself" | Inference | Chains claims 2 and 3 | low - inherits the weakness of both | - |
+| 5 | Q3 growth target requires this approach | Assumption | No alternatives were compared | - | unexamined - assumes no cheaper option exists |
+
+## Load-bearing unknowns
+
+- **Free-to-paid conversion at Northwind's ICP (claim 3):** the whole case rests on it; verify against current self-serve conversion data before committing.
+- **Competitor free-tier reality (claim 1):** presented as fact; confirm which competitors actually offer one and on what terms.
+- **Cheaper alternatives (claim 5):** untested assumption that a free tier is the only path to the target.
+
+---
+
+*Note: the value is catching that claims 3 and 5 are unexamined assumptions doing the heavy lifting, and that claim 1 is an uncited assertion wearing the costume of evidence. The skill did not verify any fact; it exposed which "facts" still need verifying.*

--- a/skills/tfs-evidence-vs-inference-sort/references/TEMPLATE.md
+++ b/skills/tfs-evidence-vs-inference-sort/references/TEMPLATE.md
@@ -1,0 +1,25 @@
+# Evidence / Inference Ledger - Template
+
+Fill this in. The deliverable is the ledger plus the load-bearing-unknowns list, not prose. This sorts claim *type*; it does not verify truth.
+
+---
+
+## Subject
+
+- **What was sorted:** [the prompt, document, or proposed conclusion]
+
+## Ledger
+
+| # | Claim | Type (Evidence / Inference / Assumption) | Basis or source | Confidence (inferences) | Flag |
+|---|---|---|---|---|---|
+| 1 | | | | | |
+| 2 | | | | | |
+
+- **Type:** Evidence = observed/verifiable with a source; Inference = deduced from other claims; Assumption = unstated premise it depends on.
+- **Flag:** mark "uncited" (presented as fact, no source) or "unexamined" (load-bearing assumption not tested).
+
+## Load-bearing unknowns
+
+The few unsupported or low-confidence claims that most need verification before the conclusion is trusted:
+
+- [claim] - why it matters - how to verify.

--- a/skills/tfs-evidence-vs-inference-sort/skill.meta.yml
+++ b/skills/tfs-evidence-vs-inference-sort/skill.meta.yml
@@ -1,0 +1,77 @@
+# Rich sidecar for the tfs-evidence-vs-inference-sort skill.
+# DRAFT shape. A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.evidence-vs-inference-sort
+  slug: evidence-vs-inference-sort
+  name: tfs-evidence-vs-inference-sort
+  display_name: Evidence vs Inference Sort
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: reasoning-clarity
+  secondary_families: [assumption-and-belief-challenge]
+  thinking_modes: [critical, analytical]
+  problem_contexts: [high-stakes, high-complexity]
+  use_cases:
+    - check that a recommendation is trustworthy before acting on it
+    - audit the reasoning behind a conclusion (including the agent's own)
+    - separate verified facts from deductions and unstated assumptions
+  poor_fit_cases:
+    - using it as a fact-checker (it labels claim type, not truth)
+    - creative or exploratory work where rigor is not the point
+    - trivial claims where sorting is only noise
+    - claims that are already well-sourced with explicit leaps
+
+interface:
+  required_inputs:
+    - a body of claims: a prompt, document, or proposed conclusion
+  optional_inputs:
+    - known sources or evidence already gathered
+  primary_artifact_type: evidence-inference-ledger
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.ladder-of-inference-check
+    - thinking-framework-skills.parallel-perspectives-review
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.problem-restatement
+  often_precedes:
+    - thinking-framework-skills.ladder-of-inference-check
+  complements:
+    - thinking-framework-skills.what-would-have-to-be-true
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - mislabeling confident inference as evidence
+    - treating plausibility as verification
+    - over-flagging trivial claims
+    - implying the sort verified truth when it only classified claim type
+
+evidence:
+  evidence_tier: "P"
+  confidence: high that the distinction matters; the specific sort is practitioner-grade
+  transferred_evidence: true
+  lineage:
+    derived_from: [Facione critical-thinking consensus, structured analytic techniques]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-evidence-vs-inference-sort/SKILL.md
+  references_path: skills/tfs-evidence-vs-inference-sort/references/
+  evidence_path: skills/tfs-evidence-vs-inference-sort/evidence/dossier.md
+  evals_path: skills/tfs-evidence-vs-inference-sort/eval/

--- a/skills/tfs-scamper/SKILL.md
+++ b/skills/tfs-scamper/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: tfs-scamper
+description: Generates a structured set of variations on an existing idea, product, or process by running it through seven transformation prompts (substitute, combine, adapt, modify, put to other use, eliminate, reverse), then shortlists the most promising, producing an expansion sheet. Use when you have a seed idea and need to break past the obvious options; not for blank-page ideation.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.scamper
+  family: divergent-ideation
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# SCAMPER
+
+People and models fixate on the first few obvious variations of an idea. SCAMPER counters that by running an existing idea, product, or process through seven transformation prompts, each forcing a different kind of change: Substitute, Combine, Adapt, Modify (magnify or minify), Put to other use, Eliminate, Reverse. It is a later-stage method: it transforms a seed that already exists, it is not a blank-page generator. The output is an **expansion sheet** that ends in a shortlist of the most promising variations, not an undifferentiated pile of ideas.
+
+## When to Use
+
+- A seed idea, product, feature, or process already exists and needs to be pushed past the obvious.
+- Late-stage ideation, or loosening a stuck or merely incremental option set.
+- After the problem is framed and before converging on a choice.
+
+## When NOT to Use
+
+- Blank page. With no seed to transform, there is nothing to operate on; reframe first or use a different generator.
+- When the problem needs reframing, not more options (use problem restatement).
+- When you need to converge and decide (use a decision skill); this diverges.
+- If the result would be volume without selection. The shortlist step is mandatory.
+
+## Instructions
+
+When asked to run SCAMPER, follow these steps:
+
+1. **State the seed.** Name the existing idea, product, or process being transformed, in one sentence.
+2. **Run the seven lenses.** For each, apply the prompt and generate one to three concrete variations:
+   - **Substitute** a component, material, rule, or person.
+   - **Combine** it with another idea, feature, or step.
+   - **Adapt** a solution from a different domain.
+   - **Modify** an attribute (magnify or minify it).
+   - **Put to other use** (a different user, job, or context).
+   - **Eliminate** a part, step, or assumption.
+   - **Reverse** the order, roles, or direction.
+3. **Skip what does not apply.** If a lens yields nothing real, say so rather than padding.
+4. **Shortlist.** Select the three to five most promising variations to carry forward, and say why.
+5. **Emit the expansion sheet** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the per-lens expansion plus the shortlist, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] There was a real seed idea to transform (this is not blank-page ideation).
+- [ ] Each applied lens produced a concrete variation, not a vague gesture.
+- [ ] Lenses that do not apply are skipped with a note, not padded.
+- [ ] A shortlist of three to five variations is selected, with reasons.
+- [ ] The output is the expansion sheet artifact, not prose.
+
+## Evidence
+
+Tier **P**. SCAMPER is a practitioner ideation mnemonic (Eberle 1971, built on Osborn's idea-spurring checklists). Structured prompts can help break functional fixedness and broaden an option set, but there is no strong evidence SCAMPER specifically produces better or more original ideas than other generators, and increasing idea quantity is not the same as quality. Evidence is transferred from human contexts, not AI-validated. Methods with stronger generation evidence (Brainwriting / NGT) are separate skills. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed expansion sheet.

--- a/skills/tfs-scamper/evidence/dossier.md
+++ b/skills/tfs-scamper/evidence/dossier.md
@@ -1,0 +1,64 @@
+# Evidence Dossier: SCAMPER
+
+> Single source of truth for the `scamper` skill. The SKILL.md, sidecar, and evals derive from this. If a claim is not here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.scamper` (installable name `tfs-scamper`) |
+| **Family** | divergent-ideation |
+| **Evidence tier** | **P** (practitioner ideation heuristic) |
+| **Confidence** | Moderate that structured prompts break fixedness; low that SCAMPER specifically outperforms other generators |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+People and models fixate on the first few obvious variations of an idea (functional fixedness). SCAMPER counters this by running an existing idea, product, or process through seven transformation prompts, each forcing a different kind of change:
+
+- **S**ubstitute - swap a component, material, rule, or person.
+- **C**ombine - merge with another idea, feature, or step.
+- **A**dapt - borrow a solution from a different domain.
+- **M**odify - magnify, minify, or change an attribute.
+- **P**ut to other use - apply it to a different user, job, or context.
+- **E**liminate - remove a part, step, or assumption.
+- **R**everse - invert order, roles, or direction.
+
+The work is done by *systematically* forcing variation along axes a free-association brainstorm would skip, then *selecting* the promising few. It is a later-stage method: it transforms a seed that already exists; it is not a blank-page generator.
+
+## 2. Lineage
+
+- Alex Osborn's "idea-spurring questions" checklists (mid-20th-century creativity work) were arranged into the SCAMPER mnemonic by **Bob Eberle** (1971, *SCAMPER: Games for Imagination Development*). Design and innovation guides (Delft design method guide; IMD) document it as a standard later-stage ideation method.
+
+No trademark on the technique; "SCAMPER" is a widely used generic mnemonic. Named descriptively as the skill; lineage cited.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Supported (modestly):** structured ideation prompts can help break functional fixedness and broaden an option set relative to unaided free association. This is consistent with the broader creativity-technique literature.
+
+**NOT shown:** there is no strong controlled evidence that SCAMPER specifically produces better or more original ideas than other structured generators, or that idea *quantity* (which it reliably increases) translates to idea *quality*. Methods with stronger evidence for generation exist (Brainwriting 6-3-5 / Nominal Group Technique reliably beat verbal group brainstorming - those are separate skills, graded S). SCAMPER's honest grade is practitioner.
+
+## 4. Transferred-evidence flag
+
+Evidence is from human ideation contexts, not AI-augmented use. Transferred, not AI-validated. The AI value is specific: a model generates fluent but narrow variations by default; the seven prompts force breadth along defined axes, and the expansion sheet is a structured artifact that ends in a selected shortlist rather than a wall of ideas.
+
+## 5. When it works / when it fails
+
+**Works best when:** a seed idea, product, feature, or process already exists and needs to be pushed past the obvious; late-stage ideation; loosening a stuck or incremental option set.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **Blank page** - with no seed to transform, SCAMPER has nothing to operate on (reframe first, or use a different generator).
+- The problem actually needs **reframing**, not more options (use problem restatement).
+- **Volume without selection** - generating dozens of variants and stopping is the central failure mode; the skill must shortlist.
+- **Mechanical seven-lens application** when only two or three lenses are relevant, padding the output.
+- When you need to **converge and decide** (use a decision skill); SCAMPER diverges.
+
+## 6. Output artifact
+
+A **SCAMPER expansion sheet**: for each of the seven lenses, the prompt and one to three concrete variations it produced (skip lenses that genuinely do not apply, and say so), followed by a shortlist of the three to five most promising variations to carry forward.
+
+## 7. Sources
+
+1. Eberle, B. (1971). *SCAMPER: Games for Imagination Development* - the mnemonic, built on Osborn's idea-spurring checklists.
+2. Delft design guide; IMD innovation guide - SCAMPER as a standard later-stage ideation method.
+3. (Contrast) Diehl & Stroebe and the brainwriting/NGT literature - the methods with stronger generation evidence, noted here so SCAMPER's tier is not overstated.
+
+> **Verification status:** the Eberle/Osborn lineage is well-attested. The "structured prompts help break fixedness" claim is directional from the creativity literature; do not attach a quantified effect to SCAMPER specifically in any public-facing text.

--- a/skills/tfs-scamper/references/EXAMPLE.md
+++ b/skills/tfs-scamper/references/EXAMPLE.md
@@ -1,0 +1,33 @@
+# SCAMPER Expansion Sheet - Worked Example
+
+A completed run of `tfs-scamper`, on the shared Northwind scenario. This is the quality bar a generated sheet should meet.
+
+> Northwind is a B2B SaaS. After problem restatement reframed the goal to "generate qualified pipeline with the least irreversible commitment," SCAMPER expands the seed idea "offer a free tier" into a broader set of growth options.
+
+---
+
+## Seed
+
+- **What is being transformed:** "Offer a self-serve free tier" as the approach to hitting the Q3 growth target.
+
+## Expansion
+
+| Lens | Prompt | Variations generated |
+|---|---|---|
+| Substitute | swap a component or rule | Replace "free forever" with a time-limited extended trial; or free only for one high-value use case |
+| Combine | merge with another step | Pair a gated free tier with guided onboarding; or bundle free access with a partner's distribution |
+| Adapt | borrow from another domain | Adopt a "reverse trial" (full features for 14 days, then auto-downgrade to a limited free plan) |
+| Modify | magnify or minify | Magnify free value for ICP-fit accounts only (gated free); minify or block it for clearly non-ICP signups |
+| Put to other use | different user or job | Use "free" as a sales-assist tool for existing pipeline (free pilots for active deals), not a top-of-funnel magnet |
+| Eliminate | remove a part or assumption | Eliminate the free tier entirely; instead remove friction in the existing paid trial (fix the funnel that may be the real problem) |
+| Reverse | invert roles or motion | Reverse the motion: outbound-led with a free pilot offered to qualified prospects, rather than open self-serve free |
+
+## Shortlist (carry forward)
+
+1. **Gated reverse-trial (Adapt + Modify):** full features, auto-downgrade, ICP-gated. Captures most of the free-tier upside while limiting non-ICP cost. Test conversion in a pilot.
+2. **Fix the paid-trial funnel (Eliminate):** the cheapest, most reversible option; directly addresses the possibility that low conversion, not missing packaging, is the real constraint.
+3. **Outbound + free pilot (Reverse):** qualified-only, low cannibalization risk; fits the "least irreversible commitment" frame.
+
+---
+
+*Note: the value is that Eliminate and Reverse produced the two options that best fit the reframed goal, both cheaper and more reversible than the original "build a free tier." Carry the shortlist into a decision skill, then test the chosen option with What Would Have to Be True and stress-test the plan with premortem.*

--- a/skills/tfs-scamper/references/TEMPLATE.md
+++ b/skills/tfs-scamper/references/TEMPLATE.md
@@ -1,0 +1,28 @@
+# SCAMPER Expansion Sheet - Template
+
+Fill this in. The deliverable is the per-lens expansion plus the shortlist, not prose. Skip lenses that genuinely do not apply (note why).
+
+---
+
+## Seed
+
+- **What is being transformed:** [one sentence: the existing idea, product, or process]
+
+## Expansion
+
+| Lens | Prompt | Variations generated |
+|---|---|---|
+| Substitute | swap a component, material, rule, or person | |
+| Combine | merge with another idea, feature, or step | |
+| Adapt | borrow a solution from another domain | |
+| Modify | magnify or minify an attribute | |
+| Put to other use | a different user, job, or context | |
+| Eliminate | remove a part, step, or assumption | |
+| Reverse | invert order, roles, or direction | |
+
+## Shortlist (carry forward)
+
+The three to five most promising variations, and why:
+
+1. **[variation]** - why it is promising / what to do next with it.
+2. ...

--- a/skills/tfs-scamper/skill.meta.yml
+++ b/skills/tfs-scamper/skill.meta.yml
@@ -1,0 +1,75 @@
+# Rich sidecar for the tfs-scamper skill.
+# DRAFT shape. A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.scamper
+  slug: scamper
+  name: tfs-scamper
+  display_name: SCAMPER
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: divergent-ideation
+  secondary_families: []
+  thinking_modes: [divergent, lateral, creative]
+  problem_contexts: [high-ambiguity]
+  use_cases:
+    - expand an existing idea, product, or process past the obvious options
+    - loosen a stuck or merely incremental option set in later-stage ideation
+  poor_fit_cases:
+    - blank-page ideation with no seed to transform
+    - problems that need reframing rather than more options
+    - converging on or choosing among options (use a decision skill)
+    - generating volume without selecting a shortlist
+
+interface:
+  required_inputs:
+    - a seed idea, product, or process to transform
+  optional_inputs:
+    - constraints or the goal the options should serve
+  primary_artifact_type: scamper-expansion-sheet
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.problem-restatement
+    - thinking-framework-skills.decision-option-review
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.problem-restatement
+  often_precedes:
+    - thinking-framework-skills.decision-option-review
+  complements: []
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - generating volume without selecting a shortlist
+    - superficial tweaks that do not really transform the seed
+    - mechanically applying all seven lenses when only two or three fit
+    - using it on a blank page with no seed
+
+evidence:
+  evidence_tier: "P"
+  confidence: moderate that structured prompts break fixedness; low that SCAMPER specifically outperforms other generators
+  transferred_evidence: true
+  lineage:
+    derived_from: [Osborn idea-spurring checklists, Eberle SCAMPER mnemonic]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-scamper/SKILL.md
+  references_path: skills/tfs-scamper/references/
+  evidence_path: skills/tfs-scamper/evidence/dossier.md
+  evals_path: skills/tfs-scamper/eval/

--- a/skills/tfs-what-would-have-to-be-true/SKILL.md
+++ b/skills/tfs-what-would-have-to-be-true/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: tfs-what-would-have-to-be-true
+description: Converts a strategy, option, or contested claim into the specific conditions that would have to be true for it to be the best choice, rates each condition's confidence, and identifies which load-bearing assumptions to test first, producing an assumption ledger. Use when evaluating a strategic bet, or when a disagreement has become a clash of opinions rather than evidence.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.what-would-have-to-be-true
+  family: decision-and-option-evaluation
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# What Would Have to Be True
+
+When a team debates whether an option is right, it becomes a clash of opinions and the loudest advocate tends to win. This skill flips the question: instead of "is this a good idea?", ask "what would have to be true for this to be the best choice?" That turns a position into explicit conditions, which can be rated for confidence and tested. It depersonalizes disagreement (we are not debating who is right, we are listing conditions and checking them) and separates what *would have to be true* from what *is* true. The output is an **assumption ledger** that ends by naming the one or two conditions worth testing before committing.
+
+## When to Use
+
+- Evaluating a consequential strategic bet or a specific option.
+- A disagreement has hardened into competing opinions with no way to resolve it.
+- A choice rests on optimistic or unstated assumptions.
+- Often after options exist and before a final decision; pairs with a decision-comparison skill and with premortem.
+
+## When NOT to Use
+
+- Trivial or fully reversible decisions where the ceremony is not worth it.
+- To generate options (use an ideation skill) or to choose among several at once (use a decision-comparison skill).
+- As a substitute for actually testing the conditions; listing them is not validating them.
+
+## Instructions
+
+When asked what would have to be true, follow these steps:
+
+1. **State the option or claim** under examination in one sentence (the thing whose conditions you will surface).
+2. **Enumerate the conditions.** List the things that would have to be true for this to be the best choice. Push for the load-bearing and risky ones, not the easy, agreeable ones. Cover demand, economics, execution, competitive response, and stakeholder conditions.
+3. **Mark which are load-bearing.** For each, note why the choice fails if it is false.
+4. **Rate current confidence.** High / medium / low, with a reason. Be honest where you do not know.
+5. **Say how each could be tested.** A cheap test, a signal, or the data that would confirm or kill it.
+6. **Name the killer conditions.** Identify the one or two conditions that are both most load-bearing and least certain. These should be tested before committing.
+7. **Emit the assumption ledger** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the ledger ending in the killer conditions, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] Conditions are framed as "would have to be true," not asserted as already true.
+- [ ] The risky, load-bearing conditions are present, not just easy ones.
+- [ ] Each condition has a confidence level and a way to test it.
+- [ ] One or two killer conditions (load-bearing and uncertain) are named.
+- [ ] The output is the ledger artifact, not prose.
+- [ ] No overclaiming: this structures and tests the bet, it does not prove it (see `evidence/dossier.md`).
+
+## Evidence
+
+Tier **P**. A widely adopted strategy method from Lafley and Martin's *Playing to Win* (2013): reverse-engineer an option into the conditions under which it would be best, then test the ones you are least sure of. It has strong practitioner traction and sound hypothesis discipline, but no controlled evidence of improved outcomes, and the evidence is transferred from human strategy practice, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed assumption ledger.

--- a/skills/tfs-what-would-have-to-be-true/evidence/dossier.md
+++ b/skills/tfs-what-would-have-to-be-true/evidence/dossier.md
@@ -1,0 +1,53 @@
+# Evidence Dossier: What Would Have to Be True
+
+> Single source of truth for the `what-would-have-to-be-true` skill. The SKILL.md, sidecar, and evals derive from this. If a claim is not here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.what-would-have-to-be-true` (installable name `tfs-what-would-have-to-be-true`) |
+| **Family** | decision-and-option-evaluation |
+| **Evidence tier** | **P** (practitioner; respected strategy method) |
+| **Confidence** | High that it improves the quality of a strategy conversation; no controlled outcome evidence |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+When a team debates whether an option is right, the conversation becomes a clash of opinions and the loudest advocate often wins. WWHTBT flips it: instead of asking "is this a good idea?", ask "**what would have to be true for this to be the best choice?**" That converts a position into a set of explicit conditions. The conditions can then be assessed for current confidence and, crucially, the few that are both load-bearing and uncertain can be tested before committing. The work is done by (a) depersonalizing disagreement (we are not debating who is right, we are listing conditions and checking them) and (b) separating what *would have to be true* from what *is* true, which exposes the assumptions a choice silently rests on.
+
+## 2. Lineage
+
+- Roger Martin and A.G. Lafley, *Playing to Win* (2013), and Martin's related HBR strategy work, introduce "what would have to be true" as a reverse-engineering test for strategic options: rather than defend a favorite, articulate the conditions under which each option would be the best one, then test the conditions you are least sure of.
+
+No trademark on the phrase. Named descriptively; lineage cited.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Supported (as practice):** it is a widely adopted strategy method with strong practitioner traction, and it has a sound logical basis (converting claims to testable conditions is good hypothesis discipline).
+
+**NOT shown:** there is no controlled study that WWHTBT improves decision outcomes or accuracy. Its value is in structuring the conversation and surfacing assumptions; do not claim a measured effect on results.
+
+## 4. Transferred-evidence flag
+
+Evidence is from human strategy practice, not AI-augmented use. Transferred, not AI-validated. The AI value: a model will happily argue for or against an option; forcing it to enumerate the conditions that would have to hold, and to flag the riskiest, is a direct counter to confident advocacy, and the ledger is testable and inspectable.
+
+## 5. When it works / when it fails
+
+**Works best when:** evaluating a consequential strategic bet or option; a disagreement has become a clash of opinions; a choice rests on optimistic or unstated assumptions.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- Trivial or fully reversible decisions where the ceremony is not worth it.
+- Listing conditions but never prioritizing or testing them (the central failure mode).
+- Generating agreeable, easy-to-meet conditions instead of the load-bearing risky ones.
+- Confusing "would have to be true" (a condition to test) with "is true" (already verified).
+- It tests a given option or claim; it does not generate options (use ideation) or choose among several (use a decision-comparison skill, though it pairs well with one).
+
+## 6. Output artifact
+
+An **assumption ledger**: each condition that would have to hold, why it is load-bearing, current confidence (high/medium/low), how it could be tested, and a test priority. It ends by naming the one or two "killer" conditions that are both most load-bearing and least certain, which should be tested before committing.
+
+## 7. Sources
+
+1. Lafley, A. G., & Martin, R. L. (2013). *Playing to Win: How Strategy Really Works*.
+2. Martin, R. L. - HBR strategy writing on reverse-engineering options and testing the assumptions you are least sure of.
+
+> **Verification status:** the attribution to Lafley & Martin / *Playing to Win* is well-attested. Treat all effectiveness as practitioner-reported; do not attach a quantified outcome claim in any public-facing text.

--- a/skills/tfs-what-would-have-to-be-true/references/EXAMPLE.md
+++ b/skills/tfs-what-would-have-to-be-true/references/EXAMPLE.md
@@ -1,0 +1,31 @@
+# Assumption Ledger - Worked Example
+
+A completed run of `tfs-what-would-have-to-be-true`, on the shared Northwind scenario. This is the quality bar a generated ledger should meet.
+
+> Northwind is a B2B SaaS weighing a self-serve free-tier launch. Here the skill tests the option "launch a free tier" by surfacing what would have to be true for it to be the best growth move.
+
+---
+
+## Option or claim under examination
+
+- **The choice:** Launching a self-serve free tier is the best way to hit Northwind's Q3 growth target.
+
+## Conditions that would have to be true
+
+| # | Condition that must hold | Why it is load-bearing | Confidence | How to test it |
+|---|---|---|---|---|
+| 1 | Free-to-paid conversion among ICP-fit free users is high enough to cover the free tier's cost | If conversion is too low, the free tier is pure cost and does not produce paid growth | low | Cohort analysis of current self-serve conversion; a small gated pilot measuring ICP-fit free-to-paid |
+| 2 | The free tier attracts ICP-fit users, not mostly tire-kickers | Growth in non-ICP signups does not convert and inflates cost | low | Light qualification at signup; measure firmographic fit of free cohort in a pilot |
+| 3 | The free tier does not materially cannibalize paid plans | Downgrades would offset or exceed new growth | medium | Limited rollout; monitor downgrade rate and trial-to-free vs trial-to-paid |
+| 4 | Support and infrastructure cost per free user stays within budget | Cost overrun breaks unit economics regardless of growth | medium | Cost model + a usage-capped pilot with a cost-per-free-user ceiling |
+| 5 | Sales cooperates (comp and lead-routing realigned before launch) | Reps steering away from free suppresses the whole motion | medium | Written rules of engagement and sign-off from sales leadership |
+| 6 | No cheaper path hits the Q3 target with less irreversible commitment | If a cheaper option exists, the free tier is not the *best* choice | low | Quick comparison against 2-3 alternatives (funnel fix, outbound, partnerships) |
+
+## Killer conditions (test these before committing)
+
+- **Condition 1 (ICP-fit conversion economics)** - confidence low - cheapest test: a gated pilot to ~100 ICP-fit free users measuring conversion and cost. If it fails, the free tier produces cost without paid growth and the whole case collapses.
+- **Condition 6 (no cheaper path)** - confidence low - cheapest test: a one-day comparison of alternatives. If a funnel fix or outbound hits the target cheaper, the free tier is not the best choice even if it works.
+
+---
+
+*Note: the value is forcing conditions 1 and 6 into the open. The original proposal asserted growth; this ledger shows the bet rests on two low-confidence conditions that a small pilot and a one-day comparison could de-risk before committing engineering to a one-way door. From here, run `tfs-premortem` on the chosen plan.*

--- a/skills/tfs-what-would-have-to-be-true/references/TEMPLATE.md
+++ b/skills/tfs-what-would-have-to-be-true/references/TEMPLATE.md
@@ -1,0 +1,25 @@
+# Assumption Ledger (What Would Have to Be True) - Template
+
+Fill this in. The deliverable is the ledger ending in the killer conditions, not prose.
+
+---
+
+## Option or claim under examination
+
+- **The choice:** [one sentence: the option or claim whose conditions you are surfacing]
+
+## Conditions that would have to be true
+
+| # | Condition that must hold | Why it is load-bearing | Confidence (H/M/L) | How to test it |
+|---|---|---|---|---|
+| 1 | | | | |
+| 2 | | | | |
+| 3 | | | | |
+
+Push for the risky, load-bearing conditions (demand, economics, execution, competitive response, stakeholders), not the easy, agreeable ones.
+
+## Killer conditions (test these before committing)
+
+The one or two conditions that are both most load-bearing and least certain:
+
+- **[condition]** - confidence [L/M] - cheapest test: [...] - if it fails, the choice fails because [...].

--- a/skills/tfs-what-would-have-to-be-true/skill.meta.yml
+++ b/skills/tfs-what-would-have-to-be-true/skill.meta.yml
@@ -1,0 +1,76 @@
+# Rich sidecar for the tfs-what-would-have-to-be-true skill.
+# DRAFT shape. A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.what-would-have-to-be-true
+  slug: what-would-have-to-be-true
+  name: tfs-what-would-have-to-be-true
+  display_name: What Would Have to Be True
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: decision-and-option-evaluation
+  secondary_families: [assumption-and-belief-challenge, strategy-and-opportunity]
+  thinking_modes: [strategic, critical, counterfactual]
+  problem_contexts: [high-stakes, high-conflict]
+  use_cases:
+    - evaluate a consequential strategic bet or option
+    - resolve a disagreement that has become a clash of opinions
+    - surface the load-bearing assumptions a choice silently rests on
+  poor_fit_cases:
+    - trivial or fully reversible decisions
+    - generating options (use ideation) or choosing among several (use a decision-comparison skill)
+    - substituting condition-listing for actually testing the conditions
+
+interface:
+  required_inputs:
+    - a specific option, strategy, or contested claim to examine
+  optional_inputs:
+    - known constraints, data, or stakeholder positions
+  primary_artifact_type: assumption-ledger
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.decision-option-review
+    - thinking-framework-skills.premortem
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.problem-restatement
+    - thinking-framework-skills.decision-option-review
+  often_precedes:
+    - thinking-framework-skills.premortem
+  complements:
+    - thinking-framework-skills.evidence-vs-inference-sort
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - listing conditions but never prioritizing or testing them
+    - generating agreeable, easy-to-meet conditions instead of the risky load-bearing ones
+    - confusing "would have to be true" with "is true"
+
+evidence:
+  evidence_tier: "P"
+  confidence: high that it improves the strategy conversation; no controlled outcome evidence
+  transferred_evidence: true
+  lineage:
+    derived_from: [Lafley and Martin, Playing to Win]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-what-would-have-to-be-true/SKILL.md
+  references_path: skills/tfs-what-would-have-to-be-true/references/
+  evidence_path: skills/tfs-what-would-have-to-be-true/evidence/dossier.md
+  evals_path: skills/tfs-what-would-have-to-be-true/eval/


### PR DESCRIPTION
Finishes the 5-skill showcase, all built through `docs/internal/AUTHORING.md`, all evidence-graded honestly, all artifact-first, all using the shared **Northwind** scenario so they compose into one coherent thread (restate -> SCAMPER options -> WWHTBT test -> premortem).

- **`tfs-evidence-vs-inference-sort`** (P) - evidence/inference ledger; classifies claim type, explicitly does not verify truth.
- **`tfs-what-would-have-to-be-true`** (P) - assumption ledger ending in the killer conditions to test first (Lafley & Martin).
- **`tfs-scamper`** (P) - seven-lens expansion sheet ending in a shortlist; honest that quantity != quality.

All five showcase skills validate at `Tier universal, 0 errors / 0 warnings`. Backlog: 1-5 done; Now = `tfs-ladder-of-inference-check` (begins the full-MVP tranche).

🤖 Generated with [Claude Code](https://claude.com/claude-code)