### PR TITLE
Housekeeping: rename _LOCAL to _local; keep discovery corpus private

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Local working material and scratch (raw research, transcripts, throwaway notes)
-_LOCAL/
+_local/
 
 # Agent session context and logs (local for now)
 _agent-context/

--- a/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
+++ b/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
@@ -41,6 +41,6 @@ Statuses: `done` | `now` | `next` | `later`. The two `wk3` rows are the strong-e
 
 ## Parallel / later (not gates on the Now skill)
 
-- Relocate the discovery corpus into committed `docs/internal/research/` (secret-scan first); rename `_LOCAL` -> `_local`.
+- DONE: renamed `_LOCAL` -> `_local` (folder + `.gitignore`). Corpus relocation reconsidered and NOT done: kept private (gitignored `_local/` + the `backup/discovery-corpus-2026-05-31` branch) rather than committed, because the repo is heading public and committing it would expose ~106k words of strategy research in public history. See `docs/internal/research/README.md`.
 - DONE: `eval/cases.md` authored for every skill (triggers, anti-triggers, output checks, value-vs-unaided baseline). Not yet executed by a harness; the runner is a Silver-climb item.
 - Confirm license (Apache-2.0); decide the Silver climb; the go-public flip at the showcase.

--- a/docs/internal/research/README.md
+++ b/docs/internal/research/README.md
@@ -1,0 +1,23 @@
+# Research
+
+This is where the library's evidentiary foundation is referenced. The raw discovery corpus itself is **deliberately not committed here.**
+
+## Where the discovery corpus lives
+
+The original discovery research (three LLMs across five dimensions: validation, landscape, architecture, portfolio, naming, plus the Claude-Opus meta-analyses, ~106k words) lives in two private places:
+
+- **Working tree:** gitignored at `_local/initial-discovery/`.
+- **Backup (offsite, with history):** branch `backup/discovery-corpus-2026-05-31` on the private origin.
+
+## Why it is not committed to `main`
+
+The earlier plan (fork 4 of the 2026-05-28 decision sheet) was to relocate the corpus into this committed folder, on the reasoning that the repo was permanently private and "gitignored means no backup." Both premises have since changed:
+
+1. **The repo is heading public** (the marketplace listing requires it). Committing the corpus to `main` would publish ~106k words of candid competitive and strategic analysis into public git history, which is hard to reverse.
+2. **The "no backup" problem is already solved** by the `backup/discovery-corpus-2026-05-31` branch.
+
+So the corpus stays private. Per-skill evidence is carried forward where it belongs: each skill's `evidence/dossier.md` cites its sources and grades them honestly. The raw multi-LLM research is internal scaffolding, not something the public catalog needs.
+
+## If you later decide the research should be public
+
+Move the specific files you want to publish into this folder deliberately (after a fresh secret scan), rather than committing the whole corpus. Anything committed here becomes part of public history once the repo is public.


### PR DESCRIPTION
- Renamed the scratch folder `_LOCAL` -> `_local` (folder + `.gitignore` entry).
- **Did not** relocate the discovery corpus into committed `docs/internal/research/` as fork-4 planned. That decision assumed a permanently-private repo; the repo is now heading public, so committing ~106k words of candid competitive/strategic research into public git history is the wrong call - and the "no backup" concern fork-4 raised is already solved by the `backup/discovery-corpus-2026-05-31` branch.
- Added `docs/internal/research/README.md` documenting where the corpus lives (gitignored `_local/` + the backup branch) and why it is kept private, with instructions for deliberately publishing specific files later if desired.

Validated `Tier universal, 0 errors / 0 warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)