### PR TITLE
Recipes (4 composable chains) + eval cases for all 14 skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,35 @@ Each skill is built around four commitments, not just a prompt:
 
 ## Skills
 
-| Skill | Family | Evidence | What it produces |
+| Skill | Family | Evidence | Artifact |
 |---|---|---|---|
-| [`tfs-premortem`](skills/tfs-premortem/SKILL.md) | risk-and-resilience | S/M (contested) | A risk register: ranked failure causes with tripwires, mitigations, owners, and kill criteria |
+| [`tfs-premortem`](skills/tfs-premortem/SKILL.md) | risk-and-resilience | S/M | risk register |
+| [`tfs-problem-restatement`](skills/tfs-problem-restatement/SKILL.md) | problem-framing | M/P | problem frame set |
+| [`tfs-evidence-vs-inference-sort`](skills/tfs-evidence-vs-inference-sort/SKILL.md) | reasoning-clarity | P | evidence/inference ledger |
+| [`tfs-ladder-of-inference-check`](skills/tfs-ladder-of-inference-check/SKILL.md) | assumption-and-belief-challenge | P | reasoning trace |
+| [`tfs-what-would-have-to-be-true`](skills/tfs-what-would-have-to-be-true/SKILL.md) | decision-and-option-evaluation | P | assumption ledger |
+| [`tfs-decision-option-review`](skills/tfs-decision-option-review/SKILL.md) | decision-and-option-evaluation | P (flag) | option matrix |
+| [`tfs-parallel-perspectives-review`](skills/tfs-parallel-perspectives-review/SKILL.md) | perspective-and-multi-lens | P (flag) | multi-lens review |
+| [`tfs-red-team-light`](skills/tfs-red-team-light/SKILL.md) | assumption-and-belief-challenge | P (flag) | adversarial critique |
+| [`tfs-scamper`](skills/tfs-scamper/SKILL.md) | divergent-ideation | P | expansion sheet |
+| [`tfs-question-burst`](skills/tfs-question-burst/SKILL.md) | divergent-ideation | P | ranked question set |
+| [`tfs-assumption-reversal`](skills/tfs-assumption-reversal/SKILL.md) | divergent-ideation | P | assumptions-and-reversals sheet |
+| [`tfs-brainwriting`](skills/tfs-brainwriting/SKILL.md) | divergent-ideation | **S** | idea pool |
+| [`tfs-futures-wheel`](skills/tfs-futures-wheel/SKILL.md) | systems-and-consequences | P | consequence map |
+| [`tfs-reference-class-forecasting`](skills/tfs-reference-class-forecasting/SKILL.md) | risk-and-resilience | **S** | reference-class estimate |
 
-More skills are in progress; see the release plan and the audit in `_local/`.
+The two **S** skills (brainwriting, reference-class-forecasting) are the strong-evidence anchors. "(flag)" marks skills with a documented evidence or trademark caveat in their dossier.
+
+## Recipes
+
+Composable chains that solve a recurring job end to end (documented chains today; they graduate to invokable commands at the Silver climb). See [`recipes/`](recipes/README.md).
+
+| Recipe | Chain |
+|---|---|
+| [reframe-problem](recipes/reframe-problem.md) | restate -> evidence-sort -> perspectives |
+| [expand-options](recipes/expand-options.md) | restate -> scamper -> assumption-reversal |
+| [stress-test-decision](recipes/stress-test-decision.md) | option-review -> WWHTBT -> premortem -> reference-class |
+| [audit-reasoning](recipes/audit-reasoning.md) | evidence-sort -> ladder -> perspectives |
 
 ## Skill anatomy
 

--- a/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
+++ b/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
@@ -4,7 +4,7 @@ The single source of "what to build next." WIP = 1: build the **Now** skill end 
 
 ## Now
 
-> **All 14 MVP skills are complete and validated (Tier universal, 0/0).** Next build action: the 4 recipes (thin `/think:*` command files), then per-skill `eval/` cases. Going live is gated on your go (make the repo public, re-pin and merge the held `agent-plugins` listing).
+> **MVP complete: 14 skills + 4 recipes + eval cases for every skill, all validated (Tier universal, 0/0).** Next build action: the Silver climb (package the recipes as workflow + command components; add per-target Codex emission), and/or the go-public flip (gated on your go: make the repo public, re-pin and merge the held `agent-plugins` listing).
 
 ## Build order
 
@@ -42,5 +42,5 @@ Statuses: `done` | `now` | `next` | `later`. The two `wk3` rows are the strong-e
 ## Parallel / later (not gates on the Now skill)
 
 - Relocate the discovery corpus into committed `docs/internal/research/` (secret-scan first); rename `_LOCAL` -> `_local`.
-- Add `eval/` cases per skill (incl. a run vs a frontier model doing the method unaided).
+- DONE: `eval/cases.md` authored for every skill (triggers, anti-triggers, output checks, value-vs-unaided baseline). Not yet executed by a harness; the runner is a Silver-climb item.
 - Confirm license (Apache-2.0); decide the Silver climb; the go-public flip at the showcase.

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,0 +1,18 @@
+# Recipes
+
+Recipes are composable workflows: short, ordered chains of skills that solve a recurring job end to end. Each recipe names the skills to run, in order, what to carry forward (compressed) between steps, and the composite artifact produced.
+
+These are **documented chains**, runnable by an agent that reads the recipe and invokes each skill in turn. They are intentionally not yet packaged as invokable slash-commands: in the `agent-skills-toolkit` Standard a multi-skill chain is a *workflow* component with a command that maps to it, which is Silver-tier machinery. That packaging is deferred to the Silver climb so the library stays cleanly at Bronze (Universal) for now. The chains themselves are usable today.
+
+**Token discipline:** between steps, carry forward only the compressed artifact (the chosen frame, the shortlist, the ledger), not the full working text of the prior step. The audit flagged unbounded recipe context as the main operational risk; compress at each handoff.
+
+## The recipes
+
+| Recipe | Job | Chain |
+|---|---|---|
+| [reframe-problem](reframe-problem.md) | Make sure you are solving the right problem | problem-restatement -> evidence-vs-inference-sort -> parallel-perspectives-review |
+| [expand-options](expand-options.md) | Break past the obvious option set | problem-restatement -> scamper -> assumption-reversal |
+| [stress-test-decision](stress-test-decision.md) (marquee) | Pressure-test a decision before committing | decision-option-review -> what-would-have-to-be-true -> premortem -> reference-class-forecasting |
+| [audit-reasoning](audit-reasoning.md) | Check whether a conclusion is sound | evidence-vs-inference-sort -> ladder-of-inference-check -> parallel-perspectives-review |
+
+Each chain references skills by their installable name (`tfs-<method>`) and `skills/tfs-<method>/SKILL.md`.

--- a/recipes/audit-reasoning.md
+++ b/recipes/audit-reasoning.md
@@ -1,0 +1,25 @@
+# Recipe: audit-reasoning
+
+**Job:** check whether a conclusion or recommendation is actually sound before trusting it.
+
+**Use when:** a conclusion feels confident but consequential, or you want to audit the reasoning behind a recommendation (the agent's own or someone else's). This recipe operationalizes the library's epistemic positioning.
+
+## Chain
+
+1. **`tfs-evidence-vs-inference-sort`** (`skills/tfs-evidence-vs-inference-sort/SKILL.md`)
+   - Sort the claims behind the conclusion into evidence, inference, and assumption; flag the uncited.
+   - Carry forward: the **load-bearing unknowns** (unsupported claims doing the heavy lifting).
+2. **`tfs-ladder-of-inference-check`** (`skills/tfs-ladder-of-inference-check/SKILL.md`)
+   - Reconstruct how the conclusion was reached; flag the riskiest leap; test an alternative interpretation.
+   - Carry forward: the **riskiest rung** and the alternative interpretation.
+3. **`tfs-parallel-perspectives-review`** (`skills/tfs-parallel-perspectives-review/SKILL.md`)
+   - Review the conclusion through separated lenses to surface what a single viewpoint missed.
+   - Carry forward: the **synthesis** and the central tension.
+
+## Composite artifact
+
+A reasoning audit: which claims are actually supported, where the inferential leaps and alternative readings are, and a rounded verdict on whether the conclusion can be trusted or needs more before it is acted on.
+
+## Token discipline
+
+Carry only the flagged items between steps (unknowns -> riskiest rung -> synthesis), not the full ledgers and traces.

--- a/recipes/expand-options.md
+++ b/recipes/expand-options.md
@@ -1,0 +1,26 @@
+# Recipe: expand-options
+
+**Job:** break past the obvious option set and generate a genuinely broader range of candidates.
+
+**Use when:** the options on the table feel incremental or all share a hidden premise, and you need more and better candidates before deciding.
+
+## Chain
+
+1. **`tfs-problem-restatement`** (`skills/tfs-problem-restatement/SKILL.md`)
+   - Make sure you are expanding options for the right problem.
+   - Carry forward: the **chosen working frame**.
+2. **`tfs-scamper`** (`skills/tfs-scamper/SKILL.md`)
+   - Transform the seed idea(s) through the seven lenses; shortlist.
+   - Carry forward: the **SCAMPER shortlist**.
+   - Swap-in: for blank-page breadth (no seed yet), use **`tfs-brainwriting`** instead, which has stronger evidence for generation.
+3. **`tfs-assumption-reversal`** (`skills/tfs-assumption-reversal/SKILL.md`)
+   - Surface and reverse the foundational assumptions the options share; generate non-obvious candidates.
+   - Carry forward: the **combined shortlist** of candidates (SCAMPER + reversal), flagged as candidates not decisions.
+
+## Composite artifact
+
+A de-duplicated shortlist of candidate options spanning incremental variations and assumption-breaking alternatives, ready to hand to a decision skill.
+
+## Token discipline
+
+Carry only the shortlists between steps. Hand the final combined shortlist to `tfs-decision-option-review` to converge.

--- a/recipes/reframe-problem.md
+++ b/recipes/reframe-problem.md
@@ -1,0 +1,25 @@
+# Recipe: reframe-problem
+
+**Job:** make sure you are solving the right problem, stated at the right altitude, before generating solutions.
+
+**Use when:** a problem is ambiguous, arrived as a symptom or a pre-baked solution, or a team is answering a question that may be the wrong one.
+
+## Chain
+
+1. **`tfs-problem-restatement`** (`skills/tfs-problem-restatement/SKILL.md`)
+   - Produces a problem frame set ending in one chosen working frame.
+   - Carry forward: the **chosen working frame** and its 1-line rationale (not the whole set).
+2. **`tfs-evidence-vs-inference-sort`** (`skills/tfs-evidence-vs-inference-sort/SKILL.md`)
+   - Run it on the chosen frame and the claims behind it: separate what is known from what is inferred or assumed.
+   - Carry forward: the **load-bearing unknowns** (the assumptions the frame rests on).
+3. **`tfs-parallel-perspectives-review`** (`skills/tfs-parallel-perspectives-review/SKILL.md`)
+   - Review the reframed problem through the separated lenses to catch a blind spot the reframing missed.
+   - Carry forward: the **synthesis** (the rounded read + the central tension).
+
+## Composite artifact
+
+A reframed problem statement, the assumptions it rests on (flagged for verification), and a rounded multi-lens read - i.e. a problem you can trust enough to start solving.
+
+## Token discipline
+
+Pass only the chosen frame, then the unknowns, then the synthesis. Do not re-feed each step's full output into the next.

--- a/recipes/stress-test-decision.md
+++ b/recipes/stress-test-decision.md
@@ -1,0 +1,30 @@
+# Recipe: stress-test-decision (marquee)
+
+**Job:** pressure-test a consequential, hard-to-reverse decision before committing.
+
+**Use when:** a real choice is about to be made and the cost of being wrong is high. This is the library's flagship chain.
+
+## Chain
+
+1. **`tfs-decision-option-review`** (`skills/tfs-decision-option-review/SKILL.md`)
+   - Compare the options against weighted criteria; recommend one.
+   - Carry forward: the **recommended option** and what would flip it.
+2. **`tfs-what-would-have-to-be-true`** (`skills/tfs-what-would-have-to-be-true/SKILL.md`)
+   - Convert the recommended option into the conditions that must hold; name the killer conditions.
+   - Carry forward: the **killer conditions** (load-bearing + uncertain).
+3. **`tfs-premortem`** (`skills/tfs-premortem/SKILL.md`)
+   - Assume the chosen plan has failed; surface causes, mitigations, tripwires, kill criteria.
+   - Carry forward: the **top risks with tripwires and kill criteria**.
+4. **`tfs-reference-class-forecasting`** (`skills/tfs-reference-class-forecasting/SKILL.md`)
+   - Sanity-check the cost/time/success estimate against the base rates of comparable past cases.
+   - Carry forward: the **outside-view estimate range**.
+
+**Optional adds** (when stakes justify the tokens): insert **`tfs-red-team-light`** after step 2 to steelman the opposition, and/or **`tfs-futures-wheel`** after step 3 to map second- and third-order effects.
+
+## Composite artifact
+
+A decision brief: the recommended option, the conditions it depends on, its top risks with pre-decided responses, and an honest outside-view estimate - enough to commit with eyes open, or to decide not to.
+
+## Token discipline
+
+This is the longest chain; compression matters most here. Pass only each step's compressed artifact (recommendation -> killer conditions -> risk register -> estimate range), never the full working text. The audit named unbounded chains like this as the main operational risk.

--- a/skills/tfs-assumption-reversal/eval/cases.md
+++ b/skills/tfs-assumption-reversal/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-assumption-reversal
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "Our growth options all boil down to 'lower the price or spend more on ads' and feel stale. Break out of the default assumptions about how we acquire customers."
+- "Every onboarding redesign still assumes the user signs up first, then we convert them. Challenge the premises this whole flow rests on."
+- "We're early in exploring our pricing model and want maximum breadth - surface the assumptions baked into 'software is sold by subscription' and flip each."
+- "All our distribution ideas share some hidden premise I can't name. Make the taken-for-granted assumptions explicit, negate them, and generate ideas from the reversals."
+- "Run assumption reversal on our support strategy - an assumptions-and-reversals sheet ending in a shortlist of candidates, not recommendations."
+- "The team is stuck inside the same default constraints on checkout. Reverse the load-bearing premises and give me ideas from the flipped world."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "We've narrowed to three pricing models and need to pick one. Score them and tell me which to commit to." (decision)
+- "Imagine our launch failed six months from now - walk backward through what went wrong." (near-miss: premortem/inversion 'how to fail', not surfacing-and-reversing premises)
+- "Our device must meet FDA Class II via the 510(k) pathway, non-negotiable. Help us design within those fixed constraints." (binding constraints can't be reversed)
+- "Summarize this finalized go-to-market doc into a one-page brief." (summarization)
+- "Give me your top three recommendations for which growth channel to invest in." (recommendations)
+- "The fonts and button colors on our pricing page feel off - suggest tweaks." (cosmetic)
+
+## Output checks (a good output must)
+
+- [ ] Be an assumptions-and-reversals sheet (subject, assumptions/reversed/ideas table, shortlist), not prose.
+- [ ] List load-bearing assumptions (business model, user, channel, sequence, who pays, what is required), each genuinely negated/inverted, not reworded.
+- [ ] Tie every idea explicitly to the specific reversed assumption it comes from (no decoration).
+- [ ] Select a shortlist of the most promising non-obvious ideas, each naming what would have to be true to be viable.
+- [ ] Flag reversed assumptions and shortlisted ideas as candidates, not recommendations or decisions.
+- [ ] Stay divergent and distinct from generic inversion (not collapse into a "how would we cause failure?" exercise).
+
+## Value vs unaided baseline
+
+Unprompted, a strong model reverses surface-level or cosmetic assumptions and then drifts into recommending the most plausible reversal, because it anchors on the prompt's premises. This skill forces naming the load-bearing, usually-unspoken premises, keeping each generated idea tied to its reversal, and holding every output as a candidate (with a what-would-have-to-be-true condition) rather than a validated decision.

--- a/skills/tfs-brainwriting/eval/cases.md
+++ b/skills/tfs-brainwriting/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-brainwriting
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "I need a wide range of options for how we could onboard new users - lots of different angles, not just the obvious first idea."
+- "Help me brainstorm podcast names, but I keep landing on variations of the same theme. Generate ideas from genuinely different directions and build on them."
+- "We're at the early divergent stage for our Q3 campaign. I want breadth before we narrow - independent idea streams consolidated into a shortlist."
+- "Give me ways to reduce churn from several distinct perspectives so I don't anchor on the first thing."
+- "Brainwrite product feature concepts - a few separate streams from different personas, then a build-on round, then the strongest short-listed."
+- "My brainstorm feels too narrow and everything sounds alike. Generate parallel sets of ideas independently, then pull together the best."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "I have 12 product ideas already - help me rank them and pick the one to build." (convergence/decision)
+- "Score these 8 vendors against our criteria and recommend one." (decision)
+- "Write a single deeply-reasoned analysis of whether to migrate to Postgres - one expert take, not a spread." (deep single reasoning)
+- "We have 40 sticky notes from a brainstorm. Cluster into themes and decide which three to move forward." (near-miss: synthesis/convergence, not generation)
+- "Summarize the ideas from yesterday's offsite into a one-page recap." (summarization)
+- "Just dump 50 blog titles, whatever comes to mind, unorganized." (bulk dump, no streams/build-on)
+
+## Output checks (a good output must)
+
+- [ ] Contain 3-4 separately-labeled idea streams, each from a distinct angle/persona/constraint, kept visibly separate (not one list relabeled).
+- [ ] Include a distinct build-on round that combines and extends across streams (not a fourth parallel list).
+- [ ] Merge near-duplicates across streams while keeping distinct ideas.
+- [ ] Select a shortlist of the strongest ideas with a reason for each.
+- [ ] Be the idea-pool artifact (streams + build-on + shortlist), not prose; not rank/decide a single winner.
+- [ ] State the single ideation prompt in one line at the top.
+
+## Value vs unaided baseline
+
+Asked to brainstorm, a strong model defaults to one anchored stream of ideas sharing an implicit framing. This skill forces 3-4 genuinely independent streams generated as if blind to each other, then an explicit cross-stream build-on round before consolidating - the structural step a model does not do unaided. It also keeps scope honest: it generates and shortlists but does not rank/decide, and its evidence is for human groups (mechanism transferred to AI, effect size not measured), so checks must not assume a proven AI advantage.

--- a/skills/tfs-decision-option-review/eval/cases.md
+++ b/skills/tfs-decision-option-review/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-decision-option-review
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "We're down to three CI/CD vendors and the team keeps going in circles. Lay out the tradeoffs so we can pick one and defend it."
+- "Choose between rebuilding billing in-house, buying Stripe Billing, or extending our current hack. Weigh them against what matters."
+- "Compare these four office locations against cost, commute, and room to grow, and recommend one with reasons."
+- "Leadership wants a clear writeup of why we picked Postgres over DynamoDB and MongoDB. Objectives conflict and it's all gut feel now."
+- "Score these three onboarding-redesign approaches on the criteria that matter, show what each gives up, then recommend."
+- "Two job offers, very different in salary, growth, location. Make the tradeoffs explicit instead of me feeling my way through."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "Brainstorm fresh ideas for improving activation - I have no options yet." (ideation; nothing to compare)
+- "Deploy the hotfix now or wait for the morning window? Pretty obvious, just confirm." (trivial)
+- "We're considering an irreversible migration off our DB vendor - I need a deep risk analysis, not a quick comparison." (near-miss: one-way door needs deeper analysis)
+- "Run a premortem on the launch plan." (risk)
+- "Write the postmortem for last week's outage." (after the fact)
+- "Just tell me which laptop to buy, I trust you, no reasoning needed." (no decision support wanted)
+
+## Output checks (a good output must)
+
+- [ ] Be a criteria-weighted option matrix artifact (options vs weighted criteria, score per cell), not prose and not a bare total.
+- [ ] Give each criterion an explicit weight and a reason it is included.
+- [ ] Flag soft/low-confidence scores rather than presenting them as exact (or state scores are confident); soft scores not dressed as precise.
+- [ ] State plainly what each leading option gives up (its tradeoff).
+- [ ] Note factors that resist quantification rather than dropping them.
+- [ ] Recommend one option and state what would flip it, with a confidence note; not treat a single weighted total as settling a close call.
+
+## Value vs unaided baseline
+
+Asked to compare options unaided, a strong model tends to compute a weighted total and present it as the answer, hiding soft scores and unscoreable factors inside tidy arithmetic. This skill makes weights and criteria reasons explicit so they can be argued, flags soft scores, keeps hard-to-quantify factors visible, and states the recommendation with what would flip it - treating the matrix as support for judgment, not a total that proves the choice.

--- a/skills/tfs-evidence-vs-inference-sort/eval/cases.md
+++ b/skills/tfs-evidence-vs-inference-sort/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-evidence-vs-inference-sort
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "Before we greenlight this migration, audit the architecture proposal: which claims are backed by data versus stuff we're assuming?"
+- "Here's the memo arguing we should acquire the competitor. It must be trusted before the board acts. Separate evidence from inference and flag anything stated as fact with no source."
+- "Look at the conclusion you just gave me and sort your own reasoning: which parts are observed, which are deduced, and how confident are you in each leap?"
+- "This clinical summary mixes study findings with the author's interpretation. Build a ledger separating verifiable evidence from inference and assumption, with confidence on each inference."
+- "Our thesis says the free tier will triple signups and pay for itself. Label each claim and tell me which unsupported claims most need verifying first."
+- "I need a reasoning audit on this safety case before sign-off - mark the load-bearing assumptions nobody has tested."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "Fact-check this article - go confirm whether the numbers are actually true." (near-miss: verifies truth; this skill only classifies claim type)
+- "Brainstorm some wild taglines for the brand campaign - no need to be rigorous." (creative)
+- "Summarize this already well-sourced report into three bullets." (summarization)
+- "Just tell me: is it true our competitor offers a free tier? Go verify it." (fact verification)
+- "Write a persuasive one-pager arguing for the free-tier launch." (persuasion)
+- "Run a premortem on the migration plan." (risk, not reasoning audit)
+
+## Output checks (a good output must)
+
+- [ ] Be an evidence/inference ledger table (claim, type, basis/source, inference confidence, flag), not prose.
+- [ ] Label every claim as exactly one of Evidence / Inference / Assumption; no confident inference mislabeled as evidence.
+- [ ] Give each inference a confidence level with a reason; not treat plausibility as verification.
+- [ ] Flag claims presented as fact but uncited ("uncited") and load-bearing unexamined assumptions ("unexamined").
+- [ ] Explicitly not claim to have verified the truth of any evidence; only sort claim type.
+- [ ] End with a "load-bearing unknowns" list (the few unsupported/low-confidence claims that most need verification, with how to verify).
+
+## Value vs unaided baseline
+
+Asked to "vet this reasoning," a strong model renders a fluent prose critique that still blends its own deductions with the source's facts in the same confident register - the exact failure this targets. The skill forces a discrete per-claim ledger that distinguishes uncited assertions wearing the costume of evidence from genuine assumptions, attaches reasoned confidence to each leap, and holds the boundary that it sorts claim type without claiming to have verified truth.

--- a/skills/tfs-futures-wheel/eval/cases.md
+++ b/skills/tfs-futures-wheel/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-futures-wheel
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "We're about to launch a self-serve free tier. Map out the knock-on effects this could have over time across the business."
+- "I want to move the whole team to a 4-day work week. Trace the first, second, and third-order consequences so we don't get blindsided."
+- "My analysis of deprecating the legacy API just says 'fewer support tickets, good.' That's too shallow - push past the first-order view to the ripple effects."
+- "Give me a quick second-order-effects pass on unlimited PTO - what happens, and then what happens after that?"
+- "We're considering acquiring a competitor. Walk the cross-domain ripples - technical, financial, team, competitive - radiating out."
+- "Build me a consequence map for switching pricing from seat-based to usage-based."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "The free-tier launch went sideways last quarter. Run a postmortem on what broke and why." (after the fact)
+- "Should we launch the free tier or not? I've seen the trade-offs - just make the call." (decision)
+- "Summarize this 10-page strategy doc into a paragraph." (summarization)
+- "Our deploy script needs to delete a temp file after the build. Write the bash - single linear step, no side effects." (no higher-order effects)
+- "Brainstorm catchy names for our free tier." (ideation)
+- "Forecast next quarter's MRR with a probability range for the board deck." (near-miss: forecasting/probabilities, not a consequence map)
+
+## Output checks (a good output must)
+
+- [ ] Be a nested consequence map artifact (center, then first/second/third-order branches), not prose.
+- [ ] Reach at least second order; not stop at first-order consequences.
+- [ ] Span multiple domains at first order (technical, financial, customer, team, competitive), not just the obvious one.
+- [ ] Flag high-impact or non-obvious branches, each with a short "watch or do about it" note.
+- [ ] Prune trivial branches rather than padding to irrelevance.
+- [ ] Frame branches as possible ripples to watch, not predictions or probabilities.
+
+## Value vs unaided baseline
+
+Asked the same question, a frontier model tends to answer at first order and stop, or list flat consequences without the disciplined "and then what?" expansion across orders. This skill forces the multi-order structure, cross-domain spread at first order, and explicit flagging of non-obvious downstream branches with response notes - while honestly framing them as speculative ripples to watch, not predictions (its evidence is transferred foresight practice, not validated forecast accuracy).

--- a/skills/tfs-ladder-of-inference-check/eval/cases.md
+++ b/skills/tfs-ladder-of-inference-check/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-ladder-of-inference-check
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "I'm convinced our biggest customer is about to churn - they went quiet after the last release. Walk me back through how I got there and whether it holds."
+- "My co-founder and I look at the same launch metrics and reach opposite conclusions. Reconstruct how each of us is reading the data."
+- "You concluded the regression was caused by the caching change. Reconstruct your own reasoning from raw evidence to that conclusion and flag the weakest link."
+- "I keep telling myself the new PM is underperforming, but it feels like a story I built. Lay out the rungs from what I observed to that judgment and test another reading."
+- "We decided the experiment failed and we should kill the feature. Before we act, audit that inference: what data did we select, what did we leave out, is there a credible alternative?"
+- "Take the conclusion 'engineering doesn't care about quality' and trace it down from the observable facts to show where interpretation crept in."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "Give me five feature ideas to improve retention." (ideation)
+- "The conclusion is just arithmetic - we lost three $40k contracts, so $120k. Confirm the total." (no inferential leap)
+- "I've decided we're migrating to Postgres. Write me a justification that makes the case as strongly as possible." (advocacy, not audit)
+- "Should we order pizza or sandwiches for the offsite?" (trivial)
+- "Run a premortem on our Q3 launch plan." (risk, not inference audit)
+- "Summarize this finished strategy doc into three bullets." (summarization)
+
+## Output checks (a good output must)
+
+- [ ] Be the annotated reasoning-trace artifact (conclusion on top, reconstructed-ladder table, riskiest rung, alternative interpretation), not prose.
+- [ ] Reconstruct the rungs in order: observable data available, data actually selected, meaning added, assumptions, conclusion.
+- [ ] Include in "observable data available" the data that was left out / not used, not only the selected subset.
+- [ ] State meaning added and assumptions explicitly, separate from the data.
+- [ ] Name exactly one riskiest / most-likely-wrong rung.
+- [ ] Give at least one credible alternative interpretation of the same data with what it implies - testing the climb, not defending the conclusion.
+
+## Value vs unaided baseline
+
+Asked to "check my reasoning," a strong model tends to evaluate whether the conclusion is right and subtly defend it. This skill forces the inverse: surfacing the data that was left out and committing to a credible alternative reading of the same facts, countering the model's own fluent conclusions. Per the dossier (tier P) it claims no measured accuracy gain, only that it makes a silent inferential jump inspectable.

--- a/skills/tfs-parallel-perspectives-review/eval/cases.md
+++ b/skills/tfs-parallel-perspectives-review/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-parallel-perspectives-review
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "We're deciding whether to launch a free tier in 6 weeks. Give this a rounded look before we commit - I don't want us to only see the downside."
+- "Weigh this acquisition offer from every angle - facts, upside, risks, gut-feel, other options - then pull it together into a balanced call."
+- "Every time we discuss the migration the most risk-averse person hijacks it. Make sure the optimistic and creative angles get airtime too."
+- "I want a multi-lens review of moving to a four-day work week, with separate lenses so one perspective doesn't drown out the rest."
+- "We keep skipping intuition and alternatives when we evaluate vendors. Walk through this vendor choice one perspective at a time."
+- "Should we rebrand next quarter? Give a balanced read separating what we know from upside, cautions, and creative alternatives, then name the tension."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "Tear apart my argument that we should drop the on-prem line - the strongest case against it." (near-miss: red team, single adversarial thesis)
+- "Run a premortem on the Q3 launch." (risk over time)
+- "Write up the postmortem for last night's incident." (after the fact)
+- "Just tell me the security risks of exposing this billing endpoint - that's all I care about." (single lens is all that matters)
+- "Summarize this 12-page strategy doc into one page." (summarization)
+- "What's the cheapest cloud provider for a 500GB Postgres database?" (factual lookup)
+
+## Output checks (a good output must)
+
+- [ ] Be the multi-lens review artifact (one-line "under review", per-lens rows, then a synthesis), not blended prose.
+- [ ] Address all six lenses in order - Facts, Upside, Risks, Intuition, Alternatives, Process - or explicitly drop an inapplicable lens with a note (not padded).
+- [ ] Keep each lens to its own mode; risk content does not leak into upside and vice versa.
+- [ ] Give the easily-skipped Intuition and Alternatives lenses a real, substantive pass.
+- [ ] End with a synthesis that integrates the lenses and names a central tension to resolve.
+- [ ] Not cite de Bono's "493%" figure or lean on Six Thinking Hats marketing; lineage, if mentioned, is descriptive.
+
+## Value vs unaided baseline
+
+Asked to "look at this from all sides," an unaided model produces one blended take where the dominant mode (usually risk or upside) quietly colors everything and the quiet lenses get a token line or get skipped. This skill forces a genuinely separate pass per lens with the easily-skipped ones protected, keeps the lenses from blurring, ends in a synthesis that names the actual tension, and avoids importing the unsupported branded productivity claims.

--- a/skills/tfs-premortem/eval/cases.md
+++ b/skills/tfs-premortem/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-premortem
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (a harness is deferred to the Silver climb); these are the cases to check by hand, or to wire into evals later.
+
+## Should trigger
+
+- "We're two weeks out from launching the new billing system and everyone seems weirdly confident. Can we stress-test this before we ship?"
+- "I'm about to sign off on hiring this VP of Sales. Before I make the offer, walk me through what could blow up."
+- "We've picked the cloud vendor and migration kicks off Monday. I want the risks surfaced with concrete warning signs and a point where we'd pull the plug."
+- "Imagine it's six months from now and this product investment has totally failed. Why did it fail, and what should we watch for?"
+- "We chose to rebuild the checkout flow in-house. This is the last gate before we commit budget. Run a premortem."
+- "I have a nagging feeling about this acquisition but nobody will say anything. Help me get the unspoken concerns on the table with owners and kill criteria."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "The migration shipped last quarter and it went badly. Help me run a postmortem." (near-miss: after the fact, not before)
+- "Should I rename my staging environment? One-line config change I can revert anytime." (trivial / reversible)
+- "I need fresh ideas for features we could add next quarter. Brainstorm options." (ideation, not risk)
+- "We have three vendors on the shortlist. Help me build a scorecard and pick the best one." (decision comparison)
+- "We've already decided to go ahead; leadership just wants a risk doc for the board deck so it looks like due diligence." (theater; mitigations won't be acted on)
+- "Write a project status update summarizing what the team shipped this sprint." (unrelated)
+
+## Output checks (a good output must)
+
+- [ ] Declare the failure in the definite past with a concrete, specific scenario anchored to a stated horizon (not "it underperformed").
+- [ ] Include at least one people/political, process, second-order, or external cause, not only technical ones.
+- [ ] Pair every high-priority cause with all four: a tripwire, a mitigation, a named owner, and a pre-decided kill criterion.
+- [ ] Rank risks by likelihood and impact (each H/M/L), not a flat list.
+- [ ] Deliver the risk-register artifact (ranked table + a short "top risks and what we will do" summary), not prose.
+- [ ] Not promise a better decision/outcome; limit any claim to better-surfaced and better-handled risk.
+
+## Value vs unaided baseline
+
+Unprompted, a strong model produces a brainstormed list of risks but typically skips the mandatory conversion step, leaving causes without a paired tripwire, owner, and pre-decided kill criterion, and it tends to imply the exercise yields a better decision. This skill forces prospective-hindsight framing (definite past, concrete horizon), enforces the full four-element conversion into a ranked register, and holds the honest no-overclaim caveat.

--- a/skills/tfs-problem-restatement/eval/cases.md
+++ b/skills/tfs-problem-restatement/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-problem-restatement
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "My CEO wants us to build a mobile app for customer support. Help me think about this before we kick off."
+- "Churn is up and the team keeps proposing fixes, but I'm not sure we've pinned down the actual problem. Can you help reframe it?"
+- "The problem I was handed is 'users aren't engaging with the dashboard' - that feels like a symptom. Restate it a few ways before I scope work."
+- "Before I commit a quarter of engineering, I want to make sure we're solving the right problem. The ask is vague: 'reduce support ticket volume.'"
+- "Stakeholders keep describing this differently and the brief is ambiguous. Generate a few genuinely different framings and pick the most useful."
+- "We're at the start of a discovery effort and the problem is ill-defined. Sharpen the problem before ideation."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "We've already validated the problem and it's well-defined and agreed. Now give me solution ideas to evaluate." (problem is settled)
+- "We've narrowed it to three options for the checkout redesign - help me pick the best one." (decision)
+- "Rename this variable across the file and fix the lint error - quick reversible change." (trivial)
+- "The launch already failed. Run a postmortem." (after the fact)
+- "Write the marketing copy for the feature we already decided to build." (execution)
+- "Summarize this already-structured PRD into one paragraph." (summarization)
+
+## Output checks (a good output must)
+
+- [ ] Be a problem frame set artifact (original, tagged restatement table, How Might We angles, chosen working frame), not prose.
+- [ ] Produce 5-8 restatements, each tagged with a distinct move (altitude up/down, goal-vs-implementation, stakeholder, inversion, is/is-not) and a one-line "why this might be the real problem" - not cosmetic rewordings.
+- [ ] Include at least one restatement separating goal from proposed implementation, and at least one inversion or is/is-not.
+- [ ] Include 3-5 open "How might we ..." questions from the most promising restatements.
+- [ ] Converge on exactly one working frame with a rationale tied to the user's actual goal (not left open).
+- [ ] Not overclaim: it sharpens the problem; it does not guarantee a better solution.
+
+## Value vs unaided baseline
+
+A strong model is obligingly literal and defaults to solving the first stated framing, accepting a symptom or a pre-baked "build X" at face value. This skill forces an explicit interrupt that escapes the initial frame via distinct moves and converges on one justified frame plus a durable artifact, rather than sliding into solutioning or producing reworded variants that never shift altitude, stakeholder, or goal-vs-implementation.

--- a/skills/tfs-question-burst/eval/cases.md
+++ b/skills/tfs-question-burst/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-question-burst
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "I've been staring at this churn problem for an hour and I'm stuck. Help me get unstuck before I try to solve it."
+- "I think I'm too attached to framing this as a pricing problem. Help me find a better question first."
+- "We're just starting to explore this ambiguous onboarding mess and I don't want to commit to an answer yet. Where do I start?"
+- "Run a question burst on 'why are users abandoning the signup flow'."
+- "I feel like I'm answering the wrong question about our retention dip. Generate questions about it and tell me which one to chase."
+- "Before I write the strategy doc, give me a ranked set of questions and pick the most catalytic one to dig into."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "I already know the real question is 'why does activation drop after day 3' - now help me answer it." (catalytic question already known)
+- "Give me a flat list of 30 questions for our discovery survey." (near-miss: bulk question list, no ranking/selection wanted)
+- "We've explored enough. I need a decision on which pricing tier to ship." (convergence)
+- "Write a postmortem of last week's outage." (after the fact)
+- "Summarize the questions raised in this transcript into a tidy bullet list." (summarization)
+- "Brainstorm 20 feature ideas and group them by theme." (ideation)
+
+## Output checks (a good output must)
+
+- [ ] Burst of roughly 12-20 questions, questions only, no answers, no preamble.
+- [ ] Rank the questions by how much answering them would change the approach, not by ease.
+- [ ] Select exactly one "next question" with a one-line reason it would shift the problem.
+- [ ] Be a ranked question set (raw burst, ranking, chosen next question), not a flat dump and not answers.
+- [ ] Mix angles (why, how, what-if, who, what-would-change-if), not all one type.
+- [ ] State the problem in one line at the top.
+
+## Value vs unaided baseline
+
+Asked to "brainstorm questions," a strong model dumps a long flat list and often slips into answering them - the low-signal failure the dossier flags as worthless for AI (generation is trivial). This skill forces the actual value: ranking by catalytic potential and committing to a single chosen next question with a reason, turning cheap question generation into disciplined reframing.

--- a/skills/tfs-red-team-light/eval/cases.md
+++ b/skills/tfs-red-team-light/eval/cases.md
@@ -1,0 +1,35 @@
+# Eval cases: tfs-red-team-light
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "Everyone agreed we should launch the free tier in Q3 and it felt too easy. Red team this and argue the strongest case against it before we commit."
+- "I'm about to recommend we sunset the legacy API. Steelman the opposition first so I'm not walking into a wall I didn't see."
+- "You just confidently told me microservices is the right call. Now build the best case against your own recommendation."
+- "We have consensus that acquiring this startup is the move. Give me the strongest objections an intelligent skeptic would raise, ranked by how badly they'd hurt us if true."
+- "Pressure-test this thesis: 'cutting prices 20% will win back enterprise.' I want the objections that actually land, not nitpicks."
+- "Before I sign off, play devil's advocate properly - the strongest version - and tell me which objections are decisive versus survivable."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "The free-tier launch flopped last quarter. Walk us through what went wrong and what we'd do differently." (postmortem)
+- "We're committing to the roadmap and need buy-in. Help me write the announcement that aligns the team, not more debate." (alignment, not critique)
+- "Give me a rounded view of this pricing decision from customer, sales, finance, and engineering angles." (near-miss: parallel perspectives, not single adversarial case)
+- "Assume we launch and it fails 12 months from now; map all the ways it could go wrong over time." (premortem)
+- "Just poke holes for fun - any objection, doesn't matter if real or strong." (performative contrarianism)
+- "Summarize the attached strategy doc into three bullets." (summarization)
+
+## Output checks (a good output must)
+
+- [ ] Open by stating the thesis fairly in its strongest honest form, not a weakened version.
+- [ ] Steelman the objections (strongest a motivated informed critic would raise), not strawmen.
+- [ ] Rank objections by force (damage if true), not by ease, with the ranking explicit.
+- [ ] For top objections, state how the thesis would have to answer each and whether it plausibly can.
+- [ ] Give a verdict naming which objections are decisive vs survivable.
+- [ ] Note whether a real, independent dissenting view should be sought for high stakes, acknowledging this is constructed/role-played dissent.
+- [ ] Deliver the ranked-objections artifact, not free prose.
+
+## Value vs unaided baseline
+
+Asked to "critique this," a frontier model tends toward sycophantic, easy objections and stops at listing concerns. The skill forces a genuinely adversarial steelman ranked by force with a decisive-vs-survivable verdict, and critically surfaces the Nemeth honesty flag - that this is constructed dissent that does not replicate authentic dissent - telling the user to seek a real dissenter for high-stakes/one-way-door calls, a limit an unaided model presenting its own critique as sufficient would not flag.

--- a/skills/tfs-reference-class-forecasting/eval/cases.md
+++ b/skills/tfs-reference-class-forecasting/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-reference-class-forecasting
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "We told the board this migration would take 3 months and cost $200k. I think that's optimistic - help me get a realistic estimate."
+- "Forecast how long our platform rewrite will actually take. We keep blowing past our own timelines."
+- "What are realistic odds this new B2B SaaS hits $1M ARR in two years? Our deck assumes we sail past it."
+- "Give me a defensible budget range for this office buildout. Every construction project we've done ran over."
+- "Our roadmap says the API integration ships in 6 weeks. Sanity-check it against how similar integrations usually go."
+- "I want an outside-view estimate for this acquisition's integration cost instead of the bottom-up number my team built."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "The project finished 4 months late and 60% over budget. Run a postmortem." (after the fact)
+- "We're inventing a genuinely new category - no one has shipped anything like this. How should I size it?" (near-miss: no comparable reference class exists)
+- "Give me one exact number for Q3 revenue for the press release - a single committed value, no ranges." (wants a point certainty)
+- "Walk me through the bottom-up engineering breakdown so I can assign tasks." (inside-view task breakdown)
+- "Imagine this launch already failed - work backward and list what caused it." (premortem)
+- "What's the current USD/EUR exchange rate?" (factual lookup)
+
+## Output checks (a good output must)
+
+- [ ] Name an explicit reference class of comparable past cases and say why they are genuinely comparable (not narrow/self-flattering).
+- [ ] State a base-rate distribution (typical and worst-case) with a data source, OR explicitly flag that real data is missing and refuse to fabricate numbers.
+- [ ] Present the final estimate as a range/distribution, not a point certainty.
+- [ ] Anchor on the base-rate distribution first, adjusting for specifics conservatively; the optimistic inside-view number does not reappear as the answer.
+- [ ] Be the reference-class estimate artifact (reference class, base rates, inside-view estimate, outside-anchored estimate, adjustment rationale), not prose.
+- [ ] Capture and label the original inside-view estimate separately so the outside view can be contrasted.
+
+## Value vs unaided baseline
+
+Unprompted, a strong model readily produces a fluent inside-view estimate from the plan's details and, asked for an outside view, often invents a plausible-sounding base-rate distribution rather than admit none exists. This skill's distinctive value is enforcing the honest constraint - construct a real reference class, cite or flag the base-rate source, refuse to fabricate numbers - while preventing the optimistic inside-view figure from sneaking back as the answer.

--- a/skills/tfs-scamper/eval/cases.md
+++ b/skills/tfs-scamper/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-scamper
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "We already offer a self-serve free tier but our growth options feel like minor tweaks. Push this past the obvious variations."
+- "Here's our existing onboarding flow. Systematically generate a wider set of variations before we pick a direction."
+- "Our subscription box product is stuck on incremental ideas. Run it through SCAMPER and give me the most promising ones."
+- "The team keeps proposing the same two or three options for checkout. I want a structured expansion of alternatives on the current design."
+- "We have a seed idea (a weekly customer webinar). Break functional fixedness and explore transformations, then narrow to a shortlist."
+- "Take our existing referral program and force non-obvious variations - substitute, combine, eliminate - then tell me which few are worth pursuing."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "Blank page, no product idea yet - help me brainstorm what we could build in the parental-leave space." (near-miss: no seed to transform)
+- "Our launch failed last quarter. Walk me through what went wrong." (postmortem)
+- "We have eight expansion options and need to pick one - help me decide which to fund." (decision)
+- "I don't think we're solving the right problem. Help me restate and reframe." (reframing)
+- "Run a premortem on our Q3 launch plan." (risk)
+- "Summarize the attached product strategy doc into bullets." (summarization)
+
+## Output checks (a good output must)
+
+- [ ] Name the existing seed being transformed in one sentence before generating variations (no blank-page ideation).
+- [ ] Cover the seven lenses (Substitute, Combine, Adapt, Modify, Put to other use, Eliminate, Reverse), each applied lens producing a concrete, specific variation.
+- [ ] Explicitly skip any lens that genuinely does not apply, with a note, not filler.
+- [ ] End with a mandatory shortlist of 3-5 variations to carry forward, each with a reason.
+- [ ] Be the expansion-sheet artifact (per-lens table + shortlist), not prose.
+- [ ] Not converge to a single decision or claim SCAMPER produces objectively better/more original ideas than other generators.
+
+## Value vs unaided baseline
+
+Asked to vary an idea unaided, a strong model produces a fluent but narrow pile of options biased toward Substitute/Modify and stops at volume. This skill forces breadth across all seven defined axes (especially the often-skipped Eliminate and Reverse), explicitly drops non-applicable lenses instead of padding, and mandates a justified 3-5 shortlist so the output is a selected expansion sheet, not a dump.

--- a/skills/tfs-what-would-have-to-be-true/eval/cases.md
+++ b/skills/tfs-what-would-have-to-be-true/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-what-would-have-to-be-true
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "We're about to commit engineering to a self-serve free tier to hit our Q3 target. What would have to be true for this to actually be the right bet?"
+- "The team has argued for two weeks about moving upmarket into enterprise. It's just dueling opinions now. Help me cut through it."
+- "I want to acquire this competitor. The deal looks great but I think I'm being optimistic. Pressure-test the assumptions my case rests on."
+- "We've narrowed to building the integration in-house. Before the go/no-go, surface the conditions this depends on and which to test first."
+- "My VP is convinced doubling the sales team fixes our pipeline. What conditions would need to hold for that to be the best use of budget, and how confident should we be?"
+- "Lay out the load-bearing assumptions behind our plan to enter Europe and tell me which is most likely to sink us if it's wrong."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "We shut down the free-tier launch after six months and it flopped. Run a retrospective." (after the fact)
+- "Brainstorm a wide list of growth strategies for next year, nothing decided." (ideation)
+- "Build me a scorecard comparing four vendor proposals so I can pick one." (decision comparison)
+- "PostgreSQL or MySQL for an internal logging tool? Quick reversible call." (trivial)
+- "Imagine our launch failed six months from now; map everything that caused it." (near-miss: premortem, failure causes not success conditions)
+- "Summarize this finished strategy deck; the decision is already made." (summarization)
+
+## Output checks (a good output must)
+
+- [ ] Be an assumption-ledger artifact (option statement, conditions table, killer-conditions section), not prose arguing for/against.
+- [ ] Open by stating the single option/claim under examination in one sentence.
+- [ ] Frame conditions as "would have to be true," not asserted as true, each marked for why it is load-bearing.
+- [ ] Give each condition a confidence (H/M/L) with a reason and a concrete cheap test/signal.
+- [ ] Name one or two "killer" conditions (most load-bearing and least certain) to test before committing.
+- [ ] Reach for risky load-bearing factors (demand, economics, execution, competitive response, stakeholders), not only easy ones; not claim the bet is proven.
+
+## Value vs unaided baseline
+
+Asked the same question, a strong model fluently argues for or against the option and may list some assumptions, but tends to produce agreeable, already-true-sounding conditions and stop. This skill forces separating "would have to be true" from "is true," rating each condition's confidence honestly, and converging on the one or two load-bearing-and-uncertain killer conditions to test first, rather than declaring the bet validated.


### PR DESCRIPTION
Two additions that round out the v0.x catalog.

## Recipes (`recipes/`)
Four composable chains, each naming the skill chain, the compressed handoff between steps, and the composite artifact, with explicit token-discipline notes (the audit's main operational-risk mitigation):
- `reframe-problem`, `expand-options`, `stress-test-decision` (marquee), `audit-reasoning`.

Shipped as **documented chains, not Claude commands** - a multi-skill chain is a workflow+command in the toolkit Standard (Silver-tier S6/S7), so packaging them as components is deferred to the Silver climb to keep the repo cleanly at Bronze. The chains are agent-runnable today.

## Eval cases (`skills/*/eval/cases.md`)
One eval file per skill (authored by a 14-agent workflow, each grounded in its skill's SKILL.md + dossier): should-trigger prompts, should-NOT-trigger prompts (with a near-miss for the most-confusable neighbor, e.g. postmortem vs premortem), checkable output assertions, and a "what it catches that an unaided model would miss" baseline note that addresses the base-model-obsolescence risk. No runner yet (a harness is a Silver-climb item).

AGENTS.md now lists all 14 skills + the recipes. Everything validates at `Tier universal, 0 errors / 0 warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)