### PR TITLE
Complete the MVP: skills 6-14 (the full 14-skill thinking-framework-skills v0.x catalog)

### DIFF
--- a/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
+++ b/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
@@ -4,7 +4,7 @@ The single source of "what to build next." WIP = 1: build the **Now** skill end 
 
 ## Now
 
-> **`tfs-ladder-of-inference-check`** - trace the jump from data to conclusion to catch silent leaps. Build this next. (Showcase slice 1-5 is complete; this begins the full-MVP tranche.)
+> **All 14 MVP skills are complete and validated (Tier universal, 0/0).** Next build action: the 4 recipes (thin `/think:*` command files), then per-skill `eval/` cases. Going live is gated on your go (make the repo public, re-pin and merge the held `agent-plugins` listing).
 
 ## Build order
 
@@ -17,15 +17,15 @@ Statuses: `done` | `now` | `next` | `later`. The two `wk3` rows are the strong-e
 | 3 | `tfs-evidence-vs-inference-sort` | reasoning-clarity | P | showcase | **done (v0.1.0)** |
 | 4 | `tfs-what-would-have-to-be-true` | decision | P | showcase | **done (v0.1.0)** |
 | 5 | `tfs-scamper` | divergent-ideation | P | showcase | **done (v0.1.0)** |
-| 6 | `tfs-ladder-of-inference-check` | assumptions | P | mvp | **now** |
-| 7 | `tfs-parallel-perspectives-review` | perspective | P | mvp | later |
-| 8 | `tfs-question-burst` | ideation | P | mvp | later |
-| 9 | `tfs-futures-wheel` (sub: second-order-effects) | systems | P | mvp | later |
-| 10 | `tfs-decision-option-review` | decision | P | mvp | later |
-| 11 | `tfs-assumption-reversal` | assumptions | P | mvp | later |
-| 12 | `tfs-red-team-light` | assumptions | P | mvp | later |
-| 13 | `tfs-brainwriting` (6-3-5 / NGT) | ideation | **S** | mvp (wk3) | later |
-| 14 | `tfs-reference-class-forecasting` | risk-and-resilience | **S** | mvp (wk3) | later |
+| 6 | `tfs-ladder-of-inference-check` | assumption-and-belief-challenge | P | mvp | **done** |
+| 7 | `tfs-parallel-perspectives-review` | perspective-and-multi-lens | P (flag) | mvp | **done** |
+| 8 | `tfs-question-burst` | divergent-ideation | P | mvp | **done** |
+| 9 | `tfs-futures-wheel` (sub: second-order-effects) | systems-and-consequences | P | mvp | **done** |
+| 10 | `tfs-decision-option-review` | decision-and-option-evaluation | P (flag) | mvp | **done** |
+| 11 | `tfs-assumption-reversal` | divergent-ideation | P | mvp | **done** |
+| 12 | `tfs-red-team-light` | assumption-and-belief-challenge | P (flag) | mvp | **done** |
+| 13 | `tfs-brainwriting` (6-3-5 / NGT) | divergent-ideation | **S** | mvp | **done** |
+| 14 | `tfs-reference-class-forecasting` | risk-and-resilience | **S** | mvp | **done** |
 
 ## Milestones
 

--- a/library.json
+++ b/library.json
@@ -17,7 +17,10 @@
       { "name": "tfs-what-would-have-to-be-true", "path": "skills/tfs-what-would-have-to-be-true/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-scamper", "path": "skills/tfs-scamper/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-ladder-of-inference-check", "path": "skills/tfs-ladder-of-inference-check/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
-      { "name": "tfs-parallel-perspectives-review", "path": "skills/tfs-parallel-perspectives-review/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
+      { "name": "tfs-parallel-perspectives-review", "path": "skills/tfs-parallel-perspectives-review/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-question-burst", "path": "skills/tfs-question-burst/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-futures-wheel", "path": "skills/tfs-futures-wheel/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-decision-option-review", "path": "skills/tfs-decision-option-review/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
     ]
   },
   "repository": "https://github.com/product-on-purpose/thinking-framework-skills",

--- a/library.json
+++ b/library.json
@@ -15,7 +15,9 @@
       { "name": "tfs-problem-restatement", "path": "skills/tfs-problem-restatement/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-evidence-vs-inference-sort", "path": "skills/tfs-evidence-vs-inference-sort/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-what-would-have-to-be-true", "path": "skills/tfs-what-would-have-to-be-true/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
-      { "name": "tfs-scamper", "path": "skills/tfs-scamper/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
+      { "name": "tfs-scamper", "path": "skills/tfs-scamper/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-ladder-of-inference-check", "path": "skills/tfs-ladder-of-inference-check/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-parallel-perspectives-review", "path": "skills/tfs-parallel-perspectives-review/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
     ]
   },
   "repository": "https://github.com/product-on-purpose/thinking-framework-skills",

--- a/library.json
+++ b/library.json
@@ -20,7 +20,11 @@
       { "name": "tfs-parallel-perspectives-review", "path": "skills/tfs-parallel-perspectives-review/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-question-burst", "path": "skills/tfs-question-burst/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-futures-wheel", "path": "skills/tfs-futures-wheel/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
-      { "name": "tfs-decision-option-review", "path": "skills/tfs-decision-option-review/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
+      { "name": "tfs-decision-option-review", "path": "skills/tfs-decision-option-review/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-assumption-reversal", "path": "skills/tfs-assumption-reversal/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-red-team-light", "path": "skills/tfs-red-team-light/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-brainwriting", "path": "skills/tfs-brainwriting/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-reference-class-forecasting", "path": "skills/tfs-reference-class-forecasting/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
     ]
   },
   "repository": "https://github.com/product-on-purpose/thinking-framework-skills",

--- a/skills/tfs-assumption-reversal/SKILL.md
+++ b/skills/tfs-assumption-reversal/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: tfs-assumption-reversal
+description: Generates non-obvious ideas by surfacing the foundational assumptions a problem or solution rests on, negating each, and reframing from the reversed assumptions, then shortlisting, producing an assumptions-and-reversals sheet. Use when an option space feels stuck inside default constraints, or when you need to expose premises that are taken for granted.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.assumption-reversal
+  family: divergent-ideation
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Assumption Reversal
+
+Solutions stay trapped inside the assumptions a problem is stated with. Assumption reversal makes those premises explicit, negates or reverses each, and generates ideas from the reversed world. It is not generic inversion ("how would we cause failure?"); it targets the foundational premises the option space rests on and uses their reversal as an idea generator. The output is an **assumptions-and-reversals sheet** ending in a shortlist. Reversed assumptions are candidates to explore, not recommendations.
+
+## When to Use
+
+- An option space feels stuck inside default constraints.
+- The obvious solutions all seem to share a hidden premise.
+- Early divergent exploration, when breadth matters more than convergence.
+
+## When NOT to Use
+
+- When the binding constraints are genuinely fixed (regulatory, physical) and cannot be reversed in reality.
+- When you need to converge and choose (use a decision skill).
+- As a source of recommendations (it produces candidates, not decisions).
+- If it would only reverse trivial, cosmetic assumptions.
+
+## Instructions
+
+When asked to run assumption reversal, follow these steps:
+
+1. **State the problem or solution** in one line.
+2. **Surface the foundational assumptions.** List the load-bearing premises it rests on (business model, user, channel, sequence, who pays, what is required). Push for the ones so basic they are usually unspoken.
+3. **Reverse each.** Negate or invert the assumption ("what if the opposite were true?").
+4. **Generate from the reversal.** For each reversed assumption, write the ideas it provokes. Keep the ideas genuinely tied to the reversal.
+5. **Shortlist.** Pick the most promising non-obvious ideas to carry forward, and note what would have to be true for each to be viable.
+6. **Emit the sheet** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the assumptions, reversals, ideas, and shortlist, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The assumptions surfaced are load-bearing, not trivial.
+- [ ] Each assumption is genuinely reversed, not just reworded.
+- [ ] The ideas are tied to the reversal, not generic.
+- [ ] A shortlist of non-obvious ideas is selected, flagged as candidates not decisions.
+- [ ] The output is the sheet artifact, not prose.
+
+## Evidence
+
+Tier **P**. Assumption reversal is a recognized divergent-ideation technique from lateral-thinking practice, distinct from inversion. Deliberately challenging default premises broadens the option set, but there is no strong evidence it outperforms other generators, and reversing an assumption does not make the reversal viable. Evidence is transferred from human creativity practice, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed sheet.

--- a/skills/tfs-assumption-reversal/evidence/dossier.md
+++ b/skills/tfs-assumption-reversal/evidence/dossier.md
@@ -1,0 +1,52 @@
+# Evidence Dossier: Assumption Reversal
+
+> Single source of truth for the `assumption-reversal` skill. The SKILL.md, sidecar, and evals derive from this.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.assumption-reversal` (installable name `tfs-assumption-reversal`) |
+| **Family** | divergent-ideation |
+| **Evidence tier** | **P** (practitioner creativity technique) |
+| **Confidence** | Moderate that perturbing assumptions yields novel options; the gain is breadth, not correctness |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+Solutions stay trapped inside the assumptions a problem is stated with ("software is sold by subscription", "the user needs a screen", "onboarding requires a signup"). Assumption reversal makes those premises explicit, negates or reverses each, and generates ideas from the reversed world. It differs from generic inversion (which asks "how would we cause failure?"): this targets the **foundational premises** the option space rests on, and uses their reversal as a generator. For a model specifically, reversing a load-bearing assumption pushes generation into the less-obvious regions it would otherwise skip.
+
+## 2. Lineage
+
+- A staple of lateral-thinking and creative-problem-solving practice (assumption-busting / assumption reversal). The discovery research flags it as a distinct white-space technique, separate from inversion.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Supported (modestly):** structured perturbation of assumptions is a recognized divergent-ideation technique; deliberately challenging defaults broadens the option set relative to working inside them.
+
+**NOT shown:** no strong controlled evidence that assumption reversal outperforms other generators, and reversing an assumption proves nothing about whether the reversal is viable. It generates candidates; it does not validate them. Grade P.
+
+## 4. Transferred-evidence flag
+
+Evidence is from human creativity practice, not AI-augmented use. Transferred, not AI-validated. The AI value: a model anchors hard on the assumptions in the prompt; forcing it to name and reverse the load-bearing ones is a direct counter to that anchoring, and the sheet is a structured artifact.
+
+## 5. When it works / when it fails
+
+**Works best when:** an option space feels stuck inside default constraints; the obvious solutions all share a hidden premise; early divergent exploration.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- Reversing trivial or cosmetic assumptions rather than the load-bearing ones.
+- Generating ideas with no real link to the reversal (decoration).
+- Treating a reversed assumption, or an idea from it, as a recommendation (it is a candidate, not a decision).
+- When the binding constraints are genuinely fixed (regulatory, physical) and cannot be reversed in reality.
+- When you need to converge and choose (use a decision skill).
+
+## 6. Output artifact
+
+An **assumptions-and-reversals sheet**: the foundational assumptions listed, each with its reversal, the ideas the reversal provokes, and then a shortlist of the most promising non-obvious ideas to carry forward.
+
+## 7. Sources
+
+1. Lateral-thinking / creative-problem-solving practice on assumption reversal and assumption-busting (distinct from inversion).
+
+> **Verification status:** the technique is well-attested in creativity practice; treat effectiveness as practitioner-level. Do not present reversed assumptions as validated options.

--- a/skills/tfs-assumption-reversal/references/EXAMPLE.md
+++ b/skills/tfs-assumption-reversal/references/EXAMPLE.md
@@ -1,0 +1,31 @@
+# Assumptions-and-Reversals Sheet - Worked Example
+
+A completed run of `tfs-assumption-reversal`, on the shared Northwind scenario. This is the quality bar a generated sheet should meet.
+
+> Northwind is a B2B SaaS stuck on growth options that all assume the same things. Here the skill reverses the premises under "how we acquire customers."
+
+---
+
+## Subject
+
+- How Northwind acquires new customers (the growth motion).
+
+## Assumptions and reversals
+
+| # | Foundational assumption | Reversed | Ideas the reversal provokes |
+|---|---|---|---|
+| 1 | Users sign up, then we convert them | They are converted before they sign up | Sell the outcome via a done-for-you pilot; signup is the last step, not the first |
+| 2 | Each company buys its own seats | Someone else pays for their access | Partner/marketplace bundles; an integration partner includes Northwind for its customers |
+| 3 | Growth means more new logos | Growth comes from existing accounts | Expansion-led growth: land tiny, expand within the account; no new free-tier funnel needed |
+| 4 | Acquisition is self-serve and async | Acquisition is high-touch and synchronous | Concierge onboarding for a narrow ICP segment that converts at a premium |
+| 5 | We must lower the barrier to entry (free) | We raise the barrier deliberately | Invite-only / qualified-access positioning that increases perceived value and ICP fit |
+
+## Shortlist (carry forward)
+
+1. **Expansion-led growth (reverse of #3)** - would have to be true: existing accounts have meaningful unpenetrated seats/use cases. Cheap to test from current account data, and sidesteps the entire free-tier debate.
+2. **Partner-paid distribution (reverse of #2)** - would have to be true: a partner with the right install base exists and benefits from bundling. Higher effort, large upside.
+3. **Qualified-access positioning (reverse of #5)** - would have to be true: scarcity raises ICP conversion more than openness raises volume. Directly contradicts the free-tier instinct, worth a small test.
+
+---
+
+*Note: the value is that reversing assumptions #3 and #5 produced options that make the free-tier question moot (grow from existing accounts; or go more exclusive, not less). These are candidates - feed the shortlist into a decision review, not straight into a build.*

--- a/skills/tfs-assumption-reversal/references/TEMPLATE.md
+++ b/skills/tfs-assumption-reversal/references/TEMPLATE.md
@@ -1,0 +1,24 @@
+# Assumptions-and-Reversals Sheet - Template
+
+Fill this in. The deliverable is the assumptions, reversals, ideas, and shortlist, not prose. Surface load-bearing assumptions, not trivial ones. Ideas are candidates, not decisions.
+
+---
+
+## Subject
+
+- [one line: the problem or solution being challenged]
+
+## Assumptions and reversals
+
+| # | Foundational assumption | Reversed | Ideas the reversal provokes |
+|---|---|---|---|
+| 1 | | | |
+| 2 | | | |
+| 3 | | | |
+
+## Shortlist (carry forward)
+
+The most promising non-obvious ideas, with the condition each would need to be viable:
+
+1. **[idea]** - from reversing [assumption] - would have to be true: [...].
+2. ...

--- a/skills/tfs-assumption-reversal/skill.meta.yml
+++ b/skills/tfs-assumption-reversal/skill.meta.yml
@@ -1,0 +1,77 @@
+# Rich sidecar for the tfs-assumption-reversal skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.assumption-reversal
+  slug: assumption-reversal
+  name: tfs-assumption-reversal
+  display_name: Assumption Reversal
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: divergent-ideation
+  secondary_families: [problem-framing, assumption-and-belief-challenge]
+  thinking_modes: [divergent, lateral, counterfactual]
+  problem_contexts: [high-ambiguity]
+  use_cases:
+    - break an option space out of its default constraints
+    - expose foundational premises that are taken for granted
+    - generate non-obvious options early in divergent exploration
+  poor_fit_cases:
+    - binding constraints that are genuinely fixed and cannot be reversed
+    - converging on or choosing among options (use a decision skill)
+    - treating reversed assumptions as recommendations
+    - reversing trivial, cosmetic assumptions
+
+interface:
+  required_inputs:
+    - a problem or solution whose assumptions to challenge
+  optional_inputs:
+    - the goal, known constraints
+  primary_artifact_type: assumptions-and-reversals-sheet
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.problem-restatement
+    - thinking-framework-skills.scamper
+    - thinking-framework-skills.decision-option-review
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.problem-restatement
+  often_precedes:
+    - thinking-framework-skills.decision-option-review
+  complements:
+    - thinking-framework-skills.scamper
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - reversing trivial assumptions rather than the load-bearing ones
+    - ideas not genuinely tied to the reversal
+    - treating a reversed assumption or its ideas as a recommendation
+
+evidence:
+  evidence_tier: "P"
+  confidence: moderate that perturbing assumptions yields novelty; the gain is breadth not correctness
+  transferred_evidence: true
+  lineage:
+    derived_from: [lateral-thinking assumption-busting]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-assumption-reversal/SKILL.md
+  references_path: skills/tfs-assumption-reversal/references/
+  evidence_path: skills/tfs-assumption-reversal/evidence/dossier.md
+  evals_path: skills/tfs-assumption-reversal/eval/

--- a/skills/tfs-brainwriting/SKILL.md
+++ b/skills/tfs-brainwriting/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: tfs-brainwriting
+description: Generates ideas the way silent parallel brainwriting does, producing several independent idea streams that build on each other without anchoring on the first voice, then consolidates them into a shortlisted idea pool. Use when you need breadth of options and want to avoid the anchoring and conformity that make ordinary brainstorming underperform.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.brainwriting
+  family: divergent-ideation
+  evidence-tier: "S"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Brainwriting
+
+Verbal group brainstorming reliably underperforms: only one person talks at a time (production blocking), and the room anchors on the first speaker. Brainwriting removes those losses by generating ideas silently and in parallel, then building on each other's written ideas. This skill adapts that for solo-plus-AI: produce several genuinely independent idea streams (distinct angles, generated without contaminating each other), then run a build-on round and consolidate into a shortlist. The output is an **idea pool**. The key is keeping the streams independent first; collapsing into one stream throws away the mechanism that does the work.
+
+## When to Use
+
+- You need breadth of options and want to avoid premature convergence.
+- Anchoring or conformity would otherwise narrow the ideas (a single brainstorm).
+- Early divergent generation, before any selection.
+
+## When NOT to Use
+
+- When you need to converge, rank, or decide (use a decision skill).
+- When deep single-expert reasoning beats breadth.
+- If the result would be volume with no build-on and no selection.
+
+## Instructions
+
+When asked to brainwrite, follow these steps:
+
+1. **State the prompt** for ideation in one line.
+2. **Generate independent streams.** Produce 3 to 4 separate idea streams, each from a distinct angle, persona, or constraint, generated as if blind to the others. Keep them visibly separate. Aim for a quota per stream.
+3. **Build on, across streams.** Now combine and extend: take ideas from one stream and push them with another's logic. This is where brainwriting beats parallel lists.
+4. **Consolidate and de-duplicate.** Merge near-duplicates; keep the distinct ideas.
+5. **Shortlist.** Select the strongest ideas to carry forward, noting why.
+6. **Emit the idea pool** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the separate streams, the build-on round, and a consolidated shortlist, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The streams were genuinely independent, not one list relabeled.
+- [ ] A build-on round combined and extended across streams.
+- [ ] Near-duplicates are merged; distinct ideas kept.
+- [ ] A shortlist is selected with reasons.
+- [ ] The output is the idea pool artifact, not prose.
+
+## Evidence
+
+Tier **S**. Across decades of replicated studies, silent parallel generation (nominal groups, brainwriting) outproduces traditional verbal brainstorming in quantity and quality of ideas, because it removes production blocking and anchoring (Diehl & Stroebe 1987; Mullen, Johnson & Salas 1991 meta-analysis; methods from Rohrbach 1968 and Delbecq & Van de Ven 1971). The strong evidence is for human groups; the solo-plus-AI adaptation transfers the mechanism (independent parallel streams plus build-on) but does not inherit a measured AI effect size. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed idea pool.

--- a/skills/tfs-brainwriting/evidence/dossier.md
+++ b/skills/tfs-brainwriting/evidence/dossier.md
@@ -1,0 +1,57 @@
+# Evidence Dossier: Brainwriting (6-3-5 / Nominal Group Technique)
+
+> Single source of truth for the `brainwriting` skill. The SKILL.md, sidecar, and evals derive from this. This is one of the library's strong-evidence anchors.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.brainwriting` (installable name `tfs-brainwriting`) |
+| **Family** | divergent-ideation |
+| **Evidence tier** | **S** (strong; replicated experimental evidence) |
+| **Confidence** | High - this is among the best-evidenced ideation findings |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+Verbal group brainstorming reliably underperforms because of **production blocking** (only one person talks at a time, so ideas are lost or suppressed while waiting), plus anchoring on the first speaker and social conformity. Brainwriting removes those losses: people generate ideas **silently, in parallel, in writing**, then build on each other's written ideas. 6-3-5 is one protocol (6 people, 3 ideas each, 5-minute rounds, pass and build); Nominal Group Technique (NGT) is the close cousin (independent silent generation first, then round-robin sharing and ranking). The active ingredients are silent parallel generation, independence before discussion, and structured build-on.
+
+**Adaptation for solo-plus-AI:** the agent simulates several genuinely independent idea streams (distinct angles or personas generating without seeing each other first), then builds on them and consolidates. This captures the mechanism (parallel independent generation + build-on) even without multiple humans. Be honest that the social diversity of real participants is only approximated.
+
+## 2. Lineage
+
+- Brainwriting 6-3-5 (Bernd Rohrbach, 1968). Nominal Group Technique (Delbecq & Van de Ven, 1971).
+- Evidence base: Diehl & Stroebe (1987) demonstrated production blocking in brainstorming; Mullen, Johnson & Salas (1991) meta-analysis found nominal/brainwriting groups reliably produce more and better ideas than interacting verbal brainstorming groups.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Strongly supported (the S):** across decades of replicated studies, silent parallel generation (nominal groups, brainwriting) outproduces traditional verbal brainstorming in both quantity and quality of ideas. As the discovery research puts it, "brainstorming the activity has consistently failed replication for nearly 40 years; the underlying mechanisms - silent parallel generation, idea quotas, structured build-on - work robustly." This is a genuine strong-evidence result and a credibility anchor for an evidence-graded library.
+
+**Boundaries (still honest):** the evidence is about humans in groups. The solo-plus-AI adaptation transfers the *mechanism*; it does not inherit a measured effect size for AI use. And brainwriting improves *generation*; it is not a selection or decision method.
+
+## 4. Transferred-evidence flag
+
+The strong evidence is for human groups. The AI adaptation (simulated independent streams) is transferred, not AI-validated. The AI value is real regardless: parallel independent generation plus build-on is a structured counter to a model's tendency to produce one anchored stream of ideas.
+
+## 5. When it works / when it fails
+
+**Works best when:** you need breadth of options and want to avoid anchoring and conformity; early divergent generation; when a single brainstorm would converge too fast.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- Collapsing into a single idea stream, losing the parallel independence that does the work (the central failure mode for the AI adaptation).
+- Generating volume with no build-on and no selection.
+- Treating it as a decision or convergence method.
+- When deep single-expert reasoning beats breadth.
+
+## 6. Output artifact
+
+An **idea pool**: several independent idea streams generated in parallel (kept visibly separate at first), a build-on round that combines and extends across streams, and a consolidated, de-duplicated shortlist of the strongest ideas.
+
+## 7. Sources
+
+1. Rohrbach, B. (1968) - Method 6-3-5 (brainwriting).
+2. Delbecq, A., & Van de Ven, A. (1971) - Nominal Group Technique.
+3. Diehl, M., & Stroebe, W. (1987) - production blocking in brainstorming.
+4. Mullen, B., Johnson, C., & Salas, E. (1991) - meta-analysis: nominal groups outperform interacting brainstorming groups.
+
+> **Verification status:** these are well-attested, frequently-cited findings. The "S" grade is justified for the human evidence; keep the AI-adaptation caveat (mechanism transferred, effect size not measured for AI) visible in any public claim.

--- a/skills/tfs-brainwriting/references/EXAMPLE.md
+++ b/skills/tfs-brainwriting/references/EXAMPLE.md
@@ -1,0 +1,44 @@
+# Idea Pool - Worked Example
+
+A completed run of `tfs-brainwriting`, on the shared Northwind scenario. This is the quality bar a generated pool should meet.
+
+> Northwind is a B2B SaaS. Here the skill generates growth ideas with independent streams to avoid everyone anchoring on "free tier."
+
+---
+
+## Prompt
+
+- Ways to generate qualified pipeline for the Q3 target.
+
+## Independent streams (generated as if blind to each other)
+
+**Stream A (the growth marketer):**
+- Self-serve free tier, ICP-gated
+- Reverse trial (full features, then downgrade)
+- Referral loop with in-product incentives
+
+**Stream B (the sales leader):**
+- Outbound to a tight ICP list with free pilots
+- Re-engage closed-lost from the last 12 months
+- Partner co-sell with an adjacent vendor
+
+**Stream C (the product lead):**
+- Fix trial onboarding so existing trials convert
+- Expansion motion inside current accounts (more seats/use cases)
+- A high-value template/integration that pulls in qualified teams
+
+## Build-on round (combine and extend across streams)
+
+- ICP-gated free access (A) offered only to outbound-qualified prospects (B) - free as a sales-assist, not open top-of-funnel.
+- Fix onboarding (C) and instrument it as the test of whether packaging was ever the problem before building free (A).
+- Expansion motion (C) plus closed-lost re-engagement (B) - growth from accounts that already know us, no new funnel.
+
+## Consolidated shortlist
+
+1. **Fix-onboarding-first (C):** cheapest, most reversible, and directly tests the free-tier premise. Do now.
+2. **Expansion + closed-lost (B+C):** qualified pipeline from warm sources; low cannibalization risk.
+3. **ICP-gated free as sales-assist (A+B):** keeps the free upside while limiting non-ICP cost; pilot it.
+
+---
+
+*Note: the value is that three independent streams surfaced options a single "should we build a free tier?" brainstorm would have anchored away from. The build-on round produced the strongest idea (free as a gated sales-assist) by crossing the marketer's and sales leader's streams. Carry the shortlist into a decision review.*

--- a/skills/tfs-brainwriting/references/TEMPLATE.md
+++ b/skills/tfs-brainwriting/references/TEMPLATE.md
@@ -1,0 +1,37 @@
+# Idea Pool (Brainwriting) - Template
+
+Fill this in. The deliverable is the separate streams, the build-on round, and a consolidated shortlist, not prose. Keep the streams genuinely independent before building on them.
+
+---
+
+## Prompt
+
+- [one line: what we are generating ideas for]
+
+## Independent streams (generated as if blind to each other)
+
+**Stream A (angle/persona): [...]**
+- idea
+- idea
+- idea
+
+**Stream B (angle/persona): [...]**
+- idea
+- idea
+- idea
+
+**Stream C (angle/persona): [...]**
+- idea
+- idea
+- idea
+
+## Build-on round (combine and extend across streams)
+
+- [idea built by pushing A's idea with B's logic, etc.]
+
+## Consolidated shortlist
+
+The strongest distinct ideas (duplicates merged), with why:
+
+1. **[idea]** - why it is strong / what to do next.
+2. ...

--- a/skills/tfs-brainwriting/skill.meta.yml
+++ b/skills/tfs-brainwriting/skill.meta.yml
@@ -1,0 +1,77 @@
+# Rich sidecar for the tfs-brainwriting skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.brainwriting
+  slug: brainwriting
+  name: tfs-brainwriting
+  display_name: Brainwriting (6-3-5 / NGT)
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: divergent-ideation
+  secondary_families: []
+  thinking_modes: [divergent, creative]
+  problem_contexts: [high-ambiguity]
+  use_cases:
+    - generate breadth of options while avoiding anchoring and conformity
+    - early divergent generation before any selection
+    - replace a single anchored brainstorm with parallel independent streams
+  poor_fit_cases:
+    - converging, ranking, or deciding (use a decision skill)
+    - when deep single-expert reasoning beats breadth
+    - volume with no build-on and no selection
+    - collapsing into a single stream (loses the mechanism)
+
+interface:
+  required_inputs:
+    - an ideation prompt or challenge
+  optional_inputs:
+    - distinct angles, personas, or constraints to seed the streams
+  primary_artifact_type: idea-pool
+  output_formats: [markdown]
+
+execution:
+  mode: inline
+  subagent_suitable: true   # parallel streams map naturally to parallel sub-agents
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.scamper
+    - thinking-framework-skills.decision-option-review
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.problem-restatement
+  often_precedes:
+    - thinking-framework-skills.decision-option-review
+  complements:
+    - thinking-framework-skills.scamper
+  overlaps_with: []
+  variants:
+    - "protocols: 6-3-5, Nominal Group Technique"
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - collapsing into a single idea stream
+    - volume without build-on or selection
+    - treating it as a convergence or decision method
+
+evidence:
+  evidence_tier: "S"
+  confidence: high for the human group evidence; AI adaptation transfers the mechanism, not a measured effect
+  transferred_evidence: true
+  lineage:
+    derived_from: [Rohrbach 6-3-5, Nominal Group Technique, Diehl and Stroebe production blocking]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-brainwriting/SKILL.md
+  references_path: skills/tfs-brainwriting/references/
+  evidence_path: skills/tfs-brainwriting/evidence/dossier.md
+  evals_path: skills/tfs-brainwriting/eval/

--- a/skills/tfs-decision-option-review/SKILL.md
+++ b/skills/tfs-decision-option-review/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tfs-decision-option-review
+description: Produces a criteria-weighted option matrix by comparing a set of options against weighted criteria, scoring each, surfacing the explicit tradeoffs, and recommending one while flagging where the scoring is soft. Use when choosing among several real options, or when a decision needs its tradeoffs made explicit rather than left to intuition.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.decision-option-review
+  family: decision-and-option-evaluation
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Decision Option Review
+
+When several real options compete, intuition compares them on shifting, unstated criteria that nobody can inspect. This skill makes the comparison explicit: list the options, define and weight the criteria that actually matter, score each option, surface the tradeoffs, and recommend. The output is a **criteria-weighted option matrix**. It is a lightweight multi-criteria review, not academic MCDA, and it deliberately shows the tradeoffs rather than hiding behind a single total: weighted scores can manufacture false precision, so soft scores are flagged and the recommendation states what would flip it.
+
+## When to Use
+
+- Choosing among several real, distinct options.
+- Objectives conflict and the tradeoffs are currently implicit.
+- The decision needs to be explained or defended to others.
+
+## When NOT to Use
+
+- Trivial or obvious choices, or one-way doors needing deeper analysis than a matrix.
+- To generate options (use an ideation skill); this compares options that already exist.
+- When the criteria genuinely cannot be articulated.
+- As a way to make a single weighted total settle a close call (false precision).
+
+## Instructions
+
+When asked to review options, follow these steps:
+
+1. **List the options** being compared (the real, distinct ones).
+2. **Define the criteria** that actually matter for this decision, and weight them (high / medium / low is enough). State why each criterion is in.
+3. **Score each option** against each criterion. Use a small scale and say what a high score means. Flag any score you are not confident in.
+4. **Surface the tradeoffs.** For each leading option, state plainly what it gives up. Note factors that resist scoring rather than dropping them.
+5. **Recommend** one option, with a confidence note and the conditions under which the recommendation would flip.
+6. **Emit the matrix** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the matrix plus the tradeoffs and a recommendation, not prose and not a bare total.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] Criteria and weights are explicit, with a reason each is included.
+- [ ] Soft or low-confidence scores are flagged, not presented as exact.
+- [ ] The tradeoffs each leading option makes are stated.
+- [ ] Factors that resist quantification are noted, not dropped.
+- [ ] The recommendation states what would flip it.
+- [ ] The output is the matrix artifact, not a single total treated as the answer.
+
+## Evidence
+
+Tier **P** (flagged). Structured multi-criteria comparison is a long-standing, government-endorsed decision aid (UK Government MCDA guidance), which stresses it should support judgment, not replace it. Making criteria and weights explicit improves transparency, but a weighted total does not produce a correct decision, and over-trusting the arithmetic (false precision) is a known failure. Evidence is transferred from human practice, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed option matrix.

--- a/skills/tfs-decision-option-review/evidence/dossier.md
+++ b/skills/tfs-decision-option-review/evidence/dossier.md
@@ -1,0 +1,54 @@
+# Evidence Dossier: Decision Option Review
+
+> Single source of truth for the `decision-option-review` skill. The SKILL.md, sidecar, and evals derive from this.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.decision-option-review` (installable name `tfs-decision-option-review`) |
+| **Family** | decision-and-option-evaluation |
+| **Evidence tier** | **P** (flag: false-precision risk) |
+| **Confidence** | High that explicit criteria beat gut comparison; the numbers can mislead if over-trusted |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+When several real options compete, intuition compares them on shifting, unstated criteria and the comparison cannot be inspected. This skill makes it explicit: list the options, define the criteria that actually matter and weight them, score each option against each criterion, and surface the tradeoffs, then recommend. The work is done by forcing the criteria and weights into the open (where they can be argued) and by making the tradeoffs visible rather than buried in a hunch. It is a lightweight multi-criteria review, not academic MCDA.
+
+The honest caveat is built into the mechanism: numeric scores can manufacture **false precision**. The skill must show the tradeoffs and flag where a score is soft, not present a single total as if it settled the matter.
+
+## 2. Lineage
+
+- Multi-criteria decision analysis (MCDA). The UK Government's MCDA guidance frames it as a way to choose rationally among options when objectives conflict, and stresses that it should **support** decision makers, not replace judgment.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Supported:** structured multi-criteria comparison is a long-standing, government-endorsed decision aid; making criteria and weights explicit improves the defensibility and transparency of a choice.
+
+**NOT shown:** there is no evidence that a weighted score produces a *correct* decision, and over-trusting the arithmetic is a known failure (false precision; criteria and weights chosen to justify a favorite). Grade P with a flag; the value is the explicit tradeoffs, not the total.
+
+## 4. Transferred-evidence flag
+
+Evidence is from human decision practice, not AI-augmented use. Transferred, not AI-validated. The AI value: a model can be asked to lay out criteria, weights, and tradeoffs explicitly and consistently, producing an inspectable matrix a human can challenge - far better than a hidden "I recommend X."
+
+## 5. When it works / when it fails
+
+**Works best when:** several real, distinct options compete; objectives conflict; the decision needs to be explained or defended; the tradeoffs are currently implicit.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **False precision** - presenting a single weighted total as if it settled a close call (the central failure mode).
+- Criteria or weights chosen to justify an option already picked.
+- Ignoring factors that resist quantification (treating "unscoreable" as "unimportant").
+- Trivial or obvious choices; or one-way doors that need deeper analysis than a matrix.
+- Generating options (use an ideation skill) - this compares options that already exist.
+
+## 6. Output artifact
+
+A **criteria-weighted option matrix**: options as columns (or rows), weighted criteria, a score per cell, the explicit tradeoffs each leading option makes, and a recommendation with a confidence note and the conditions under which it would flip. Soft scores are flagged.
+
+## 7. Sources
+
+1. UK Government, MCDA guidance (multi-criteria decision analysis as a support for, not a replacement of, judgment).
+
+> **Verification status:** the UK MCDA guidance and the "support not replace judgment" framing are well-attested. Do not present weighted totals as proof of the right choice.

--- a/skills/tfs-decision-option-review/references/EXAMPLE.md
+++ b/skills/tfs-decision-option-review/references/EXAMPLE.md
@@ -1,0 +1,49 @@
+# Criteria-Weighted Option Matrix - Worked Example
+
+A completed run of `tfs-decision-option-review`, on the shared Northwind scenario. This is the quality bar a generated matrix should meet.
+
+> Northwind is a B2B SaaS. After reframing the goal to "generate qualified pipeline with the least irreversible commitment" and expanding options with SCAMPER, this skill compares the shortlisted growth options.
+
+---
+
+## Decision
+
+- Which growth approach to commit to for the Q3 target.
+
+## Options
+
+- A: Build a self-serve free tier.
+- B: Fix the paid-trial funnel (onboarding + conversion).
+- C: Outbound plus free pilots for qualified prospects.
+
+## Matrix
+
+| Criterion (weight, why) | A: Free tier | B: Fix funnel | C: Outbound + pilots |
+|---|---|---|---|
+| Likely impact on qualified pipeline by Q3 (H - it is the goal) | 3 - high if conversion holds (unproven) | 3 - directly lifts existing demand | 4 - targets qualified accounts |
+| Reversibility (H - avoid one-way doors) | 1 - hard to unwind publicly | 5 - fully reversible | 4 - low commitment |
+| Cost / unit-economics risk (H) | 2 - infra + support + cannibalization | 5 - low | 3 - sales time |
+| Time to first signal (M) | 2 - weeks to build | 5 - days | 4 - days |
+| Strategic upside if it works (M) | 5 - durable self-serve motion | 2 - incremental | 3 - repeatable but sales-heavy |
+
+Score scale 1-5; 5 = best on that criterion. **Flagged soft scores:** A's impact (3) is unproven (depends on unmeasured ICP conversion); all of A's scores carry that uncertainty.
+
+## Tradeoffs
+
+- **Option A** gives up reversibility and cost-safety for a large but unproven upside.
+- **Option B** gives up strategic upside for speed, safety, and reversibility.
+- **Option C** balances both but consumes sales capacity.
+
+## Factors that resist scoring
+
+- Board optics: a visible "free tier" launch may satisfy the board narratively even if it underperforms. Real but not a sound basis for the decision.
+- Morale / momentum of shipping something bold.
+
+## Recommendation
+
+- **Recommended:** B now (fix the funnel) as the cheapest, most reversible move that also tests whether packaging was ever the real problem; run C in parallel. Treat A as a deferred bet gated on the conversion pilot.
+- **Would flip if:** the funnel is already healthy (then B has little headroom and A/C rise), or the conversion pilot shows strong ICP free-to-paid economics (then A's upside becomes worth the irreversibility).
+
+---
+
+*Note: the value is that the explicit weights (reversibility and cost-risk both high) demote the option with the biggest raw upside. A single total would have hidden that A wins only on the criteria we deliberately down-weighted. Test the recommendation with What Would Have to Be True, then premortem the chosen plan.*

--- a/skills/tfs-decision-option-review/references/TEMPLATE.md
+++ b/skills/tfs-decision-option-review/references/TEMPLATE.md
@@ -1,0 +1,39 @@
+# Criteria-Weighted Option Matrix - Template
+
+Fill this in. The deliverable is the matrix plus tradeoffs and a recommendation, not a bare total. Flag soft scores; note factors that resist scoring.
+
+---
+
+## Decision
+
+- [one line: what is being chosen]
+
+## Options
+
+- A: [...]
+- B: [...]
+- C: [...]
+
+## Matrix
+
+| Criterion (weight H/M/L, why) | Option A | Option B | Option C |
+|---|---|---|---|
+| [criterion 1] (H - reason) | | | |
+| [criterion 2] (M - reason) | | | |
+| [criterion 3] (L - reason) | | | |
+
+Score scale: [state it, e.g. 1-5, and what "5" means]. Flag any score you are not confident in.
+
+## Tradeoffs
+
+- **Option A** gives up: [...]
+- **Option B** gives up: [...]
+
+## Factors that resist scoring
+
+- [important considerations not captured by the matrix]
+
+## Recommendation
+
+- **Recommended:** [option] - confidence [H/M/L].
+- **Would flip if:** [the condition or new information that would change the choice].

--- a/skills/tfs-decision-option-review/skill.meta.yml
+++ b/skills/tfs-decision-option-review/skill.meta.yml
@@ -1,0 +1,79 @@
+# Rich sidecar for the tfs-decision-option-review skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.decision-option-review
+  slug: decision-option-review
+  name: tfs-decision-option-review
+  display_name: Decision Option Review
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: decision-and-option-evaluation
+  secondary_families: []
+  thinking_modes: [convergent, critical, analytical]
+  problem_contexts: [high-stakes, high-complexity]
+  use_cases:
+    - choose among several real, distinct options
+    - make implicit tradeoffs explicit and defensible
+    - support (not replace) judgment on a conflicting-objectives decision
+  poor_fit_cases:
+    - trivial or obvious choices, or one-way doors needing deeper analysis
+    - generating options (use an ideation skill)
+    - letting a single weighted total settle a close call (false precision)
+    - ignoring factors that resist quantification
+
+interface:
+  required_inputs:
+    - two or more real options to compare
+  optional_inputs:
+    - the criteria that matter, constraints, the goal
+  primary_artifact_type: option-matrix
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.what-would-have-to-be-true
+    - thinking-framework-skills.premortem
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.scamper
+    - thinking-framework-skills.assumption-reversal
+  often_precedes:
+    - thinking-framework-skills.what-would-have-to-be-true
+    - thinking-framework-skills.premortem
+  complements:
+    - thinking-framework-skills.parallel-perspectives-review
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - false precision (a single weighted total treated as the answer)
+    - criteria or weights chosen to justify a pre-picked option
+    - dropping factors that resist quantification
+
+evidence:
+  evidence_tier: "P"
+  confidence: high that explicit criteria beat gut comparison; the numbers mislead if over-trusted
+  transferred_evidence: true
+  lineage:
+    derived_from: [multi-criteria decision analysis, UK Government MCDA guidance]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+  risk_flags: [false-precision]
+
+implementation:
+  skill_path: skills/tfs-decision-option-review/SKILL.md
+  references_path: skills/tfs-decision-option-review/references/
+  evidence_path: skills/tfs-decision-option-review/evidence/dossier.md
+  evals_path: skills/tfs-decision-option-review/eval/

--- a/skills/tfs-futures-wheel/SKILL.md
+++ b/skills/tfs-futures-wheel/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: tfs-futures-wheel
+description: Produces a consequence map by tracing the first, second, and third order effects of a change or decision radiating outward from the center, surfacing ripples beyond the obvious and flagging the high-impact branches. Use when a decision has knock-on effects over time, or when first-order thinking is missing downstream risks and opportunities.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.futures-wheel
+  family: systems-and-consequences
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Futures Wheel
+
+Most analysis stops at first-order consequences: the immediate, obvious results. A futures wheel pushes past that. The change goes at the center; first-order consequences radiate around it; each of those spawns second-order consequences ("and then what?"); then third-order. The structure forces attention onto the downstream and cross-domain ripples that linear thinking skips, and flags the branches worth a response. The output is a **consequence map**. For a quick pass, a lightweight "second-order effects" mode runs only the first-to-second step.
+
+## When to Use
+
+- A decision or change has knock-on effects that play out over time.
+- First-order analysis is missing downstream risks or opportunities.
+- Scanning the systemic side effects of a new idea before committing.
+
+## When NOT to Use
+
+- Simple, linear situations with no meaningful higher-order effects.
+- When you need to decide, not explore (hand the map to a decision skill).
+- When the result would be branches to irrelevance rather than a focused map.
+
+## Instructions
+
+When asked to build a futures wheel, follow these steps:
+
+1. **Center it.** State the change or decision at the middle, in one line.
+2. **First order.** List the immediate, direct consequences. Span domains (technical, financial, customer, team, competitive), not just the obvious one.
+3. **Second order.** For each meaningful first-order effect, ask "and then what happens?" and add its consequences.
+4. **Third order.** For the branches that still matter, extend one more step. Stop a branch when it goes trivial.
+5. **Flag the branches that matter.** Mark the high-impact or non-obvious consequences, and add a one-line "watch or do about it" for each.
+6. **Emit the consequence map** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the nested consequence map with flagged branches, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The map reaches at least second order; it does not stop at first-order.
+- [ ] First-order effects span multiple domains, not just the obvious one.
+- [ ] Branches that go trivial are pruned, not padded.
+- [ ] The high-impact or non-obvious branches are flagged with a response note.
+- [ ] Branches are presented as possible ripples to watch, not predictions.
+- [ ] The output is the consequence map artifact, not prose.
+
+## Evidence
+
+Tier **P**. The futures wheel is an established foresight method (Glenn, 1971; used in foresight practice and documented in primers such as UNICEF's 2025 guidance), valued for pushing analysis beyond first-order consequences. Its validation is qualitative; it does not predict the future, so branches are structured speculation, not probabilities. Evidence is transferred from human foresight practice, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed consequence map.

--- a/skills/tfs-futures-wheel/evidence/dossier.md
+++ b/skills/tfs-futures-wheel/evidence/dossier.md
@@ -1,0 +1,55 @@
+# Evidence Dossier: Futures Wheel
+
+> Single source of truth for the `futures-wheel` skill. The SKILL.md, sidecar, and evals derive from this.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.futures-wheel` (installable name `tfs-futures-wheel`) |
+| **Family** | systems-and-consequences |
+| **Evidence tier** | **P** (foresight practitioner; qualitative validation) |
+| **Confidence** | High that first-order-only thinking misses real effects; the wheel is a structured aid, not a predictor |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+Most analysis stops at first-order consequences: the immediate, obvious results of a change. A futures wheel pushes past that. Put the change or decision at the center; radiate the **first-order** consequences around it; from each of those, derive **second-order** consequences ("and then what?"); then **third-order**. The structure forces attention onto the downstream and cross-domain ripples (technical, social, financial, organizational) that linear thinking skips. The work is done by the disciplined "and then what happens?" expansion across orders, and by flagging the high-impact or non-obvious branches that deserve a response.
+
+A **lightweight mode** ("second-order effects") runs only the first-to-second order step as a quick prompt when a full wheel is overkill.
+
+## 2. Lineage
+
+- Jerome Glenn devised the Futures Wheel (1971) as a foresight technique. Widely used in foresight practice and documented in primers such as UNICEF's 2025 foresight guidance and in transport/policy research.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Supported (practitioner):** the futures wheel is an established, widely used foresight method, valued precisely for pushing analysis beyond first-order into second- and third-order consequences. Its validation is qualitative and practice-based.
+
+**NOT shown:** it does not predict the future and has no controlled evidence of forecast accuracy. The branches are structured speculation, not probabilities. Grade P; present outputs as a map of possible ripples to watch and respond to, not as predictions.
+
+## 4. Transferred-evidence flag
+
+Evidence is from human foresight practice, not AI-augmented use. Transferred, not AI-validated. The AI value: a model defaults to first-order answers; forcing the multi-order expansion and a structured map is a direct counter, though the radial diagram is approximated in markdown as nested structure.
+
+## 5. When it works / when it fails
+
+**Works best when:** a decision or change has knock-on effects over time; the obvious first-order analysis is missing downstream risks and opportunities; scanning the systemic externalities of a new idea.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- Stopping at first-order (defeats the purpose).
+- Branching to irrelevance - every node spawning trivial children until the map is noise.
+- Treating the speculative branches as predictions or probabilities.
+- Simple, linear situations where there are no meaningful higher-order effects.
+- When you need to decide, not explore (hand the map to a decision skill).
+
+## 6. Output artifact
+
+A **consequence map**: the central change, then nested first / second / third-order consequences (tagged by domain where useful), with the high-impact or non-obvious branches flagged and a short "what to watch or do about it" note for those.
+
+## 7. Sources
+
+1. Glenn, J. (1971). The Futures Wheel (foresight method).
+2. UNICEF (2025) foresight primer; foresight and transport/policy literature describing the wheel's use for second- and third-order consequences.
+
+> **Verification status:** Glenn attribution and foresight usage are well-attested. Do not attach forecast-accuracy claims; the method's validation is qualitative.

--- a/skills/tfs-futures-wheel/references/EXAMPLE.md
+++ b/skills/tfs-futures-wheel/references/EXAMPLE.md
@@ -1,0 +1,42 @@
+# Consequence Map - Worked Example
+
+A completed run of `tfs-futures-wheel`, on the shared Northwind scenario. This is the quality bar a generated map should meet.
+
+> Northwind is a B2B SaaS. Here the skill maps the ripple effects of actually launching the self-serve free tier.
+
+---
+
+## Center
+
+- **Change / decision:** Launch a self-serve free tier.
+
+## Consequence map
+
+- **First order: surge in signups** (customer)
+  - Second order: support volume rises
+    - Third order: support team overwhelmed, paid-customer SLAs slip
+  - Second order: mix shifts toward non-ICP users
+    - Third order: sales wastes time triaging unqualified leads
+- **First order: some paying customers downgrade to free** (financial)
+  - Second order: net new MRR slows
+    - Third order: board reads Q3 as a miss despite signup growth
+- **First order: infrastructure usage rises** (technical)
+  - Second order: cloud cost per user climbs
+    - Third order: unit economics break if free cohort is large and non-converting
+- **First order: competitors see the move** (competitive)
+  - Second order: price/feature response, "free tier" becomes table stakes
+- **First order: sales comp and routing strain** (team)
+  - Second order: rep behavior shifts to protect commissions
+    - Third order: reps suppress free signups, undercutting the whole motion
+
+## Flagged branches (high-impact or non-obvious)
+
+| Branch | Why it matters | Watch or do about it |
+|---|---|---|
+| Downgrade -> MRR slows -> board reads a miss | The growth move could register as a failure on the one metric that triggered it | Instrument free-vs-paid downgrade weekly; pre-brief the board on leading vs lagging signals |
+| Support overwhelmed -> paid SLA slips | A growth tactic damaging existing paid customers is a net loss | Cap free usage; ship self-serve docs before launch; set a support-load tripwire |
+| Reps suppress free signups | A non-obvious second-order effect that quietly kills the motion | Realign comp and routing before launch, not after |
+
+---
+
+*Note: the value is the second- and third-order branches. A first-order-only view ("more signups, good") misses that the same move can slip paid SLAs, break unit economics, and be quietly sabotaged by the comp plan. This map feeds directly into a premortem.*

--- a/skills/tfs-futures-wheel/references/TEMPLATE.md
+++ b/skills/tfs-futures-wheel/references/TEMPLATE.md
@@ -1,0 +1,26 @@
+# Consequence Map (Futures Wheel) - Template
+
+Fill this in as a nested map. The deliverable is the multi-order map with flagged branches, not prose. Prune branches that go trivial. Branches are possible ripples to watch, not predictions.
+
+---
+
+## Center
+
+- **Change / decision:** [one line]
+
+## Consequence map
+
+- **First order: [effect]** (domain)
+  - Second order: [effect]
+    - Third order: [effect]
+  - Second order: [effect]
+- **First order: [effect]** (domain)
+  - Second order: [effect]
+
+(Span domains at first order: technical, financial, customer, team, competitive.)
+
+## Flagged branches (high-impact or non-obvious)
+
+| Branch | Why it matters | Watch or do about it |
+|---|---|---|
+| | | |

--- a/skills/tfs-futures-wheel/skill.meta.yml
+++ b/skills/tfs-futures-wheel/skill.meta.yml
@@ -1,0 +1,79 @@
+# Rich sidecar for the tfs-futures-wheel skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.futures-wheel
+  slug: futures-wheel
+  name: tfs-futures-wheel
+  display_name: Futures Wheel
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: systems-and-consequences
+  secondary_families: [risk-and-resilience]
+  thinking_modes: [systems, consequential, divergent]
+  problem_contexts: [high-complexity, high-stakes]
+  use_cases:
+    - map the downstream and cross-domain ripple effects of a change
+    - surface second- and third-order risks and opportunities a first-order view misses
+    - scan the systemic side effects of a new idea before committing
+  poor_fit_cases:
+    - simple, linear situations with no meaningful higher-order effects
+    - when you need to decide, not explore
+    - branching to irrelevance instead of a focused map
+    - treating speculative branches as predictions
+
+interface:
+  required_inputs:
+    - a change, decision, or trend to map
+  optional_inputs:
+    - the domains or time horizons of interest
+  primary_artifact_type: consequence-map
+  output_formats: [markdown-nested-list]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.premortem
+    - thinking-framework-skills.decision-option-review
+  modes:
+    - "lightweight: second-order-effects (first-to-second order only)"
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.decision-option-review
+  often_precedes:
+    - thinking-framework-skills.premortem
+  complements:
+    - thinking-framework-skills.premortem
+  overlaps_with: []
+  variants:
+    - "sub-skill / lightweight mode: second-order-effects"
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - stopping at first-order consequences
+    - branching to irrelevance until the map is noise
+    - treating speculative branches as predictions
+
+evidence:
+  evidence_tier: "P"
+  confidence: high that first-order-only thinking misses effects; the wheel is an aid, not a predictor
+  transferred_evidence: true
+  lineage:
+    derived_from: [Glenn Futures Wheel, foresight practice]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-futures-wheel/SKILL.md
+  references_path: skills/tfs-futures-wheel/references/
+  evidence_path: skills/tfs-futures-wheel/evidence/dossier.md
+  evals_path: skills/tfs-futures-wheel/eval/

--- a/skills/tfs-ladder-of-inference-check/SKILL.md
+++ b/skills/tfs-ladder-of-inference-check/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: tfs-ladder-of-inference-check
+description: Produces an annotated reasoning trace that reconstructs how a conclusion was reached, from the observable data, to the data actually selected, to the meaning and assumptions added, then flags the riskiest leap and tests an alternative interpretation. Use when a conclusion feels certain but rests on interpretation, or to audit a contested inference.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.ladder-of-inference-check
+  family: assumption-and-belief-challenge
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Ladder of Inference Check
+
+People move from observation to action up an invisible, near-instant ladder: all available data, the data they select, the meaning they add, the assumptions they make, the conclusion they draw, the action they take. The leaps feel like facts. This skill slows the climb back down for a given conclusion: it reconstructs the rungs, exposes where selection and interpretation crept in, flags the riskiest leap, and tests at least one alternative interpretation of the same data. The output is an **annotated reasoning trace**, not prose.
+
+## When to Use
+
+- A conclusion feels certain but actually rests on interpretation.
+- A disagreement traces to two people reading the same situation differently.
+- Auditing a contested inference, including the agent's own conclusion.
+- As a step in a reasoning-audit workflow, often after an evidence/inference sort.
+
+## When NOT to Use
+
+- The conclusion follows from direct, verifiable data with no real inferential leap.
+- To generate ideas or options (wrong tool).
+- On trivial matters where the climb does not matter.
+- As a way to dress up and defend the conclusion you already hold.
+
+## Instructions
+
+When asked to check the ladder of inference, follow these steps:
+
+1. **State the conclusion** being examined, in one sentence.
+2. **List the observable data available** - everything that could have been noticed, not just what was used.
+3. **Identify the data actually selected** - which subset the conclusion was built on, and what was left out.
+4. **Surface the meaning and assumptions added** - the interpretation laid on the selected data, and the assumptions that interpretation requires.
+5. **Flag the riskiest rung** - the single leap most likely to be wrong or selective.
+6. **Test an alternative interpretation** - give at least one credible different reading of the same data, and what it would imply.
+7. **Emit the reasoning trace** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the reconstructed ladder with a flagged rung and an alternative interpretation, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] Observable data includes what was left out, not only what was used.
+- [ ] The meaning and assumptions added are stated explicitly, separate from the data.
+- [ ] The single riskiest rung is named.
+- [ ] At least one credible alternative interpretation is given.
+- [ ] The trace tests the climb rather than rationalizing the conclusion.
+- [ ] The output is the reasoning trace artifact, not prose.
+
+## Evidence
+
+Tier **P**. The ladder is an influential practitioner model (Argyris; Senge, *The Fifth Discipline*, 1990). The underlying phenomenon (people select data and add interpretation, then treat conclusions as fact) is well grounded in cognitive psychology, but the ladder itself is a map, not a validated intervention, and evidence is transferred from human contexts, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed reasoning trace.

--- a/skills/tfs-ladder-of-inference-check/evidence/dossier.md
+++ b/skills/tfs-ladder-of-inference-check/evidence/dossier.md
@@ -1,0 +1,54 @@
+# Evidence Dossier: Ladder of Inference Check
+
+> Single source of truth for the `ladder-of-inference-check` skill. The SKILL.md, sidecar, and evals derive from this. If a claim is not here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.ladder-of-inference-check` (installable name `tfs-ladder-of-inference-check`) |
+| **Family** | assumption-and-belief-challenge |
+| **Evidence tier** | **P** (practitioner model; influential but thin controlled evidence) |
+| **Confidence** | High that unexamined inference is real; the ladder is a useful map, not a validated instrument |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+People move from raw observation to action up an invisible, near-instant "ladder": all observable **data** -> the **data we select** -> the **meaning** we add -> the **assumptions** we make -> the **conclusions** we draw -> the **beliefs** that harden -> the **actions** we take. The leaps feel like facts. The check slows the climb back down: for a given conclusion, reconstruct the rungs, expose where selection and interpretation crept in, and deliberately ask what other data and interpretations were available. The work is done by making a silent inferential jump inspectable, so it can be challenged before it drives action.
+
+## 2. Lineage
+
+- Chris Argyris developed the ladder of inference (organizational learning, 1970s-1990). Peter Senge popularized it in *The Fifth Discipline* (1990). Widely taught via The Systems Thinker and similar practitioner sources.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Supported:** the underlying phenomenon - that people unconsciously select data and add interpretation, then treat conclusions as facts - is well grounded in cognitive psychology (selective attention, confirmation bias).
+
+**NOT shown:** the ladder itself is a practitioner *model*, not a validated intervention. There is little controlled evidence that running the ladder improves decisions or reasoning accuracy by a measured amount. Grade it P: a useful map of where inference goes wrong, presented as a disciplined trace, not as a proven technique.
+
+## 4. Transferred-evidence flag
+
+Evidence is from human organizational-learning and cognitive contexts, not AI-augmented use. Transferred, not AI-validated. The AI value: a model asserts conclusions fluently and can be asked to reconstruct its own (or another's) climb from data to conclusion, exposing the selection and assumptions, which is a direct counter to confident, unsourced conclusions.
+
+## 5. When it works / when it fails
+
+**Works best when:** a conclusion feels certain but rests on interpretation; a disagreement traces to different readings of the same situation; auditing a contested inference (the agent's own or another's).
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- The conclusion follows from direct, verifiable data with no real inferential leap.
+- It is used to **rationalize** the existing conclusion rather than genuinely test the climb (the central failure mode).
+- "Selected data" is presented as if it were all the data.
+- The "alternative interpretations" step is skipped, which is where most of the value is.
+- Trivial matters where the climb does not matter.
+
+## 6. Output artifact
+
+An **annotated reasoning trace**: the conclusion at the top, the ladder rungs reconstructed beneath it (observable data available -> data actually selected -> meaning added -> assumptions -> conclusion), the single riskiest rung flagged, and at least one credible alternative interpretation of the same data.
+
+## 7. Sources
+
+1. Argyris, C. (1990). *Overcoming Organizational Defenses*; and Argyris's action-science work on the ladder of inference.
+2. Senge, P. (1990). *The Fifth Discipline* - popularized the ladder.
+3. The Systems Thinker - practitioner write-up of the ladder and how to use it.
+
+> **Verification status:** Argyris/Senge attribution is well-attested. Treat effectiveness as practitioner-reported; do not attach a quantified effect in public-facing text.

--- a/skills/tfs-ladder-of-inference-check/references/EXAMPLE.md
+++ b/skills/tfs-ladder-of-inference-check/references/EXAMPLE.md
@@ -1,0 +1,34 @@
+# Reasoning Trace - Worked Example
+
+A completed run of `tfs-ladder-of-inference-check`, on the shared Northwind scenario. This is the quality bar a generated trace should meet.
+
+> Northwind is a B2B SaaS. Here the skill audits a conclusion the team reached during the free-tier debate.
+
+---
+
+## Conclusion under examination
+
+- "Our trials are not converting because the product is missing a free tier."
+
+## The ladder, reconstructed
+
+| Rung | Content |
+|---|---|
+| Observable data available | Trial-to-paid conversion is down 6 points QoQ; two lost deals mentioned wanting to "try before buying"; support tickets up; a competitor launched a free tier; onboarding completion rate also dropped; sales hired three new reps last quarter. |
+| Data actually selected | Only the two "try before buying" comments and the competitor's free tier. |
+| Meaning added | Prospects need a no-commitment way to try, and competitors are setting that expectation. |
+| Assumptions | That the two comments are representative; that the conversion drop is about packaging, not onboarding or new-rep ramp; that a free tier is what "try before buying" means. |
+| Conclusion | We need a free tier to fix conversion. |
+
+## Riskiest rung
+
+- **Data actually selected.** The conclusion ignores two strong alternative signals present in the same data: onboarding completion also dropped, and three new reps were ramping. Either could explain the conversion fall without any packaging change.
+
+## Alternative interpretation
+
+- A credible different reading: the conversion drop is an onboarding and ramp problem, not a packaging gap. The two "try before buying" comments are real but may be a small, vocal minority.
+- What it would imply: fix the onboarding funnel and support new-rep ramp first (cheap, reversible), and verify the packaging hypothesis with data before building a free tier. (This hands off cleanly to `tfs-evidence-vs-inference-sort` and `tfs-what-would-have-to-be-true`.)
+
+---
+
+*Note: the value is exposing that the conclusion was built on two anecdotes plus a competitor move, while three other data points pointing elsewhere were silently dropped at the "selected data" rung.*

--- a/skills/tfs-ladder-of-inference-check/references/TEMPLATE.md
+++ b/skills/tfs-ladder-of-inference-check/references/TEMPLATE.md
@@ -1,0 +1,28 @@
+# Reasoning Trace (Ladder of Inference) - Template
+
+Fill this in from the top conclusion downward. The deliverable is the reconstructed ladder, the flagged rung, and an alternative interpretation, not prose.
+
+---
+
+## Conclusion under examination
+
+- [the conclusion, in one sentence]
+
+## The ladder, reconstructed
+
+| Rung | Content |
+|---|---|
+| Observable data available | [everything that could have been noticed, including what was left out] |
+| Data actually selected | [the subset the conclusion was built on] |
+| Meaning added | [the interpretation laid on the selected data] |
+| Assumptions | [what that interpretation requires to be true] |
+| Conclusion | [restated] |
+
+## Riskiest rung
+
+- **[which rung]** - why this leap is the most likely to be wrong or selective.
+
+## Alternative interpretation
+
+- A credible different reading of the same data: [...]
+- What it would imply: [...]

--- a/skills/tfs-ladder-of-inference-check/skill.meta.yml
+++ b/skills/tfs-ladder-of-inference-check/skill.meta.yml
@@ -1,0 +1,76 @@
+# Rich sidecar for the tfs-ladder-of-inference-check skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.ladder-of-inference-check
+  slug: ladder-of-inference-check
+  name: tfs-ladder-of-inference-check
+  display_name: Ladder of Inference Check
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: assumption-and-belief-challenge
+  secondary_families: [reasoning-clarity]
+  thinking_modes: [critical, reflective]
+  problem_contexts: [high-conflict, high-stakes]
+  use_cases:
+    - test a conclusion that feels certain but rests on interpretation
+    - trace a disagreement back to differing readings of the same data
+    - audit a contested inference, including the agent's own
+  poor_fit_cases:
+    - conclusions that follow from direct verifiable data with no leap
+    - generating ideas or options
+    - trivial matters where the climb does not matter
+    - rationalizing a conclusion already held
+
+interface:
+  required_inputs:
+    - a specific conclusion to examine, ideally with the situation behind it
+  optional_inputs:
+    - the data available, the decision it feeds
+  primary_artifact_type: reasoning-trace
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.evidence-vs-inference-sort
+    - thinking-framework-skills.parallel-perspectives-review
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.evidence-vs-inference-sort
+  often_precedes:
+    - thinking-framework-skills.parallel-perspectives-review
+  complements:
+    - thinking-framework-skills.evidence-vs-inference-sort
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - rationalizing the existing conclusion rather than testing the climb
+    - presenting selected data as if it were all the data
+    - skipping the alternative-interpretation step
+
+evidence:
+  evidence_tier: "P"
+  confidence: high that unexamined inference is real; the ladder is a map not a validated instrument
+  transferred_evidence: true
+  lineage:
+    derived_from: [Argyris ladder of inference, Senge The Fifth Discipline]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-ladder-of-inference-check/SKILL.md
+  references_path: skills/tfs-ladder-of-inference-check/references/
+  evidence_path: skills/tfs-ladder-of-inference-check/evidence/dossier.md
+  evals_path: skills/tfs-ladder-of-inference-check/eval/

--- a/skills/tfs-parallel-perspectives-review/SKILL.md
+++ b/skills/tfs-parallel-perspectives-review/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: tfs-parallel-perspectives-review
+description: Evaluates a decision or idea through several deliberately separated lenses in turn (facts, upside, risks, intuition, alternatives, process) so that no single mode dominates, then synthesizes them into a balanced read, producing a multi-lens review. Use when a choice needs a rounded look, or when risk-aversion or optimism is drowning out the other perspectives.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.parallel-perspectives-review
+  family: perspective-and-multi-lens
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Parallel Perspectives Review
+
+In ordinary review one mode dominates: a cautious voice or an optimist colors everything, and facts, feelings, and alternatives blur together. This skill separates them, examining the same decision through one lens at a time - facts and information, upside and value, cautions and risks, intuition and feelings, alternatives and creative angles, and the process or big-picture view - then synthesizing. Looking through the same lens at once ("parallel") gives the quiet modes airtime instead of letting the loudest dominate. The output is a **multi-lens review** ending in a synthesis. (This is the generic mechanism behind Six Thinking Hats, used descriptively; the branded framework's marketing claims are not relied on.)
+
+## When to Use
+
+- A decision or idea needs a rounded, balanced look before committing.
+- Risk-aversion or optimism is dominating the discussion.
+- Quieter considerations (intuition, alternatives) keep getting skipped.
+
+## When NOT to Use
+
+- A single lens is obviously all that matters; just use it.
+- For deep adversarial stress-testing of one thesis (use red team) or for failure causes (use premortem).
+- When the six lenses would be performed mechanically with only two or three carrying weight.
+- As consensus theater rather than genuine separation of modes.
+
+## Instructions
+
+When asked for a parallel perspectives review, follow these steps:
+
+1. **State what is being reviewed** in one sentence.
+2. **Pass through each lens separately.** For each, write only what that lens surfaces, not a blended take:
+   - **Facts** - what is known and what information is missing.
+   - **Upside** - the value and best case.
+   - **Risks** - the cautions and downside.
+   - **Intuition** - the gut read and feelings, named as such.
+   - **Alternatives** - other options and creative angles.
+   - **Process** - the big picture and what to do next.
+3. **Keep the lenses clean.** Do not let one lens leak into another; that blur is what the method prevents. Drop a lens that genuinely does not apply and say so.
+4. **Synthesize.** Integrate the lenses into a balanced read and name the central tension to resolve.
+5. **Emit the multi-lens review** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the per-lens review plus a synthesis, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] Each lens contains only its own mode; the lenses do not blur together.
+- [ ] The easily-skipped lenses (intuition, alternatives) actually got a real pass.
+- [ ] Lenses that do not apply are dropped with a note, not padded.
+- [ ] The synthesis names the central tension, not just a summary.
+- [ ] The output is the multi-lens review artifact, not prose.
+
+## Evidence
+
+Tier **P** (flagged). This implements the parallel-thinking mechanism behind Six Thinking Hats (de Bono, 1985, trademarked; used here descriptively). Deliberately separating modes is modestly supported (some studies show moderate gains in critical thinking), but a Cambridge-led review found the branded framework's evidence base sparse, and de Bono's often-quoted "493%" productivity claim is uncited and is not used. Evidence is transferred from human contexts, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed multi-lens review.

--- a/skills/tfs-parallel-perspectives-review/evidence/dossier.md
+++ b/skills/tfs-parallel-perspectives-review/evidence/dossier.md
@@ -1,0 +1,55 @@
+# Evidence Dossier: Parallel Perspectives Review
+
+> Single source of truth for the `parallel-perspectives-review` skill. The SKILL.md, sidecar, and evals derive from this. If a claim is not here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.parallel-perspectives-review` (installable name `tfs-parallel-perspectives-review`) |
+| **Family** | perspective-and-multi-lens |
+| **Evidence tier** | **P** (flag: trademark lineage; branded version's headline claims are uncited) |
+| **Confidence** | Moderate that separating modes reduces blur; the branded productivity numbers are not credible |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+In ordinary review, one mode dominates: a risk-averse voice, or an optimist, colors everything, and facts, feelings, and alternatives blur together. Parallel perspectives review separates them: look at the same decision through one lens at a time - the facts and information; the upside and value; the cautions and risks; the intuition and feelings; the alternatives and creative angles; and the process or big-picture view - then synthesize. "Parallel" means everyone (or the agent) adopts the same lens at the same moment, which reduces adversarial cross-talk and makes sure the quiet modes (feelings, alternatives) actually get airtime. The work is done by forcing separation so no single mode crowds out the rest.
+
+## 2. Lineage and trademark
+
+- The branded version is **Six Thinking Hats** (Edward de Bono, 1985), a registered trademark. This skill implements the underlying mechanism - parallel thinking through separated lenses - under a **descriptive name**, citing de Bono as lineage. It does not use the trademarked "hat" branding as the product.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Mixed / weak (hence the flag):**
+- A Cambridge-led review of thinking-skills frameworks (Moseley et al.) found the evidence base for the branded framework sparse.
+- Some studies (for example with nursing students and managers) report moderate positive effects on critical thinking and cognitive complexity from deliberately separating modes.
+- **Do not repeat de Bono's often-quoted "493% productivity improvement" claim. It is uncited and unsupported.** Flagging this is part of the point: the mechanism (separating modes) is reasonable; the branded marketing numbers are not credible.
+
+**Net grade: P with a flag.** The separation mechanism is plausible and modestly supported; the branded framework's strong claims are not. Present the mechanism honestly and do not borrow the marketing.
+
+## 4. Transferred-evidence flag
+
+Evidence is from human group and educational contexts, not AI-augmented use. Transferred, not AI-validated. The AI value: a model defaults to one blended take; forcing it to produce a genuinely separate pass per lens (especially the easily-skipped feelings and alternatives lenses) yields a more rounded review and a structured artifact.
+
+## 5. When it works / when it fails
+
+**Works best when:** a decision or idea needs a rounded look; risk-aversion or optimism is dominating the discussion; quieter considerations (intuition, alternatives) keep getting skipped.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- The lenses blur together in the output - the exact failure the method exists to prevent.
+- All six lenses are performed mechanically when only two or three carry weight (padding).
+- Used as consensus theater rather than genuine separation.
+- A single lens is obviously all that matters (just use it).
+- For deep adversarial stress-testing of one thesis (use red-team) or failure causes (use premortem).
+
+## 6. Output artifact
+
+A **multi-lens review**: a row per lens (facts, upside, risks, intuition, alternatives, process) with what that lens surfaces, followed by a short synthesis that integrates them into a balanced read and names the tension to resolve.
+
+## 7. Sources
+
+1. de Bono, E. (1985). *Six Thinking Hats* - the branded lineage (trademarked; mechanism used descriptively).
+2. Moseley, D. et al. - Cambridge review of thinking-skills frameworks (sparse evidence base for the branded framework).
+3. Practitioner/education studies reporting moderate effects of deliberate mode separation.
+
+> **Verification status:** the de Bono lineage and the "493% is uncited" point are well-attested and are deliberately surfaced as an honesty demonstration. Treat the positive effect studies as moderate and context-specific; do not generalize them into a quantified product claim.

--- a/skills/tfs-parallel-perspectives-review/references/EXAMPLE.md
+++ b/skills/tfs-parallel-perspectives-review/references/EXAMPLE.md
@@ -1,0 +1,30 @@
+# Multi-Lens Review - Worked Example
+
+A completed run of `tfs-parallel-perspectives-review`, on the shared Northwind scenario. This is the quality bar a generated review should meet.
+
+> Northwind is a B2B SaaS weighing a self-serve free-tier launch. Here the skill gives the decision a rounded look before committing.
+
+---
+
+## Under review
+
+- Launching a self-serve free tier in 6 weeks to hit the Q3 growth target.
+
+## Lenses
+
+| Lens | What it surfaces |
+|---|---|
+| Facts | Trial-to-paid is down 6 points QoQ; a competitor launched a free tier; current free-to-paid conversion is unknown; the 6-week timeline is fixed by the board date. Missing: cost-per-free-user model, ICP-fit data on free signups. |
+| Upside | If conversion holds, a free tier could 3x top-of-funnel and create a durable self-serve growth motion that compounds. |
+| Risks | Cannibalizes paid; floods Sales with unqualified users; infra and support cost breaks unit economics; a rushed 6-week build ships an insecure billing path. |
+| Intuition | The team is reaching for a competitor's move under board pressure; it feels reactive rather than chosen, and "free tier" may be a proxy for "do something visible about growth." |
+| Alternatives | Fix the trial funnel; gated reverse-trial; outbound plus free pilots; extend the trial. Several are cheaper and more reversible. |
+| Process | This is a near-one-way door. The big-picture move is to de-risk the two load-bearing unknowns (ICP conversion, cheaper alternatives) before committing the 6 weeks. |
+
+## Synthesis
+
+The upside is real but rests entirely on a conversion assumption the facts cannot yet confirm, and the intuition lens flags that the decision is board-pressure-reactive rather than chosen. The central tension: speed (a fixed Q3 date) versus reversibility (a free tier is hard to unwind). Resolve it by running a small gated pilot to test ICP conversion and a one-day comparison of the cheaper alternatives before committing the build, rather than treating the free tier as decided.
+
+---
+
+*Note: the value is the intuition and alternatives lenses, which a risk-or-upside-only debate would have skipped. Together they reframed the choice from "build it fast" to "de-risk it first."*

--- a/skills/tfs-parallel-perspectives-review/references/TEMPLATE.md
+++ b/skills/tfs-parallel-perspectives-review/references/TEMPLATE.md
@@ -1,0 +1,24 @@
+# Multi-Lens Review - Template
+
+Fill this in. Keep each lens clean (only its own mode); the deliverable is the per-lens review plus a synthesis, not prose. Drop a lens that does not apply and say so.
+
+---
+
+## Under review
+
+- [one sentence: the decision or idea]
+
+## Lenses
+
+| Lens | What it surfaces |
+|---|---|
+| Facts | [what is known; what information is missing] |
+| Upside | [value, best case] |
+| Risks | [cautions, downside] |
+| Intuition | [gut read and feelings, named as such] |
+| Alternatives | [other options, creative angles] |
+| Process | [big picture, what to do next] |
+
+## Synthesis
+
+[A balanced read that integrates the lenses, and names the central tension to resolve, e.g. "the upside is real but hinges on a risk the facts cannot yet confirm; resolve by ..."]

--- a/skills/tfs-parallel-perspectives-review/skill.meta.yml
+++ b/skills/tfs-parallel-perspectives-review/skill.meta.yml
@@ -1,0 +1,78 @@
+# Rich sidecar for the tfs-parallel-perspectives-review skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.parallel-perspectives-review
+  slug: parallel-perspectives-review
+  name: tfs-parallel-perspectives-review
+  display_name: Parallel Perspectives Review
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: perspective-and-multi-lens
+  secondary_families: [decision-and-option-evaluation]
+  thinking_modes: [critical, divergent, reflective]
+  problem_contexts: [high-stakes, high-conflict]
+  use_cases:
+    - give a decision or idea a rounded, balanced look before committing
+    - stop risk-aversion or optimism from dominating a discussion
+    - ensure quieter modes (intuition, alternatives) get airtime
+  poor_fit_cases:
+    - a single lens is obviously all that matters
+    - deep adversarial stress-test of one thesis (use red team) or failure causes (use premortem)
+    - performing six lenses mechanically when only two or three carry weight
+    - consensus theater rather than genuine separation
+
+interface:
+  required_inputs:
+    - a decision or idea to review
+  optional_inputs:
+    - constraints, stakeholders, the known facts
+  primary_artifact_type: multi-lens-review
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.problem-restatement
+    - thinking-framework-skills.decision-option-review
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.problem-restatement
+  often_precedes:
+    - thinking-framework-skills.decision-option-review
+  complements:
+    - thinking-framework-skills.ladder-of-inference-check
+  overlaps_with: []
+  variants:
+    - "branded lineage: Six Thinking Hats (de Bono, trademarked)"
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - lenses blur together (the failure the method exists to prevent)
+    - mechanical six-lens application when fewer matter
+    - consensus theater rather than genuine separation
+
+evidence:
+  evidence_tier: "P"
+  confidence: moderate that separating modes helps; the branded productivity claims are not credible
+  transferred_evidence: true
+  lineage:
+    derived_from: [parallel thinking, Six Thinking Hats mechanism]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: "Six Thinking Hats is a registered mark; this skill is named descriptively and does not use the branded hats"
+  risk_flags: [trademark-adjacent, popular-but-weak-branded-evidence]
+
+implementation:
+  skill_path: skills/tfs-parallel-perspectives-review/SKILL.md
+  references_path: skills/tfs-parallel-perspectives-review/references/
+  evidence_path: skills/tfs-parallel-perspectives-review/evidence/dossier.md
+  evals_path: skills/tfs-parallel-perspectives-review/eval/

--- a/skills/tfs-question-burst/SKILL.md
+++ b/skills/tfs-question-burst/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: tfs-question-burst
+description: Generates a rapid burst of questions about a problem (questions only, no answers), then ranks them for which would most change the approach and selects the single most catalytic one to pursue, producing a ranked question set. Use when you are stuck, too attached to one framing, or need a better question before answering.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.question-burst
+  family: divergent-ideation
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Question Burst
+
+Stuck thinking is usually stuck on the wrong question. A question burst generates many questions about a problem in a short, constrained burst (questions only, no answers), to break attachment to the current framing, then ranks them and picks the single most catalytic one. Because a model can generate questions endlessly, the value here is not the generation, it is the **ranking and selection**: this skill produces a ranked set ending in one chosen next question, never a bulk dump. The output is that ranked question set.
+
+## When to Use
+
+- Stuck, or over-attached to a single framing of the problem.
+- At the start of exploring an ambiguous problem, before committing to an answer.
+- When a better question would unlock more than another answer.
+
+## When NOT to Use
+
+- To produce a bulk list of questions with no ranking or selection (low signal; the main failure mode for an AI).
+- When the issue needs answers and convergence, not more questions.
+- When the catalytic question is already known.
+
+## Instructions
+
+When asked to run a question burst, follow these steps:
+
+1. **State the problem** in one line.
+2. **Burst.** Generate roughly 12 to 20 questions about it. Questions only, no answers, no preamble. Mix angles: why, how, what-if, who, what-would-change-if. Keep it brief.
+3. **Rank.** Order the questions by how much answering them would change the approach, not by how easy they are.
+4. **Select.** Choose the single most catalytic "next question" and give a one-line reason it would shift the problem.
+5. **Emit the ranked question set** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the ranked questions plus the one chosen next question, not a flat list and not answers.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The burst was questions only, no answers.
+- [ ] The questions are ranked by catalytic potential, not ease.
+- [ ] Exactly one "next question" is selected with a reason.
+- [ ] The output curates, it does not just dump a long list.
+- [ ] The output is the ranked question set artifact.
+
+## Evidence
+
+Tier **P**. The method is Hal Gregersen's question burst (MIT Sloan): generate many questions under a strict questions-only rule, then find the catalytic ones. MIT Sloan reports participant benefits (broader view, recognizing one's own role); there is no controlled decision-outcome evidence, and for AI the generation half has little value, so this skill is built around curation. Evidence is transferred from human workshops, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed ranked question set.

--- a/skills/tfs-question-burst/evidence/dossier.md
+++ b/skills/tfs-question-burst/evidence/dossier.md
@@ -1,0 +1,53 @@
+# Evidence Dossier: Question Burst
+
+> Single source of truth for the `question-burst` skill. The SKILL.md, sidecar, and evals derive from this.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.question-burst` (installable name `tfs-question-burst`) |
+| **Family** | divergent-ideation |
+| **Evidence tier** | **P** (practitioner; MIT Sloan reports participant benefits) |
+| **Confidence** | Moderate that questioning shifts framing; for AI the value is curation, not generation |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+Stuck thinking is often stuck on the wrong question. A question burst generates many questions about a problem in a short, constrained burst - questions only, no answers, no preamble - to break attachment to the current framing, then ranks them for which would most change the approach and picks the single most catalytic one to pursue. The discipline (questions only, a quota, a time box) suppresses the reflex to answer prematurely.
+
+**Critical adaptation for AI:** a model can produce hundreds of questions instantly, so raw generation is worthless here. The value is entirely in the **ranking and selection** - identifying the few questions that would actually shift the problem. This skill therefore requires a ranked output and one chosen next question, not a bulk dump.
+
+## 2. Lineage
+
+- Hal Gregersen (MIT Sloan), "Better Brainstorming" / the question-burst method: generate at least ~15-20 questions in a few minutes under a strict questions-only rule, then study them for the catalytic ones.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Supported (practitioner):** MIT Sloan reports that participants who run a question burst commonly leave with a better emotional state, a broader view of the problem, or the recognition that they are themselves part of the issue. The questions-only constraint is the active ingredient.
+
+**NOT shown:** no controlled evidence that it improves decision outcomes. And for AI specifically, the generation half has near-zero value (the well-known critique: LLMs generate questions trivially; the challenge is curation). Grade P, and design the skill around the curation, not the volume.
+
+## 4. Transferred-evidence flag
+
+Evidence is from human workshop contexts, not AI-augmented use. Transferred, not AI-validated. The honest AI value is narrow but real: forcing a ranked, selected output (not a bulk list) turns cheap question generation into a genuine reframing aid.
+
+## 5. When it works / when it fails
+
+**Works best when:** stuck, over-attached to one framing, or at the very start of exploring an ambiguous problem; when a better question is needed before any answer.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- Used to dump a bulk list of questions with no ranking or selection (the central AI failure mode; low signal-to-noise).
+- Answering instead of questioning during the burst.
+- When the issue needs answers and convergence, not more questions.
+- When the catalytic question is already known.
+
+## 6. Output artifact
+
+A **ranked question set**: the raw burst (kept brief), then the questions ranked by how much they would change the approach, and the single chosen "next question" to pursue with a one-line reason.
+
+## 7. Sources
+
+1. Gregersen, H. (MIT Sloan), "Better Brainstorming" (HBR) and the Question Burst method.
+
+> **Verification status:** Gregersen/MIT Sloan attribution is well-attested. Treat participant benefits as practitioner-reported, not a measured decision-quality effect.

--- a/skills/tfs-question-burst/references/EXAMPLE.md
+++ b/skills/tfs-question-burst/references/EXAMPLE.md
@@ -1,0 +1,44 @@
+# Ranked Question Set - Worked Example
+
+A completed run of `tfs-question-burst`, on the shared Northwind scenario. This is the quality bar a generated set should meet.
+
+> Northwind is a B2B SaaS weighing a self-serve free-tier launch and feeling stuck on "build it or not."
+
+---
+
+## Problem
+
+- We are stuck debating whether to build a free tier to hit the Q3 growth target.
+
+## The burst (questions only)
+
+- Why do we believe a free tier drives growth here specifically?
+- What is our current trial-to-paid conversion, and why is it falling?
+- Who are the users we actually want more of?
+- What would have to be true for a free tier to pay for itself?
+- What is the cheapest experiment that would tell us if free works?
+- Who loses if we launch a free tier?
+- What problem did the free tier idea originally come from?
+- Is "growth" the goal, or is it revenue, or qualified pipeline?
+- What happens to Sales the day we launch free?
+- How would a competitor without a free tier hit this target?
+- What would we do if we could not build anything new for Q3?
+- Are we solving a packaging problem or a funnel problem?
+- What is the most irreversible part of this decision?
+- Who has hit this target before, and how?
+
+## Ranked by catalytic potential
+
+| Rank | Question | Why it would change the approach |
+|---|---|---|
+| 1 | Are we solving a packaging problem or a funnel problem? | If it is the funnel, the entire free-tier premise is wrong and the fix is cheaper. |
+| 2 | What is the cheapest experiment that would tell us if free works? | Converts a one-way-door build into a reversible test. |
+| 3 | Is the goal growth, revenue, or qualified pipeline? | The real objective changes which option even qualifies. |
+
+## Next question to pursue
+
+- **"Are we solving a packaging problem or a funnel problem?"** - it is upstream of everything else: answering it either kills or confirms the free-tier hypothesis before any build, and it is answerable from data we already have.
+
+---
+
+*Note: the value is the ranking. A model can list these 14 questions instantly; the work was deciding that question 1 reframes the whole debate, and feeding it into a problem-restatement or evidence sort next.*

--- a/skills/tfs-question-burst/references/TEMPLATE.md
+++ b/skills/tfs-question-burst/references/TEMPLATE.md
@@ -1,0 +1,25 @@
+# Ranked Question Set - Template
+
+Fill this in. The deliverable is the ranked questions plus one chosen next question, not a flat list and not answers.
+
+---
+
+## Problem
+
+- [one line]
+
+## The burst (questions only)
+
+[12 to 20 questions, no answers. Keep brief.]
+
+## Ranked by catalytic potential
+
+| Rank | Question | Why it would change the approach |
+|---|---|---|
+| 1 | | |
+| 2 | | |
+| 3 | | |
+
+## Next question to pursue
+
+- **[the single most catalytic question]** - one line on why answering this shifts the problem most.

--- a/skills/tfs-question-burst/skill.meta.yml
+++ b/skills/tfs-question-burst/skill.meta.yml
@@ -1,0 +1,73 @@
+# Rich sidecar for the tfs-question-burst skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.question-burst
+  slug: question-burst
+  name: tfs-question-burst
+  display_name: Question Burst
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: divergent-ideation
+  secondary_families: [problem-framing]
+  thinking_modes: [divergent, lateral]
+  problem_contexts: [high-ambiguity]
+  use_cases:
+    - break attachment to a single framing when stuck
+    - surface a better question before answering, early in an ambiguous problem
+  poor_fit_cases:
+    - dumping a bulk list of questions with no ranking or selection
+    - issues that need answers and convergence, not more questions
+    - when the catalytic question is already known
+
+interface:
+  required_inputs:
+    - a problem or topic to question
+  optional_inputs:
+    - what has already been tried or assumed
+  primary_artifact_type: ranked-question-set
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.problem-restatement
+    - thinking-framework-skills.evidence-vs-inference-sort
+
+relationships:
+  often_follows: []
+  often_precedes:
+    - thinking-framework-skills.problem-restatement
+  complements:
+    - thinking-framework-skills.problem-restatement
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - generating volume without ranking or selecting (the AI failure mode)
+    - answering instead of questioning during the burst
+    - vague questions that would not change the approach
+
+evidence:
+  evidence_tier: "P"
+  confidence: moderate; for AI the value is curation, not generation
+  transferred_evidence: true
+  lineage:
+    derived_from: [Gregersen question burst, MIT Sloan]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-question-burst/SKILL.md
+  references_path: skills/tfs-question-burst/references/
+  evidence_path: skills/tfs-question-burst/evidence/dossier.md
+  evals_path: skills/tfs-question-burst/eval/

--- a/skills/tfs-red-team-light/SKILL.md
+++ b/skills/tfs-red-team-light/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: tfs-red-team-light
+description: Produces an adversarial critique by constructing the strongest case against a proposal or thesis (the best objections an intelligent adversary would raise), then judging which objections actually land and what would rebut them. Use when a plan has too-easy consensus and needs pressure-testing, or to steelman the opposition before committing.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.red-team-light
+  family: assumption-and-belief-challenge
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Red Team Light
+
+Plans that reach easy consensus go untested. This skill suspends the cooperative stance and constructs the strongest case against a single proposal or thesis: the best objections a motivated, intelligent adversary would raise (steelman, not strawman), then judges which land and what would rebut them. The output is an **adversarial critique**. Honest limit: an AI red team is constructed, role-played dissent, and role-played dissent does not match genuine dissent (Nemeth) - so for high stakes it flags whether a real dissenting view should be sought, not just the model's.
+
+## When to Use
+
+- A plan has too-easy consensus and nobody is really arguing the other side.
+- Before committing to a strong thesis or recommendation.
+- To pressure-test the agent's own confident output.
+
+## When NOT to Use
+
+- When the team needs alignment and buy-in more than another critique.
+- When you need failure causes over time (use premortem) or a rounded multi-lens view (use parallel perspectives).
+- If it would only produce performative contrarianism rather than the strongest objections.
+
+## Instructions
+
+When asked to red team, follow these steps:
+
+1. **State the thesis fairly** in one or two sentences - the proposal being attacked, in its strongest honest form.
+2. **Build the strongest objections.** Adopt a genuinely adversarial stance and construct the best case against it: where it is weakest, what an informed critic or competitor would attack, what evidence cuts against it. Steelman, do not strawman.
+3. **Rank by force.** Order the objections by how much damage they do if true, not by how easy they are to raise.
+4. **Test each.** For the top objections, state how the thesis would have to answer them, and whether it plausibly can.
+5. **Verdict.** Say which objections are decisive (would sink or substantially change the plan) and which are survivable. For high stakes, note whether a real, independent dissenting view should be sought, given this is constructed dissent.
+6. **Emit the critique** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the ranked objections with verdicts, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] Objections are steelmanned (strongest form), not strawmen.
+- [ ] They are ranked by force, not by ease.
+- [ ] Each top objection has how the thesis must answer it.
+- [ ] The verdict names which objections are decisive.
+- [ ] It notes whether genuine (not constructed) dissent should be sought for high stakes.
+- [ ] The output is the adversarial critique artifact, not prose.
+
+## Evidence
+
+Tier **P** (flagged). Adversarial review (red teaming, from military/intelligence/security practice) surfaces objections cooperative review misses. But Nemeth et al. (2001) found role-played dissent does not replicate the reasoning gains of authentic dissent, and an AI red team is constructed dissent, so it is a blind-spot finder, not a substitute for a real dissenter. Evidence is transferred from human contexts, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed critique.

--- a/skills/tfs-red-team-light/evidence/dossier.md
+++ b/skills/tfs-red-team-light/evidence/dossier.md
@@ -1,0 +1,56 @@
+# Evidence Dossier: Red Team Light
+
+> Single source of truth for the `red-team-light` skill. The SKILL.md, sidecar, and evals derive from this.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.red-team-light` (installable name `tfs-red-team-light`) |
+| **Family** | assumption-and-belief-challenge |
+| **Evidence tier** | **P** (flag: role-played dissent underperforms genuine dissent) |
+| **Confidence** | High that surfacing the strongest counter-case is useful; honest that constructed dissent is weaker than authentic dissent |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+Plans that reach easy consensus go untested. Red Team Light deliberately suspends the cooperative, agreeable stance and constructs the **strongest case against** a single proposal or thesis - the best objections an intelligent, motivated adversary would raise (steelman, not strawman) - then judges which objections actually land and what would rebut them. The work is done by forcing a genuinely adversarial pass that an obliging model (or a harmonious team) skips, and by ranking objections so the decisive ones are not lost among the weak.
+
+It is distinct from neighbors: premortem maps *failure causes over time*; parallel perspectives gives a *rounded* view; red team builds the *single strongest opposing case*.
+
+## 2. Lineage and the honest caveat
+
+- Red teaming comes from military, intelligence, and security practice (an adversarial team attacks a plan). It is related to devil's advocacy.
+- **Important honesty (drives the flag):** Nemeth et al. (2001) found that **role-played** devil's advocacy does **not** replicate the reasoning gains of **authentic** dissent (a genuine minority that really disagrees). An AI red team is constructed, role-played dissent. So treat its output as "the strongest objections we could articulate," which is useful for surfacing blind spots, not as a substitute for a real dissenter who actually believes the counter-case.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Supported:** adversarial review surfaces objections that cooperative review misses; steelmanning the opposition is a sound reasoning discipline.
+
+**NOT shown:** that constructed/role-played dissent improves decisions as much as genuine dissent (Nemeth indicates it does not). Grade P with a flag; present it as a blind-spot finder, and where stakes are high, recommend seeking a real dissenting view, not just the model's.
+
+## 4. Transferred-evidence flag
+
+Evidence is from human group-reasoning and security contexts, not AI-augmented use. Transferred, not AI-validated. The AI value: a model is strongly biased toward agreeing and completing the user's framing; explicitly instructing it to build the best opposing case is a direct counter to that sycophancy, with the Nemeth caveat that this is constructed, not authentic, dissent.
+
+## 5. When it works / when it fails
+
+**Works best when:** a plan has too-easy consensus; before committing to a strong thesis; to pressure-test the agent's own confident recommendation.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- Producing a weak strawman instead of the strongest objections.
+- Performative contrarianism (objecting for its own sake) without judging which objections land.
+- Treating the constructed critique as equivalent to genuine dissent (the central honesty failure).
+- When the team needs alignment and buy-in more than another critique.
+- When you need failure causes over time (premortem) or a rounded view (parallel perspectives).
+
+## 6. Output artifact
+
+An **adversarial critique**: the thesis stated fairly, then the strongest objections ranked by force, each with how it would have to be answered, a verdict on which objections are decisive, and a one-line note on whether a real (not constructed) dissenting view should be sought given the stakes.
+
+## 7. Sources
+
+1. Red teaming practice (military / intelligence / security).
+2. Nemeth, C. et al. (2001) - authentic dissent vs role-played devil's advocacy (role-play does not replicate the gains).
+
+> **Verification status:** the Nemeth finding is well-attested and is deliberately surfaced as the honesty flag. Do not present an AI red team as equivalent to genuine dissent.

--- a/skills/tfs-red-team-light/references/EXAMPLE.md
+++ b/skills/tfs-red-team-light/references/EXAMPLE.md
@@ -1,0 +1,30 @@
+# Adversarial Critique - Worked Example
+
+A completed run of `tfs-red-team-light`, on the shared Northwind scenario. This is the quality bar a generated critique should meet.
+
+> Northwind is a B2B SaaS and the team has reached easy consensus that the free tier is the answer. Here the skill attacks that thesis.
+
+---
+
+## Thesis under attack
+
+- Launching a self-serve free tier is the best way for Northwind to hit the Q3 growth target, because it lowers the barrier to entry and competitors already have one.
+
+## Strongest objections (ranked by force)
+
+| Rank | Objection (steelmanned) | Damage if true | How the thesis must answer it | Can it? |
+|---|---|---|---|---|
+| 1 | The conversion drop is a funnel/ramp problem, not a packaging gap; a free tier adds cost without fixing the actual cause | Fatal - the whole rationale collapses and money is spent on the wrong problem | Show data that packaging, not onboarding or new-rep ramp, drives the drop | Not yet; the data has not been checked |
+| 2 | Free-to-paid economics at our ICP are unproven; a large non-converting free cohort breaks unit economics | Severe - growth in signups with negative margin is worse than no growth | Cite or pilot ICP free-to-paid conversion and cost-per-free-user | Not yet; no pilot run |
+| 3 | "Competitors have one" is imitation, not strategy; their economics and ICP may differ from ours | Moderate - removes the main external justification | Show why it works for our model specifically | Weakly |
+| 4 | A 6-week build risks shipping an insecure billing/auth path under time pressure | Moderate - reputational and security risk | Commit to a security gate and scope cut | Yes, if disciplined |
+
+## Verdict
+
+- **Decisive objections:** #1 and #2. Either, if true, sinks the plan. Both are currently unanswered and both are cheaply testable (data check + small pilot) before committing.
+- **Survivable objections:** #3 (weakens the case but not fatal) and #4 (manageable with a gate).
+- **Genuine dissent needed?** Given this is a near-one-way-door, board-visible decision, yes: before committing, get a real dissenter (someone who genuinely believes the funnel-fix thesis) to argue #1, rather than relying on this constructed critique alone.
+
+---
+
+*Note: the value is ranking #1 and #2 as decisive and noting both are unanswered yet cheap to test. The honesty flag matters here: the model can articulate the counter-case, but on a one-way door the team should still hear it from someone who actually holds it.*

--- a/skills/tfs-red-team-light/references/TEMPLATE.md
+++ b/skills/tfs-red-team-light/references/TEMPLATE.md
@@ -1,0 +1,23 @@
+# Adversarial Critique - Template
+
+Fill this in. The deliverable is the ranked objections with verdicts, not prose. Steelman the objections; rank by force, not ease.
+
+---
+
+## Thesis under attack
+
+- [the proposal, stated fairly in its strongest honest form]
+
+## Strongest objections (ranked by force)
+
+| Rank | Objection (steelmanned) | Damage if true | How the thesis must answer it | Can it? |
+|---|---|---|---|---|
+| 1 | | | | |
+| 2 | | | | |
+| 3 | | | | |
+
+## Verdict
+
+- **Decisive objections** (would sink or substantially change the plan): [...]
+- **Survivable objections:** [...]
+- **Genuine dissent needed?** [for high stakes: should a real, independent dissenting view be sought, beyond this constructed critique?]

--- a/skills/tfs-red-team-light/skill.meta.yml
+++ b/skills/tfs-red-team-light/skill.meta.yml
@@ -1,0 +1,78 @@
+# Rich sidecar for the tfs-red-team-light skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.red-team-light
+  slug: red-team-light
+  name: tfs-red-team-light
+  display_name: Red Team Light
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: assumption-and-belief-challenge
+  secondary_families: [risk-and-resilience]
+  thinking_modes: [critical, adversarial]
+  problem_contexts: [high-stakes, high-conflict]
+  use_cases:
+    - pressure-test a plan that has reached too-easy consensus
+    - steelman the opposition before committing to a thesis
+    - challenge the agent's own confident recommendation
+  poor_fit_cases:
+    - when the team needs alignment and buy-in more than critique
+    - when you need failure causes over time (premortem) or a rounded view (parallel perspectives)
+    - performative contrarianism without judging which objections land
+    - treating constructed critique as equivalent to genuine dissent
+
+interface:
+  required_inputs:
+    - a proposal or thesis to attack
+  optional_inputs:
+    - the stakes and reversibility of the decision
+  primary_artifact_type: adversarial-critique
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.premortem
+    - thinking-framework-skills.what-would-have-to-be-true
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.decision-option-review
+  often_precedes:
+    - thinking-framework-skills.premortem
+  complements:
+    - thinking-framework-skills.parallel-perspectives-review
+  overlaps_with: []
+  variants:
+    - "related: devil's advocacy (weaker, role-played)"
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - strawman instead of the strongest objections
+    - performative contrarianism without verdicts
+    - treating constructed critique as genuine dissent
+
+evidence:
+  evidence_tier: "P"
+  confidence: high that surfacing the strongest counter-case helps; constructed dissent is weaker than authentic dissent
+  transferred_evidence: true
+  lineage:
+    derived_from: [red teaming practice, devil's advocacy]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+  risk_flags: [constructed-vs-authentic-dissent]
+
+implementation:
+  skill_path: skills/tfs-red-team-light/SKILL.md
+  references_path: skills/tfs-red-team-light/references/
+  evidence_path: skills/tfs-red-team-light/evidence/dossier.md
+  evals_path: skills/tfs-red-team-light/eval/

--- a/skills/tfs-reference-class-forecasting/SKILL.md
+++ b/skills/tfs-reference-class-forecasting/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tfs-reference-class-forecasting
+description: Produces a reference-class estimate by defining a class of similar past cases, taking their base-rate distribution of outcomes, and anchoring the forecast on that outside view rather than the optimistic inside view, with a conservative adjustment for specifics. Use when forecasting cost, time, or odds of success for a project prone to optimism or the planning fallacy.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.reference-class-forecasting
+  family: risk-and-resilience
+  evidence-tier: "S"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Reference Class Forecasting
+
+People forecast from the inside view, building an estimate from their own plan's details, which invites optimism and the planning fallacy. This skill replaces that with the outside view: find a reference class of similar past cases, take the base-rate distribution of how they actually turned out, and anchor the forecast on that, adjusting only cautiously for genuine specifics. The output is a **reference-class estimate**. The honest constraint: it requires real base-rate data; inventing a distribution is worse than admitting uncertainty.
+
+## When to Use
+
+- Forecasting cost, time, or odds of success for something with comparable precedents.
+- The inside-view estimate is likely optimistic.
+- High-stakes commitments prone to the planning fallacy.
+
+## When NOT to Use
+
+- Genuinely novel undertakings with no comparable reference class.
+- When you have no real base-rate data and would have to invent it.
+- When the specifics genuinely dominate and no class is comparable.
+- When a point certainty is expected (this produces a distribution).
+
+## Instructions
+
+When asked to forecast with the outside view, follow these steps:
+
+1. **State what is being forecast** (cost, duration, success odds) and the inside-view estimate if one exists.
+2. **Define the reference class.** Identify the set of genuinely comparable past cases, and say why they are comparable. Resist a class that is too narrow or too flattering.
+3. **Get the base rates.** State the distribution of outcomes for that class - typical and worst-case - with the data source. If real data is unavailable, say so explicitly and stop or downgrade to a clearly-flagged rough estimate; do not fabricate numbers.
+4. **Anchor on the outside view.** Set the estimate from the base-rate distribution, not the plan's details.
+5. **Adjust conservatively.** Only then adjust for genuine specifics, in small amounts, and resist sliding back to the optimistic inside view.
+6. **Emit the reference-class estimate** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the reference class, base rates, and the outside-anchored estimate as a range, not a single optimistic number.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The reference class is genuinely comparable, not narrow or flattering.
+- [ ] Base rates come with a data source, or missing data is flagged (not invented).
+- [ ] The estimate is anchored on the distribution, then adjusted only conservatively.
+- [ ] The result is a range/distribution, not a point certainty.
+- [ ] The inside-view estimate did not sneak back in as the answer.
+- [ ] The output is the reference-class estimate artifact, not prose.
+
+## Evidence
+
+Tier **S**. The planning fallacy is robustly demonstrated and the outside view measurably reduces forecast error (Kahneman & Lovallo 1993; Kahneman 2011). Bent Flyvbjerg's reference class forecasting for infrastructure documented systematic overruns and has been adopted by institutions (e.g. UK guidance) - real-world validation, not only lab results. The strong evidence is from human forecasting; the AI use transfers the method, with the firm constraint that base rates must be real, not invented. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed reference-class estimate.

--- a/skills/tfs-reference-class-forecasting/evidence/dossier.md
+++ b/skills/tfs-reference-class-forecasting/evidence/dossier.md
@@ -1,0 +1,55 @@
+# Evidence Dossier: Reference Class Forecasting
+
+> Single source of truth for the `reference-class-forecasting` skill. The SKILL.md, sidecar, and evals derive from this. This is one of the library's strong-evidence anchors.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.reference-class-forecasting` (installable name `tfs-reference-class-forecasting`) |
+| **Family** | risk-and-resilience |
+| **Evidence tier** | **S** (strong; empirical + real-world institutional adoption) |
+| **Confidence** | High - among the best-evidenced debiasing methods |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+People forecast from the **inside view**: they build an estimate from the specifics of their own plan, which invites optimism and the planning fallacy (systematic underestimation of cost, time, and risk). Reference class forecasting replaces that with the **outside view**: find a reference class of similar past cases, get the **base-rate distribution** of how they actually turned out (cost overruns, schedule slips, success rates), and anchor the forecast on that distribution, adjusting only cautiously for genuine specifics. The work is done by anchoring on real outcomes of comparable cases instead of on the inside story, which is what corrects the optimism.
+
+## 2. Lineage
+
+- Kahneman & Tversky introduced the inside/outside view distinction; Kahneman & Lovallo (1993) formalized the planning fallacy and the case for the outside view.
+- Bent Flyvbjerg developed reference class forecasting for large infrastructure projects (documenting systematic cost and schedule overruns) and it has been **adopted by institutions** (for example UK Treasury / transport planning guidance) - real-world uptake, not just lab results.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Strongly supported (the S):** the planning fallacy is robustly demonstrated, and taking the outside view via reference classes measurably reduces forecast error; Flyvbjerg's work and its institutional adoption are real-world validation, not only experiments. This is a genuine strong-evidence method and a credibility anchor for the library.
+
+**Boundaries (still honest):** it requires a genuine reference class with real base-rate data. Where no comparable class exists (a truly novel undertaking), or where the specifics genuinely dominate, the method weakens. And it forecasts a distribution, not a certainty.
+
+## 4. Transferred-evidence flag
+
+The strong evidence is from human forecasting and large projects, not AI-augmented use. Transferred, not AI-validated. The AI value is real and pointed: a model will happily produce an inside-view, optimistic estimate from a plan's details; forcing it to construct a reference class and anchor on base rates is a direct counter, with the honest constraint that the agent must use real base-rate data, not invented numbers.
+
+## 5. When it works / when it fails
+
+**Works best when:** forecasting cost, time, or odds of success for something with comparable precedents; the inside view is likely optimistic; high-stakes commitments prone to the planning fallacy.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **No real base-rate data** - inventing a distribution is worse than admitting uncertainty (the central failure mode for an AI).
+- Choosing a reference class that is too narrow, too flattering, or not actually comparable.
+- Over-adjusting back toward the optimistic inside view ("but we are different").
+- Genuinely novel undertakings with no comparable class.
+- Treating the outside estimate as a point certainty rather than a distribution.
+
+## 6. Output artifact
+
+A **reference-class estimate**: the reference class defined (and why it is comparable), the base-rate distribution (typical and worst-case outcomes, with the data source or an explicit flag that data is missing), the original inside-view estimate, the outside-anchored estimate, and the adjustment rationale (kept conservative).
+
+## 7. Sources
+
+1. Kahneman, D., & Lovallo, D. (1993) - timid choices, bold forecasts; the planning fallacy and the outside view.
+2. Flyvbjerg, B. - reference class forecasting for infrastructure; documented cost/schedule overruns; institutional adoption (e.g. UK guidance).
+3. Kahneman, D. (2011), *Thinking, Fast and Slow* - inside vs outside view popularization.
+
+> **Verification status:** the planning-fallacy and Flyvbjerg findings, and the institutional adoption, are well-attested; the "S" grade is justified. Keep the "use real base rates, not invented ones" constraint front and center for AI use.

--- a/skills/tfs-reference-class-forecasting/references/EXAMPLE.md
+++ b/skills/tfs-reference-class-forecasting/references/EXAMPLE.md
@@ -1,0 +1,33 @@
+# Reference-Class Estimate - Worked Example
+
+A completed run of `tfs-reference-class-forecasting`, on the shared Northwind scenario. This is the quality bar a generated estimate should meet.
+
+> Northwind is a B2B SaaS. The team estimates the free-tier build will take 6 weeks. Here the skill checks that with the outside view.
+
+---
+
+## What is being forecast
+
+- **Quantity:** time to ship the self-serve free tier (build + billing + onboarding).
+- **Inside-view estimate:** 6 weeks (built up from the team's task list).
+
+## Reference class
+
+- **The class:** Northwind's last several "new self-serve surface" launches (billing/auth/onboarding changes of similar scope), plus comparable launches the team has data on.
+- **Why comparable:** all involved new billing states, auth edge cases, and onboarding flows under a deadline - the same risk profile, not cherry-picked easy projects.
+
+## Base rates
+
+- **Data source:** Northwind's last 5 comparable launches (internal delivery records). [If those records did not exist, the honest move would be to flag "no real base-rate data" and treat the 6-week figure as an untested inside estimate, not to invent a multiplier.]
+- **Typical outcome:** comparable launches ran ~1.5x the initial estimate (so ~9 weeks for a "6-week" plan).
+- **Worst-case / tail:** the two launches that touched billing most heavily ran ~2x (~12 weeks), usually from billing/security rework discovered late.
+
+## Outside-anchored estimate
+
+- **Anchored estimate (range):** 9 to 12 weeks, centered on ~1.5x.
+- **Conservative adjustment for specifics:** the team is slightly more experienced with this billing system now; nudge the center down modestly, not back to 6. Resisted the inside-view pull to "but this time it is simpler."
+- **Final forecast:** ~8 to 11 weeks (median ~9), with the main uncertainty in the billing/auth path. Implication: a 6-week, fixed-date commitment is likely to slip or ship rough; either move the date or cut scope now.
+
+---
+
+*Note: the value is refusing the 6-week inside estimate and anchoring on what comparable launches actually took (~1.5x). The honesty rule is load-bearing here: if Northwind had no real delivery records, the right output is "we lack a reference class" - not a fabricated multiplier. This pairs naturally with a premortem on the slip risk.*

--- a/skills/tfs-reference-class-forecasting/references/TEMPLATE.md
+++ b/skills/tfs-reference-class-forecasting/references/TEMPLATE.md
@@ -1,0 +1,27 @@
+# Reference-Class Estimate - Template
+
+Fill this in. The deliverable is the reference class, base rates, and an outside-anchored range, not a single optimistic number. Use real base rates; if data is missing, flag it rather than inventing.
+
+---
+
+## What is being forecast
+
+- **Quantity:** [cost / duration / success odds]
+- **Inside-view estimate (if any):** [the plan-based number]
+
+## Reference class
+
+- **The class:** [the set of comparable past cases]
+- **Why comparable:** [what makes these genuinely similar; why this class is not too narrow or flattering]
+
+## Base rates
+
+- **Data source:** [where the distribution comes from, or FLAG: real data unavailable]
+- **Typical outcome:** [median / common result]
+- **Worst-case / tail:** [the bad-but-real end of the distribution]
+
+## Outside-anchored estimate
+
+- **Anchored estimate (range):** [from the distribution, not the plan]
+- **Conservative adjustment for specifics:** [small, justified; note what you resisted]
+- **Final forecast:** [a range, with the confidence and the main uncertainty]

--- a/skills/tfs-reference-class-forecasting/skill.meta.yml
+++ b/skills/tfs-reference-class-forecasting/skill.meta.yml
@@ -1,0 +1,77 @@
+# Rich sidecar for the tfs-reference-class-forecasting skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.reference-class-forecasting
+  slug: reference-class-forecasting
+  name: tfs-reference-class-forecasting
+  display_name: Reference Class Forecasting
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: risk-and-resilience
+  secondary_families: [decision-and-option-evaluation]
+  thinking_modes: [critical, analytical, counterfactual]
+  problem_contexts: [high-stakes, high-complexity]
+  use_cases:
+    - forecast cost, time, or odds of success against the planning fallacy
+    - replace an optimistic inside-view estimate with an outside-view range
+    - sanity-check a high-stakes commitment with base rates
+  poor_fit_cases:
+    - genuinely novel undertakings with no comparable reference class
+    - when no real base-rate data exists (do not invent a distribution)
+    - when the specifics genuinely dominate and no class is comparable
+    - when a point certainty is expected (this produces a distribution)
+
+interface:
+  required_inputs:
+    - what is being forecast (cost, time, or success), ideally with the inside estimate
+  optional_inputs:
+    - candidate reference cases or known base-rate data
+  primary_artifact_type: reference-class-estimate
+  output_formats: [markdown]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.premortem
+    - thinking-framework-skills.what-would-have-to-be-true
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.decision-option-review
+  often_precedes:
+    - thinking-framework-skills.premortem
+  complements:
+    - thinking-framework-skills.premortem
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - inventing base-rate data when none exists
+    - choosing a reference class too narrow or too flattering
+    - over-adjusting back toward the optimistic inside view
+    - presenting the estimate as a point certainty rather than a distribution
+
+evidence:
+  evidence_tier: "S"
+  confidence: high; among the best-evidenced debiasing methods, with institutional adoption
+  transferred_evidence: true
+  lineage:
+    derived_from: [Kahneman and Lovallo outside view, Flyvbjerg reference class forecasting]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-reference-class-forecasting/SKILL.md
+  references_path: skills/tfs-reference-class-forecasting/references/
+  evidence_path: skills/tfs-reference-class-forecasting/evidence/dossier.md
+  evals_path: skills/tfs-reference-class-forecasting/eval/


### PR DESCRIPTION
Completes the full MVP. Adds the 9 remaining skills, each built through `docs/internal/AUTHORING.md`, evidence-graded honestly, artifact-first, and using the shared Northwind scenario so the whole catalog composes into one worked thread.

**Full-MVP tranche (6-14):**
- `tfs-ladder-of-inference-check` (P) - annotated reasoning trace
- `tfs-parallel-perspectives-review` (P, flagged) - multi-lens review; Six-Hats mechanism descriptively, de Bono "493%" flagged as uncited
- `tfs-question-burst` (P) - ranked question set; AI value is curation not generation
- `tfs-futures-wheel` (P) - consequence map (+ lightweight second-order mode)
- `tfs-decision-option-review` (P, flagged) - option matrix; false-precision guarded
- `tfs-assumption-reversal` (P) - assumptions-and-reversals sheet
- `tfs-red-team-light` (P, flagged) - adversarial critique; honest Nemeth caveat (constructed != authentic dissent)
- **`tfs-brainwriting` (S)** - idea pool; Diehl & Stroebe production-blocking evidence
- **`tfs-reference-class-forecasting` (S)** - outside-view estimate; Kahneman/Lovallo + Flyvbjerg

The two **S-tier** skills are the evidence-brand anchors the audit called for (the consensus roster skewed practitioner). All 14 skills validate at `Tier universal, 0 errors / 0 warnings`. Backlog marked complete; next is the 4 recipes, then the (gated) go-public flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)