### PR TITLE
v0.3: finish the empirical core (6 S-tier skills -> 20-skill catalog)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,14 @@ Each skill is built around four commitments, not just a prompt:
 | [`tfs-brainwriting`](skills/tfs-brainwriting/SKILL.md) | divergent-ideation | **S** | idea pool |
 | [`tfs-futures-wheel`](skills/tfs-futures-wheel/SKILL.md) | systems-and-consequences | P | consequence map |
 | [`tfs-reference-class-forecasting`](skills/tfs-reference-class-forecasting/SKILL.md) | risk-and-resilience | **S** | reference-class estimate |
+| [`tfs-argument-mapping`](skills/tfs-argument-mapping/SKILL.md) | reasoning-clarity | **S** | argument map |
+| [`tfs-woop`](skills/tfs-woop/SKILL.md) | risk-and-resilience | **S** | WOOP commitment card |
+| [`tfs-authentic-dissent`](skills/tfs-authentic-dissent/SKILL.md) | assumption-and-belief-challenge | **S** | dissent audit and plan |
+| [`tfs-after-action-review`](skills/tfs-after-action-review/SKILL.md) | meta-thinking-and-reflection | S/M | after-action review |
+| [`tfs-far-analogy-ideation`](skills/tfs-far-analogy-ideation/SKILL.md) | divergent-ideation | **S** | far-analogy transfer sheet |
+| [`tfs-natural-frequency-bayesian`](skills/tfs-natural-frequency-bayesian/SKILL.md) | reasoning-clarity | **S** | natural-frequency breakdown |
 
-The two **S** skills (brainwriting, reference-class-forecasting) are the strong-evidence anchors. "(flag)" marks skills with a documented evidence or trademark caveat in their dossier.
+20 skills, 9 at **S**/S-M tier (the strong-evidence anchors). "(flag)" marks skills with a documented evidence or trademark caveat in their dossier.
 
 ## Recipes
 

--- a/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
+++ b/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
@@ -4,7 +4,7 @@ The single source of "what to build next." WIP = 1: build the **Now** skill end 
 
 ## Now
 
-> **MVP complete: 14 skills + 4 recipes + eval cases for every skill, all validated (Tier universal, 0/0).** Next build action: the Silver climb (package the recipes as workflow + command components; add per-target Codex emission), and/or the go-public flip (gated on your go: make the repo public, re-pin and merge the held `agent-plugins` listing).
+> **20 skills shipped (MVP 14 + empirical core 6) + 4 recipes + eval cases for every skill, all validated (Tier universal, 0/0).** The empirical core is now complete: 9 of the 20 are S/S-M tier. Next build action: the **v0.4 coverage tranche** (fill the still-empty families - see below), and/or the Silver climb and the go-public flip (both gated on your go).
 
 ## Build order
 
@@ -45,20 +45,18 @@ Statuses: `done` | `now` | `next` | `later`. The two `wk3` rows are the strong-e
 - DONE: `eval/cases.md` authored for every skill (triggers, anti-triggers, output checks, value-vs-unaided baseline). Not yet executed by a harness; the runner is a Silver-climb item.
 - Confirm license (Apache-2.0); decide the Silver climb; the go-public flip at the showcase.
 
-## Post-MVP candidates (recommended next tranche, v0.3) - not yet committed
+## v0.3 - empirical core (DONE)
 
-The highest-value next move is to **finish the empirical core**: the strongest-evidenced methods the MVP did not include. Evidence-grading is the moat (see the audit), and only 3 of the named empirical-core methods shipped (premortem, brainwriting, reference-class-forecasting). Shipping the rest takes the catalog from 3 S-tier anchors to ~9 and makes "evidence-graded" undeniable.
+The highest-value move was to finish the empirical core: the strongest-evidenced methods the MVP did not include. All six shipped and validated (Tier universal, 0/0), taking the catalog to 9 S/S-M-tier skills of 20.
 
-Recommended v0.3 tranche (S-tier first; each also opens or deepens a family):
-
-| Skill | Family | Evidence | Why next |
+| Skill | Family | Evidence | Status |
 |---|---|---|---|
-| `tfs-argument-mapping` | reasoning-clarity | **S** (ES ~0.7-0.85, van Gelder) | strongest-evidenced reasoning method; deepens reasoning-clarity |
-| `tfs-woop` | risk-and-resilience | **S** (25+ RCTs, Oettingen) | strongest-evidenced commitment method; new use case (goal -> action) |
-| `tfs-authentic-dissent` | assumption-and-belief-challenge | **S** (Nemeth) | the real-dissent method red-team-light's dossier already points to |
-| `tfs-after-action-review` | meta-thinking-and-reflection | S/M | opens the reflection family (currently empty) |
-| `tfs-far-analogy-ideation` | divergent-ideation | **S** (Gentner & Smith) | first S-tier ideation method (current ones are P) |
-| `tfs-natural-frequency-bayesian` | reasoning-clarity | **S** (Gigerenzer) | makes conditional-probability reasoning tractable; pairs with reference-class-forecasting |
+| `tfs-argument-mapping` | reasoning-clarity | **S** (van Gelder) | **done** |
+| `tfs-woop` | risk-and-resilience | **S** (Oettingen, 25+ RCTs) | **done** |
+| `tfs-authentic-dissent` | assumption-and-belief-challenge | **S** (Nemeth) | **done** |
+| `tfs-after-action-review` | meta-thinking-and-reflection | S/M (Tannenbaum & Cerasoli) | **done** (opened the reflection family) |
+| `tfs-far-analogy-ideation` | divergent-ideation | **S** (Gentner & Smith) | **done** |
+| `tfs-natural-frequency-bayesian` | reasoning-clarity | **S** (Gigerenzer) | **done** |
 
 Later tranche (v0.4, fill still-empty families; mostly P, high composability): synthesis (`tfs-mece-decomposition` / `tfs-issue-trees`, `tfs-affinity-mapping`, `tfs-pyramid-principle`); problem-framing (`tfs-abstraction-laddering`); decision (`tfs-one-way-vs-two-way-door`, `tfs-decision-journal`); perspective (`tfs-stakeholder-lens-review`, `tfs-steelmanning`); systems (`tfs-iceberg-model`, `tfs-leverage-points`); strategy (`tfs-opportunity-solution-tree`); foresight (`tfs-backcasting`).
 

--- a/library.json
+++ b/library.json
@@ -26,7 +26,11 @@
       { "name": "tfs-brainwriting", "path": "skills/tfs-brainwriting/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-reference-class-forecasting", "path": "skills/tfs-reference-class-forecasting/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-argument-mapping", "path": "skills/tfs-argument-mapping/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
-      { "name": "tfs-woop", "path": "skills/tfs-woop/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
+      { "name": "tfs-woop", "path": "skills/tfs-woop/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-authentic-dissent", "path": "skills/tfs-authentic-dissent/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-after-action-review", "path": "skills/tfs-after-action-review/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-far-analogy-ideation", "path": "skills/tfs-far-analogy-ideation/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-natural-frequency-bayesian", "path": "skills/tfs-natural-frequency-bayesian/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
     ]
   },
   "repository": "https://github.com/product-on-purpose/thinking-framework-skills",

--- a/library.json
+++ b/library.json
@@ -24,7 +24,9 @@
       { "name": "tfs-assumption-reversal", "path": "skills/tfs-assumption-reversal/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-red-team-light", "path": "skills/tfs-red-team-light/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-brainwriting", "path": "skills/tfs-brainwriting/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
-      { "name": "tfs-reference-class-forecasting", "path": "skills/tfs-reference-class-forecasting/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
+      { "name": "tfs-reference-class-forecasting", "path": "skills/tfs-reference-class-forecasting/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-argument-mapping", "path": "skills/tfs-argument-mapping/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-woop", "path": "skills/tfs-woop/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
     ]
   },
   "repository": "https://github.com/product-on-purpose/thinking-framework-skills",

--- a/skills/tfs-after-action-review/SKILL.md
+++ b/skills/tfs-after-action-review/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tfs-after-action-review
+description: Produces a structured after-action review by comparing what was expected against what actually happened, diagnosing why the gaps occurred, and converting them into specific owned sustain-and-change actions. Use when a project, launch, sprint, or incident has finished and you want to turn the outcome into learning, not a status update.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.after-action-review
+  family: meta-thinking-and-reflection
+  evidence-tier: "S"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# After Action Review
+
+Most retrospectives are an unstructured "how did it go?" that produces venting and vague lessons. The After Action Review imposes the structure that actually carries the benefit: compare what was expected to what actually happened, diagnose why the gaps occurred (in both directions), and convert that into what to sustain and what to change, specifically and with owners. The expected-vs-actual comparison is load-bearing; without a recorded expectation there is nothing to learn against, only hindsight narrative. The output is an **after-action review**, and it must be blameless to work.
+
+## When to Use
+
+- A project, launch, sprint, experiment, or incident has finished.
+- There was a real expectation to compare the outcome against (or you can reconstruct it honestly).
+- The team wants to learn, not assign fault.
+
+## When NOT to Use
+
+- Before the event (that is a premortem).
+- As a status update or a summary of what shipped.
+- When it will become blame (it stops working the moment people fear fault).
+- When there is genuinely no expectation and none can be honestly reconstructed.
+
+## Instructions
+
+When asked to run an after-action review, follow these steps:
+
+1. **State what was expected.** The goal, the plan, and the predicted outcome going in. If it was not recorded, reconstruct it honestly and say you are doing so - do not back-fit it to the result.
+2. **State what actually happened.** The real outcome, concretely, including what went better than expected, not only what went worse.
+3. **Diagnose the gaps.** For each meaningful difference (both directions), ask why - the actual cause, not the convenient one. Keep it blameless.
+4. **Capture what to sustain.** The things that worked and should be repeated. Do not skip this for the failures.
+5. **Specify what to change.** Concrete, owned changes for next time - not vague "communicate better."
+6. **Emit the after-action review** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the expected-vs-actual review with sustain/change actions, not prose and not a status report.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] What was expected is stated (recorded or honestly reconstructed), separate from the outcome.
+- [ ] What actually happened includes the better-than-expected, not only failures.
+- [ ] Each gap has a real "why," kept blameless.
+- [ ] What to sustain is captured, not just what to change.
+- [ ] Changes are specific and owned, not vague.
+- [ ] The output is the AAR artifact, not a status update.
+
+## Evidence
+
+Tier **S**. A meta-analysis of team and individual debriefs (Tannenbaum & Cerasoli, 2013) found structured debriefs improve performance substantially (effect size ~0.79), and the effect depends on the structure - intent, comparison to expectations, specific takeaways - not on merely holding a meeting (origin: US Army TC 25-20). Unstructured retros do not carry this. Evidence is for human teams, transferred to AI use, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed after-action review.

--- a/skills/tfs-after-action-review/eval/cases.md
+++ b/skills/tfs-after-action-review/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-after-action-review
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "The Q3 launch is done. Let's actually learn from it instead of just moving on - run a proper review."
+- "Our migration finished last week. Compare what we expected to what happened and what we'd change."
+- "We just wrapped the sprint. I want a structured retro that ends in specific changes, not venting."
+- "The incident is resolved. Do a blameless after-action review: expected vs actual, why, sustain and change."
+- "We ran the pricing experiment and it's over. Turn the result into owned takeaways for next time."
+- "Review how the onboarding revamp went against what we planned - including what went better than expected."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "We're about to launch - imagine it failed and tell me why." (near-miss: premortem, before the event)
+- "Write the status update for what the team shipped this sprint." (status report, not learning)
+- "Summarize the incident timeline for the board." (summarization)
+- "Should we do A or B for the next launch?" (decision)
+- "Brainstorm improvements to onboarding." (ideation; no expected-vs-actual)
+- "The thing failed and I want to know whose fault it was." (blame - the skill explicitly resists this)
+
+## Output checks (a good output must)
+
+- [ ] State what was expected (recorded, or honestly labeled as reconstructed), separate from the outcome.
+- [ ] State what actually happened including better-than-expected, not only failures.
+- [ ] Give a real, blameless "why" for each meaningful gap.
+- [ ] Capture what to sustain, not only what to change.
+- [ ] Make changes specific and owned, not vague.
+- [ ] Be the AAR artifact (expected/actual/why/sustain/change), not a status update.
+
+## Value vs unaided baseline
+
+Asked "how did it go?", a strong model writes a tidy narrative summary that quietly back-fits the story to the known outcome and produces vague lessons. This skill forces the expected-vs-actual comparison (the structure the meta-analysis says is the active ingredient), surfaces better-than-expected results, keeps it blameless, and ends in specific owned changes - rather than hindsight narrative. Unstructured retros, the evidence shows, do not carry the benefit.

--- a/skills/tfs-after-action-review/evidence/dossier.md
+++ b/skills/tfs-after-action-review/evidence/dossier.md
@@ -1,0 +1,55 @@
+# Evidence Dossier: After Action Review
+
+> Single source of truth for the `after-action-review` skill. The SKILL.md, sidecar, and evals derive from this. A strong-evidence anchor and the library's first reflection-family skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.after-action-review` (installable name `tfs-after-action-review`) |
+| **Family** | meta-thinking-and-reflection |
+| **Evidence tier** | **S** (strong meta-analytic support for structured debriefs) |
+| **Confidence** | High that *structured* debriefs improve performance; unstructured retros do not |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+Most retrospectives are an unstructured "how did it go?" that produces venting and vague lessons. The After Action Review imposes a structure that is the source of the effect: compare **what was expected** to **what actually happened**, diagnose **why** the gaps occurred (in both directions - what went better than expected, too), and convert that into **what to sustain** and **what to change**, specifically and with owners. The "expected vs actual" comparison is the load-bearing move: without a recorded expectation, there is nothing to learn against, only hindsight narrative.
+
+It must be blameless to work: the moment it becomes about fault, people stop surfacing the real causes.
+
+## 2. Lineage
+
+- Originated in the US Army (TC 25-20, "A Leader's Guide to After-Action Reviews"). The broader research base is the team-debrief literature.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Strongly supported (the S):** a meta-analysis of team and individual debriefs (Tannenbaum & Cerasoli, 2013) found structured debriefs improve performance substantially - on the order of a ~20-25% improvement, effect size around 0.79. The effect depends on structure (intent, comparison to expectations, specific behavioral takeaways), not on simply holding a meeting.
+
+**What it does NOT show:** that an unstructured retro helps (it largely does not), or that an AAR fixes anything if its "lessons" are vague and never change behavior. The brand "AAR" is practitioner packaging; the *mechanism* (structured, expectation-anchored, blameless debrief) is what carries the evidence.
+
+## 4. Transferred-evidence flag
+
+The evidence is from human teams debriefing real events, not AI-augmented use. Transferred, not AI-validated. The AI value: a model asked "how did it go?" produces a tidy summary; this skill forces the expected-vs-actual comparison, the why, and specific owned sustain/change items - the structure the evidence says is the active ingredient - and produces a durable artifact.
+
+## 5. When it works / when it fails
+
+**Works best when:** a project, launch, sprint, experiment, or incident has finished and there was a real expectation to compare against; a team wants to actually learn and is willing to be blameless.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **No recorded expectation** to compare actual against (the central failure - you get hindsight narrative, not learning). Reconstruct the expectation honestly if it was not written down.
+- It turns into blame, so people stop surfacing real causes.
+- "Lessons" stay vague and unowned, changing no future behavior.
+- Capturing only failures and skipping what to **sustain**.
+- Run *before* the event (that is a premortem) or as a status update (wrong tool).
+
+## 6. Output artifact
+
+An **after-action review**: what was expected, what actually happened, why the gaps occurred (both better and worse than expected), what to sustain, and what to change - each change specific and owned. Blameless throughout.
+
+## 7. Sources
+
+1. US Army, TC 25-20 - the original After-Action Review guide.
+2. Tannenbaum, S. I., & Cerasoli, C. P. (2013) - meta-analysis of debriefs and performance (ES ~0.79).
+
+> **Verification status:** the Tannenbaum & Cerasoli meta-analysis and its effect-size are well-attested; confirm the exact figure against the paper before a public quantified claim. The "structure is the active ingredient" point is the honest core.

--- a/skills/tfs-after-action-review/references/EXAMPLE.md
+++ b/skills/tfs-after-action-review/references/EXAMPLE.md
@@ -1,0 +1,44 @@
+# After Action Review - Worked Example
+
+A completed run of `tfs-after-action-review`, on the shared Northwind scenario. This is the quality bar a generated AAR should meet.
+
+> Northwind is a B2B SaaS. They ran the two-week ICP free-to-paid conversion pilot (the one the decision skills called for and WOOP committed them to). Here the skill reviews it.
+
+---
+
+## Event
+
+- The two-week gated free-tier conversion pilot, run before deciding whether to build the full free tier.
+
+## What was expected
+
+- Going in (recorded in the WWHTBT ledger): the pilot would show ICP free-to-paid conversion at or above the breakeven the cost model needed (~5%), telling us cleanly whether to build.
+
+## What actually happened
+
+- ICP free-to-paid came in at ~3% - below breakeven. But unexpectedly, the onboarding fixes shipped *for* the pilot lifted the existing **paid-trial** conversion by 4 points - a bigger near-term win than the free tier would have been. The pilot also ran a few days late.
+
+## Why the gaps (both directions)
+
+| Difference (expected vs actual) | Why it happened (real cause, blameless) |
+|---|---|
+| Free-to-paid lower than expected (3% vs 5%) | The free cohort skewed less ICP-fit than the gating assumed; the value gate was too loose |
+| Paid-trial conversion rose (not predicted) | The onboarding work done to support the pilot fixed friction that was the actual constraint all along |
+| Pilot ran late | Billing edge cases took longer than scoped, as the reference-class estimate had warned |
+
+## Sustain (what worked, repeat it)
+
+- Running a cheap, time-boxed pilot before a one-way-door build - it changed the decision and cost two weeks, not a quarter.
+- Instrumenting ICP fit on signups from day one.
+
+## Change (specific and owned)
+
+| Change for next time | Owner |
+|---|---|
+| Default to fixing the funnel before assuming a packaging gap; the pilot showed packaging was not the constraint | PM (Growth) |
+| Tighten the ICP value gate before any future free-access test | PM (Growth) |
+| Budget billing/auth work at the reference-class rate (~1.5x), not the inside estimate | Eng lead |
+
+---
+
+*Note: the value is the expected-vs-actual structure. A "how did the pilot go?" retro would have recorded "free tier didn't convert, oh well." The AAR caught the more important, unexpected result - the onboarding fix was the real win - and turned it into an owned change of strategy.*

--- a/skills/tfs-after-action-review/references/TEMPLATE.md
+++ b/skills/tfs-after-action-review/references/TEMPLATE.md
@@ -1,0 +1,33 @@
+# After Action Review - Template
+
+Fill this in. The deliverable is the expected-vs-actual review with sustain/change actions, not a status report. Stay blameless. If the expectation was not recorded, reconstruct it honestly and label it as reconstructed.
+
+---
+
+## Event
+
+- [what is being reviewed, and when it ran]
+
+## What was expected
+
+- [the goal, plan, and predicted outcome going in. Mark "(reconstructed)" if it was not written down.]
+
+## What actually happened
+
+- [the real outcome, concretely - including what went BETTER than expected, not only worse]
+
+## Why the gaps (both directions)
+
+| Difference (expected vs actual) | Why it happened (real cause, blameless) |
+|---|---|
+| | |
+
+## Sustain (what worked, repeat it)
+
+- [...]
+
+## Change (specific and owned)
+
+| Change for next time | Owner |
+|---|---|
+| | |

--- a/skills/tfs-after-action-review/skill.meta.yml
+++ b/skills/tfs-after-action-review/skill.meta.yml
@@ -1,0 +1,77 @@
+# Rich sidecar for the tfs-after-action-review skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.after-action-review
+  slug: after-action-review
+  name: tfs-after-action-review
+  display_name: After Action Review
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: meta-thinking-and-reflection
+  secondary_families: []
+  thinking_modes: [reflective, critical, analytical]
+  problem_contexts: [high-complexity]
+  use_cases:
+    - turn a finished project, launch, sprint, or incident into structured learning
+    - compare expected vs actual and convert gaps into owned changes
+    - capture what to sustain, not only what failed
+  poor_fit_cases:
+    - before the event (use premortem)
+    - status updates or summaries of what shipped
+    - settings where it becomes blame
+    - when there is genuinely no expectation to compare against
+
+interface:
+  required_inputs:
+    - a finished event and its outcome
+  optional_inputs:
+    - the expectation/plan going in (recorded or reconstructable)
+  primary_artifact_type: after-action-review
+  output_formats: [markdown]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.premortem
+    - thinking-framework-skills.reference-class-forecasting
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.premortem
+  often_precedes: []
+  complements:
+    - thinking-framework-skills.premortem
+  overlaps_with: []
+  variants:
+    - "named protocol: AAR (US Army TC 25-20); team debrief"
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - skipping the recorded expectation (hindsight narrative, not learning)
+    - blame instead of learning
+    - vague unowned lessons that change no behavior
+    - capturing only failures, not what to sustain
+
+evidence:
+  evidence_tier: "S"
+  confidence: high for structured debriefs (meta-analytic); unstructured retros do not carry it
+  transferred_evidence: true
+  lineage:
+    derived_from: [US Army AAR (TC 25-20), team debrief research]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-after-action-review/SKILL.md
+  references_path: skills/tfs-after-action-review/references/
+  evidence_path: skills/tfs-after-action-review/evidence/dossier.md
+  evals_path: skills/tfs-after-action-review/eval/

--- a/skills/tfs-argument-mapping/SKILL.md
+++ b/skills/tfs-argument-mapping/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tfs-argument-mapping
+description: Produces an argument map by laying out a claim's supporting reasons, the co-premises each silently depends on, and the objections against it as an explicit structure, then flags the weakest links and unsupported premises. Use when an argument or recommendation must be evaluated for soundness, or when a fluent case may be hiding a broken inference.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.argument-mapping
+  family: reasoning-clarity
+  evidence-tier: "S"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Argument Mapping
+
+In prose, an argument's structure is hidden: the main claim, the reasons for it, the unstated co-premises each reason needs, and the objections against it are blended into fluent text where a broken inference reads as smoothly as a sound one. Argument mapping makes the structure explicit: the contention, the reasons that support it, the co-premises each reason depends on, and the objections and rebuttals, laid out as a tree so every link is visible. The output is an **argument map**. Important boundary: a valid structure does not make the premises true; the map shows structure, not truth.
+
+## When to Use
+
+- An argument or recommendation must be evaluated for soundness before it is trusted.
+- A fluent, persuasive case may be hiding a broken inference or an unstated assumption.
+- A debate needs its logical structure made explicit so people argue the same point.
+
+## When NOT to Use
+
+- Simple claims with no real argumentative structure to map.
+- To judge how persuasive something is (this analyzes logical structure, not rhetoric).
+- To generate ideas or options (wrong tool).
+- As proof an argument is sound: a tidy map can still rest on false premises.
+
+## Instructions
+
+When asked to map an argument, follow these steps:
+
+1. **State the contention.** The single main claim the argument is trying to establish.
+2. **Lay out the reasons.** For each, give the premise that directly supports the contention.
+3. **Surface co-premises.** For each reason, make explicit the unstated assumption it silently needs to actually support the contention. This is where most hidden weakness lives.
+4. **Add objections and rebuttals.** The strongest objections to the contention or to specific reasons, and any rebuttals.
+5. **Flag the weak links.** Mark the inferences that do not hold and the premises that are load-bearing but unsupported.
+6. **Emit the argument map** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the structured map with flagged weak links, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The contention is a single, clearly stated claim.
+- [ ] Each reason has its co-premises made explicit, not left unstated.
+- [ ] Objections and rebuttals are included, not only supporting reasons.
+- [ ] The weakest links and unsupported load-bearing premises are flagged.
+- [ ] The output distinguishes valid structure from true premises (it does not claim soundness from structure alone).
+- [ ] The output is the argument-map artifact, not prose.
+
+## Evidence
+
+Tier **S**, with a scope caveat. Argument-mapping-based instruction produces among the largest measured critical-thinking gains in the field (van Gelder, effect sizes ~0.7-0.85). That evidence is for sustained practice (course-length), not for a single map fixing one argument, so the strong claim is "learning to map improves reasoning," not "this one map carries that effect." Evidence is transferred from human contexts, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed argument map.

--- a/skills/tfs-argument-mapping/eval/cases.md
+++ b/skills/tfs-argument-mapping/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-argument-mapping
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "This board memo argues we should shut the on-prem line. The logic sounds airtight - map it out and tell me if it actually holds."
+- "Evaluate the soundness of this recommendation: I want the reasons, the hidden assumptions, and the objections laid out."
+- "Map the argument in your own last answer - what unstated premises is it resting on?"
+- "Our VP made a fluent case for doubling the sales team. Break the argument into its structure and flag the weak links."
+- "Here's the case for the acquisition. Show me the co-premises each reason depends on and whether the conclusion follows."
+- "I want to see the logical skeleton of this strategy doc - claim, supporting reasons, and the objections it never addresses."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "Is this pitch persuasive enough to win the deal? Make it more convincing." (rhetoric/persuasion, not logical structure)
+- "Sort the claims in this memo into evidence vs inference." (near-miss: evidence-vs-inference-sort classifies claim type; this maps inferential structure)
+- "Give me three arguments for adopting Postgres." (generating arguments, not analyzing one)
+- "Reframe this problem for me before we solve it." (problem-restatement)
+- "The claim is just that 2+2=4 - confirm it." (no argumentative structure)
+- "Summarize this debate into three bullets." (summarization)
+
+## Output checks (a good output must)
+
+- [ ] State a single contention at the top.
+- [ ] Give each reason its explicit co-premise(s), not leave them unstated.
+- [ ] Include objections and rebuttals, not only supporting reasons.
+- [ ] Flag the weakest links and the load-bearing unsupported premises.
+- [ ] Distinguish valid structure from true premises (not claim soundness from structure alone).
+- [ ] Be the argument-map artifact (structured tree + weak-links table + verdict), not prose.
+
+## Value vs unaided baseline
+
+Asked to "assess this argument," a strong model writes a fluent prose critique that mirrors the original's smooth structure and rarely surfaces the unstated co-premises a conclusion silently needs. This skill forces externalizing contention, co-premises, and objections as a tree so a broken inference and a load-bearing-but-unsupported premise become visible - and holds the boundary that valid structure is not a true conclusion. (Per the dossier, the S-tier effect is for sustained practice, not a one-shot map.)

--- a/skills/tfs-argument-mapping/evidence/dossier.md
+++ b/skills/tfs-argument-mapping/evidence/dossier.md
@@ -1,0 +1,55 @@
+# Evidence Dossier: Argument Mapping
+
+> Single source of truth for the `argument-mapping` skill. The SKILL.md, sidecar, and evals derive from this. One of the library's strong-evidence anchors.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.argument-mapping` (installable name `tfs-argument-mapping`) |
+| **Family** | reasoning-clarity |
+| **Evidence tier** | **S** (strong, with a scope caveat) |
+| **Confidence** | High that explicit structure improves reasoning quality; the measured effect is for sustained practice |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+In prose, an argument's structure is hidden: the main claim, the reasons for it, the unstated co-premises each reason needs, and the objections against it are all blended into fluent text, where a broken inference reads as smoothly as a sound one. Argument mapping makes the structure explicit: the **contention** at the top, the **reasons** (premises) that support it, the **co-premises** each reason silently depends on, and the **objections and rebuttals** against it, laid out as a tree so every inferential link is visible. The work is done by exposing the load-bearing-but-unstated premises and the links where support is weakest, which prose hides.
+
+Boundary: a tidy map shows the argument's *structure*, not the *truth* of its premises. Structure being valid does not make the premises true.
+
+## 2. Lineage
+
+- Informal logic and critical-thinking tradition; the Toulmin model is an ancestor. Tim van Gelder's work (Reason!/Rationale) operationalized computer-supported argument mapping and produced the strongest effect estimates.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Strongly supported (the S):** argument-mapping-based instruction produces among the largest measured gains in critical-thinking skill in the field - van Gelder and colleagues report effect sizes around 0.7 to 0.85.
+
+**The honest scope caveat:** those effect sizes are for **sustained practice** (typically a semester-length course building the skill), not for a single one-shot map magically improving one decision. So the strong evidence is that *learning to map arguments improves reasoning*; the claim that *producing one map fixes one argument* is weaker and practitioner-level. Grade S for the method, but do not imply a single use carries the course-length effect.
+
+## 4. Transferred-evidence flag
+
+The evidence is from human learners and analysts, not AI-augmented use. Transferred, not AI-validated. The AI value: a model produces fluent prose arguments where bad inferences hide; forcing it to externalize the contention, co-premises, and objections as a structure is a direct counter, and the map is inspectable.
+
+## 5. When it works / when it fails
+
+**Works best when:** an argument or recommendation must be evaluated for soundness; a fluent case may be hiding a broken inference or an unstated assumption; a debate needs its logical structure made explicit.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- Simple claims with no real argumentative structure to map.
+- Mapping rhetoric or persuasion as if it were logic (it analyzes logical structure, not how convincing something is).
+- Treating a tidy map as a sound argument (valid structure does not make premises true) - the central failure mode.
+- Generating ideas or options (wrong tool).
+- Claiming a single map carries the course-length learning effect.
+
+## 6. Output artifact
+
+An **argument map**: the contention; each supporting reason with its co-premises made explicit; the objections and rebuttals; and a flag on the weakest links and the unsupported or load-bearing-but-unstated premises that most need support.
+
+## 7. Sources
+
+1. van Gelder, T. (2015) and the Reason!/Rationale argument-mapping studies - effect sizes ~0.7-0.85 for critical-thinking gains.
+2. Toulmin, S. (1958) - the model of argument structure (claim, grounds, warrant, rebuttal) that underpins mapping.
+
+> **Verification status:** the van Gelder effect-size range is well-attested for course-length instruction; keep the "single map != course effect" caveat visible in any public claim. Do not attach the 0.7-0.85 figure to a one-shot use.

--- a/skills/tfs-argument-mapping/references/EXAMPLE.md
+++ b/skills/tfs-argument-mapping/references/EXAMPLE.md
@@ -1,0 +1,39 @@
+# Argument Map - Worked Example
+
+A completed run of `tfs-argument-mapping`, on the shared Northwind scenario. This is the quality bar a generated map should meet.
+
+> Northwind is a B2B SaaS. Here the skill maps the argument in the memo advocating the free tier, to test whether it actually holds together.
+
+---
+
+## Contention
+
+- Northwind should launch a self-serve free tier to hit the Q3 growth target.
+
+## Map
+
+- **Reason 1:** A free tier will sharply increase signups.
+  - *Co-premise (unstated):* The people who sign up for free are the people we want (ICP-fit), not tire-kickers.
+  - *Objection:* Competitor free tiers attract mostly non-ICP users. -> *Rebuttal:* We can gate it (but then it is not really "self-serve free").
+- **Reason 2:** More signups will increase revenue.
+  - *Co-premise (unstated):* Free-to-paid conversion at our ICP is high enough to outweigh free-tier cost.
+  - *Objection:* Our current trial-to-paid conversion is falling, which predicts low free-to-paid too.
+- **Reason 3:** Competitors all have a free tier.
+  - *Co-premise (unstated):* Their economics and ICP resemble ours (so imitation is valid).
+- **Objection to the contention:** The Q3 growth shortfall may be a funnel problem, not a packaging gap, in which case a free tier adds cost without fixing the cause. -> *Rebuttal:* None offered in the memo.
+
+## Weak links and unsupported premises
+
+| Link or premise | Problem | What it would need to hold |
+|---|---|---|
+| Co-premise of Reason 2 (ICP free-to-paid conversion) | Load-bearing and unsupported; the whole revenue case rests on it | A pilot showing ICP free-to-paid covers free-tier cost |
+| Reason 3 -> contention | Imitation is not an argument; assumes comparable economics | Evidence competitors' free tiers actually pay off, and that ours would too |
+| Unaddressed objection (funnel vs packaging) | The argument never rules out the cheaper alternative explanation | Data that packaging, not the funnel, drives the shortfall |
+
+## Verdict
+
+The structure is not yet valid: the contention follows only if the Reason-2 co-premise (ICP conversion economics) holds and the funnel-vs-packaging objection is answered, and the memo supports neither. Reason 3 is imitation dressed as logic. For the argument to hold, run the conversion pilot and rule out the funnel explanation - i.e. the case is currently fluent but unsound.
+
+---
+
+*Note: the value is exposing that the entire revenue case rests on one unstated, untested co-premise (ICP free-to-paid economics) and that the strongest objection was never addressed - both invisible in the smooth prose of the original memo.*

--- a/skills/tfs-argument-mapping/references/TEMPLATE.md
+++ b/skills/tfs-argument-mapping/references/TEMPLATE.md
@@ -1,0 +1,28 @@
+# Argument Map - Template
+
+Fill this in as a structure, not prose. A valid structure does not make the premises true; flag the weak links.
+
+---
+
+## Contention
+
+- [the single main claim the argument is trying to establish]
+
+## Map
+
+- **Reason 1:** [premise that supports the contention]
+  - *Co-premise (unstated):* [the assumption this reason needs to actually support the contention]
+  - *Objection:* [strongest objection to this reason] -> *Rebuttal:* [if any]
+- **Reason 2:** [premise]
+  - *Co-premise (unstated):* [...]
+- **Objection to the contention:** [strongest objection to the main claim] -> *Rebuttal:* [if any]
+
+## Weak links and unsupported premises
+
+| Link or premise | Problem | What it would need to hold |
+|---|---|---|
+| | | |
+
+## Verdict
+
+[One line: is the structure valid, and which premises are load-bearing but unsupported - i.e. what would have to be true for the contention to actually follow.]

--- a/skills/tfs-argument-mapping/skill.meta.yml
+++ b/skills/tfs-argument-mapping/skill.meta.yml
@@ -1,0 +1,76 @@
+# Rich sidecar for the tfs-argument-mapping skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.argument-mapping
+  slug: argument-mapping
+  name: tfs-argument-mapping
+  display_name: Argument Mapping
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: reasoning-clarity
+  secondary_families: [assumption-and-belief-challenge]
+  thinking_modes: [critical, analytical]
+  problem_contexts: [high-stakes, high-complexity]
+  use_cases:
+    - evaluate an argument or recommendation for soundness
+    - expose a broken inference or unstated assumption hidden in fluent prose
+    - make a debate's logical structure explicit
+  poor_fit_cases:
+    - simple claims with no argumentative structure
+    - judging persuasiveness/rhetoric rather than logical structure
+    - generating ideas or options
+    - treating a tidy map as proof the argument is sound
+
+interface:
+  required_inputs:
+    - an argument, claim, or recommendation to analyze
+  optional_inputs:
+    - the supporting reasons already stated; known objections
+  primary_artifact_type: argument-map
+  output_formats: [markdown-nested-list]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.evidence-vs-inference-sort
+    - thinking-framework-skills.ladder-of-inference-check
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.evidence-vs-inference-sort
+  often_precedes: []
+  complements:
+    - thinking-framework-skills.ladder-of-inference-check
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - mapping rhetoric as if it were logic
+    - treating valid structure as proof of true premises
+    - missing hidden co-premises
+    - claiming a single map carries the course-length learning effect
+
+evidence:
+  evidence_tier: "S"
+  confidence: high for the method over sustained practice; a single map is practitioner-level
+  transferred_evidence: true
+  lineage:
+    derived_from: [Toulmin model, van Gelder argument mapping]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-argument-mapping/SKILL.md
+  references_path: skills/tfs-argument-mapping/references/
+  evidence_path: skills/tfs-argument-mapping/evidence/dossier.md
+  evals_path: skills/tfs-argument-mapping/eval/

--- a/skills/tfs-authentic-dissent/SKILL.md
+++ b/skills/tfs-authentic-dissent/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tfs-authentic-dissent
+description: Checks whether a decision has genuine minority dissent or only smooth surface consensus, identifies who actually holds a contrary view, and plans how to elicit and protect real dissent, flagging clearly where a view is constructed rather than authentically held. Use when consensus feels too easy, or to set up genuine challenge before a high-stakes call.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.authentic-dissent
+  family: assumption-and-belief-challenge
+  evidence-tier: "S"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Authentic Dissent
+
+Genuine minority dissent makes a group reason better: a person who truly holds a contrary view makes the majority search more broadly and consider more options, even when the dissenter is wrong. The catch, established by the same research, is that **role-played devil's advocacy does not replicate this** - assigned dissent gets discounted as performance. So an AI cannot *be* the dissent; anything a model argues against a plan is constructed, the weaker kind. This skill therefore does not pretend to be the dissenter. It engineers the conditions for real dissent: it audits whether genuine dissent exists, surfaces who holds it, plans how to elicit and protect it, and flags constructed dissent as constructed. The output is a **dissent audit and plan**.
+
+## When to Use
+
+- A group decision shows suspiciously smooth consensus and nobody is really pushing back.
+- You can influence how challenge is gathered (who speaks, anonymous input, outside reviewers).
+- Before a high-stakes call where you want genuine, not performed, challenge.
+
+## When NOT to Use
+
+- As a source of dissent itself: the model's contrarian view is constructed, not authentic (use `red-team-light` for that, which is honest about being constructed).
+- In a purely solo setting with no access to other people - you cannot manufacture authentic dissent.
+- When genuine dissent already exists and is being heard.
+- To "assign a devil's advocate" and consider the job done (the evidence says that does not deliver the benefit).
+
+## Instructions
+
+When asked to set up or audit dissent, follow these steps:
+
+1. **Audit the consensus.** Is the agreement genuine, or is it smoothness from anchoring, hierarchy, or conformity? Note signs (no one names a downside, the senior view landed first, dissent would be costly).
+2. **Locate real dissent.** Identify whether anyone actually holds a minority view, and whether it is being voiced, ignored, or suppressed.
+3. **Label what is in play.** Mark any current "dissent" as authentic (a real holder) or constructed (assigned/role-played/AI). Do not let constructed dissent count as the real thing.
+4. **Plan to elicit and protect genuine dissent.** Concrete moves: anonymous pre-reads, asking the quietest person first, bringing in an outside reviewer who genuinely disagrees, separating generation from evaluation, protecting the dissenter from cost.
+5. **For high stakes, prescribe a real dissenter.** Recommend finding a person who actually holds the contrary view, rather than relying on a constructed critique.
+6. **Emit the dissent audit and plan** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the audit plus an elicit-and-protect plan, not a constructed counter-argument (that is `red-team-light`'s job).
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The consensus is assessed for whether it is genuine or smoothed by hierarchy/conformity.
+- [ ] Any dissent currently in play is labeled authentic vs constructed.
+- [ ] The plan gives concrete ways to elicit and protect real dissent.
+- [ ] For high stakes, it prescribes finding a real dissenter, not relying on constructed critique.
+- [ ] The skill does not present the model's own contrarian view as authentic dissent.
+- [ ] The output is the dissent audit/plan artifact, not prose.
+
+## Evidence
+
+Tier **S**. Authentic minority dissent reliably broadens a group's thinking (Nemeth et al. 2001; *In Defense of Troublemakers*), and the same research shows role-played devil's advocacy does not replicate it. That negative result is load-bearing here: an AI's contrarian output is constructed, so this skill works on the conditions for real dissent rather than claiming to supply it. The evidence is for human groups; it bounds, not just transfers to, AI use. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed dissent audit and plan.

--- a/skills/tfs-authentic-dissent/eval/cases.md
+++ b/skills/tfs-authentic-dissent/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-authentic-dissent
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "The leadership team agreed to the reorg in ten minutes and nobody pushed back. That worries me - help me figure out if this consensus is real."
+- "Before we lock the strategy, I want genuine challenge, not someone assigned to play contrarian. How do I set that up?"
+- "Our standups always 'agree.' How do I get the quieter engineers to actually voice disagreement?"
+- "Is the dissent we have on this decision real, or are people just performing objections? And how do I protect the one person who actually disagrees?"
+- "We're about to make an irreversible call with full consensus. Audit whether anyone genuinely disagrees and plan how to hear them."
+- "How do I design the review so a real skeptic's view counts, not just gets noted and ignored?"
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "Argue the strongest case against our plan." (near-miss: that is red-team-light, constructed critique - this skill is about getting *authentic* dissent)
+- "Just play devil's advocate on my idea." (the skill exists partly to say this does not deliver the benefit; it would not perform it as if it did)
+- "I'm working alone with no team - poke holes in my reasoning." (solo, no access to real dissent; route to red-team-light)
+- "Run a premortem on the reorg." (risk over time)
+- "Summarize the objections raised in the meeting." (summarization)
+- "Give a balanced multi-lens review of this decision." (parallel-perspectives)
+
+## Output checks (a good output must)
+
+- [ ] Assess whether the consensus is genuine or smoothed by hierarchy/anchoring/conformity, with signs.
+- [ ] Locate whether a real minority view exists and whether it is heard or suppressed.
+- [ ] Label any dissent in play as authentic vs constructed (and not let constructed count as real).
+- [ ] Give concrete moves to elicit and protect genuine dissent.
+- [ ] For high stakes, prescribe finding a real dissenter rather than relying on constructed critique.
+- [ ] Not present the model's own contrarian view as authentic dissent; be the audit/plan artifact, not a counter-argument.
+
+## Value vs unaided baseline
+
+Asked to "challenge this decision," a strong model will helpfully generate a counter-argument and may suggest "assign a devil's advocate" - both of which the evidence says do NOT deliver the gains of authentic dissent. This skill does the opposite: it refuses to let constructed dissent stand in for the real thing, audits whether genuine dissent is being suppressed, and plans to elicit and protect it - the meta-work an unaided model skips because it defaults to simply being the (constructed) contrarian.

--- a/skills/tfs-authentic-dissent/evidence/dossier.md
+++ b/skills/tfs-authentic-dissent/evidence/dossier.md
@@ -1,0 +1,57 @@
+# Evidence Dossier: Authentic Dissent
+
+> Single source of truth for the `authentic-dissent` skill. The SKILL.md, sidecar, and evals derive from this. One of the library's strong-evidence anchors - and one whose evidence constrains what an AI can honestly claim to do.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.authentic-dissent` (installable name `tfs-authentic-dissent`) |
+| **Family** | assumption-and-belief-challenge |
+| **Evidence tier** | **S** (strong, and pointed: it tells us role-play does NOT work) |
+| **Confidence** | High that genuine dissent helps and role-played dissent does not replicate it |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+Genuine minority dissent improves a group's reasoning: exposure to someone who *truly* holds a contrary view makes the majority search more broadly, consider more options, and think more divergently - and this happens even when the dissenter turns out to be wrong. The benefit comes from the authenticity of the disagreement, not from the content being correct.
+
+Crucially, **role-played devil's advocacy does not replicate this.** When dissent is assigned ("you argue against"), the group discounts it as a performance and the divergence gains largely disappear. So the active ingredient is hard to manufacture: it requires a person who genuinely disagrees and is heard.
+
+This is what makes the skill unusual, and honest: **an AI cannot be authentic dissent** - anything a model generates against a plan is, by definition, constructed/role-played, the weaker kind. So this skill does not pretend to *be* the dissenter. Its job is to engineer the *conditions* for real dissent: detect whether genuine dissent exists, surface who actually holds a minority view, protect it from suppression, and - for high-stakes calls - prompt seeking a real dissenter rather than relying on the model's simulated one.
+
+## 2. Lineage
+
+- Charlan Nemeth's program on minority influence and dissent (e.g., Nemeth et al. 2001; *In Defense of Troublemakers*, 2018): authentic dissent improves decision quality; role-played devil's advocacy does not match it.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Strongly supported (the S):** authentic minority dissent reliably increases divergent thought and the breadth of options a group considers (Nemeth's experiments). And the negative result is equally well-established and load-bearing here: **role-played/assigned dissent does not produce the same gains.**
+
+**What it does NOT show / cannot do:** it does not show that *simulated* dissent (an AI or an assigned advocate) carries the benefit - the evidence says the opposite. So an honest version of this skill is meta: it works on the social conditions for dissent, and explicitly does not claim the model's own contrarian output is a substitute for a real dissenter.
+
+## 4. Transferred-evidence flag
+
+The evidence is from human groups. More than transferred - it actively bounds the AI use: the model cannot supply the authentic dissent the evidence is about. The AI value is in the meta-work (detecting, eliciting, protecting genuine dissent; flagging constructed dissent as constructed), not in being the dissenter. Pair with `red-team-light` for the constructed-critique job, which is honest about being constructed.
+
+## 5. When it works / when it fails
+
+**Works best when:** a group decision shows suspiciously smooth consensus; you can influence how challenge is gathered (anonymous input, who speaks, outside reviewers); before a high-stakes call where you want real, not performed, challenge.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **Treating role-played or AI-generated dissent as authentic** - the central failure the evidence warns against.
+- Assigning a devil's advocate and assuming that delivers the benefit.
+- Punishing, sidelining, or "managing" the real dissenter (which destroys the effect).
+- A purely solo setting with no access to other people: you cannot manufacture authentic dissent from yourself or the model - use `red-team-light` and be honest it is constructed.
+- When genuine dissent already exists and is being heard (no intervention needed).
+
+## 6. Output artifact
+
+A **dissent audit and plan**: whether genuine dissent exists on this decision; who (if anyone) actually holds a minority view and whether it is being heard or suppressed; concrete ways to elicit and protect real dissent (anonymous pre-reads, asking the quietest first, an outside reviewer who genuinely disagrees, separating idea-generation from evaluation); and an explicit label of any dissent currently in play as authentic vs constructed.
+
+## 7. Sources
+
+1. Nemeth, C. et al. (2001) - dissent and decision quality; role-played devil's advocacy does not replicate authentic dissent.
+2. Nemeth, C. (2018) - *In Defense of Troublemakers: The Power of Dissent in Life and Business*.
+
+> **Verification status:** the authentic-vs-role-played finding is well-attested and is the load-bearing, honesty-defining result for this skill. Do not let the skill present the model's own contrarian output as authentic dissent.

--- a/skills/tfs-authentic-dissent/references/EXAMPLE.md
+++ b/skills/tfs-authentic-dissent/references/EXAMPLE.md
@@ -1,0 +1,39 @@
+# Dissent Audit and Plan - Worked Example
+
+A completed run of `tfs-authentic-dissent`, on the shared Northwind scenario. This is the quality bar a generated audit should meet.
+
+> Northwind is a B2B SaaS. The leadership meeting reached quick consensus to launch the free tier. This skill checks whether that consensus is real and plans for genuine challenge.
+
+---
+
+## Decision
+
+- Launch the self-serve free tier in Q3; the room agreed within ten minutes.
+
+## Consensus audit
+
+- **Is the agreement genuine?** Likely smoothed, not genuine.
+- **Signs:** the CEO floated the free tier first and spoke most; no one named a downside aloud; the one skeptic (the Finance lead) went quiet after an early "let's not relitigate"; agreeing is the low-cost move with the board date looming.
+
+## Dissent currently in play
+
+| Who / what | View | Authentic or constructed? | Heard or suppressed? |
+|---|---|---|---|
+| Finance lead | Worried free-tier cost breaks unit economics | Authentic (genuinely held) | Suppressed - went quiet after pushback |
+| The AI red-team output | Strongest case against the free tier | Constructed | Available, but not a substitute for a real holder |
+| "Assigned devil's advocate" (proposed) | Whatever they're told to argue | Constructed | Would be discounted as performance |
+
+## Plan to elicit and protect genuine dissent
+
+- Ask the Finance lead, directly and first, to make their strongest case before anyone defends the plan - and signal it is wanted, not tolerated.
+- Collect anonymous pre-reads from the team on "the biggest reason this fails" before the next meeting, so dissent does not require public courage.
+- Bring in one outside operator who has actually run a free tier and genuinely thinks it was a mistake, not someone assigned to argue it.
+- Separate generation (surface concerns) from evaluation (decide) so the concerns are not killed on contact.
+
+## High-stakes prescription
+
+- This is a near-one-way door. Do not let the AI red-team critique or an assigned devil's advocate stand in for real dissent. Put the genuine skeptic (Finance lead, plus the outside operator) in the room with explicit protection, and weight their case before committing.
+
+---
+
+*Note: the value - and the honesty - is refusing to let the constructed critiques (the AI's, or an assigned advocate's) count as the dissent that the evidence says actually helps. The skill's job was to find the real skeptic who got silenced and build a plan to genuinely hear her.*

--- a/skills/tfs-authentic-dissent/references/TEMPLATE.md
+++ b/skills/tfs-authentic-dissent/references/TEMPLATE.md
@@ -1,0 +1,28 @@
+# Dissent Audit and Plan - Template
+
+Fill this in. The deliverable is the audit plus an elicit-and-protect plan, not a constructed counter-argument (that is `red-team-light`). Label authentic vs constructed dissent honestly.
+
+---
+
+## Decision
+
+- [one line: the decision and the apparent consensus]
+
+## Consensus audit
+
+- **Is the agreement genuine?** [or smoothed by hierarchy, anchoring on the first/senior voice, or the cost of dissenting?]
+- **Signs:** [e.g. no one named a downside; the senior view landed first; dissent would be career-costly]
+
+## Dissent currently in play
+
+| Who / what | View | Authentic or constructed? | Heard or suppressed? |
+|---|---|---|---|
+| | | | |
+
+## Plan to elicit and protect genuine dissent
+
+- [concrete moves: anonymous pre-reads, ask the quietest first, an outside reviewer who genuinely disagrees, separate generation from evaluation, protect the dissenter from cost]
+
+## High-stakes prescription
+
+- [if the decision is consequential/irreversible: name the kind of real dissenter to find - someone who actually holds the contrary view - rather than relying on a constructed critique]

--- a/skills/tfs-authentic-dissent/skill.meta.yml
+++ b/skills/tfs-authentic-dissent/skill.meta.yml
@@ -1,0 +1,77 @@
+# Rich sidecar for the tfs-authentic-dissent skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.authentic-dissent
+  slug: authentic-dissent
+  name: tfs-authentic-dissent
+  display_name: Authentic Dissent
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: assumption-and-belief-challenge
+  secondary_families: [facilitation-and-group-structures]
+  thinking_modes: [critical, reflective]
+  problem_contexts: [high-conflict, high-stakes]
+  use_cases:
+    - audit whether a smooth consensus hides suppressed genuine dissent
+    - plan how to elicit and protect real minority views before a decision
+    - distinguish authentic dissent from constructed/role-played dissent
+  poor_fit_cases:
+    - using the model's own contrarian view as if it were authentic dissent
+    - purely solo settings with no access to other people
+    - when genuine dissent already exists and is heard
+    - assigning a devil's advocate and assuming that delivers the benefit
+
+interface:
+  required_inputs:
+    - a decision and its current state of agreement/consensus
+  optional_inputs:
+    - who is in the room, the hierarchy, how challenge is gathered
+  primary_artifact_type: dissent-audit
+  output_formats: [markdown]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.red-team-light
+    - thinking-framework-skills.premortem
+
+relationships:
+  often_follows: []
+  often_precedes:
+    - thinking-framework-skills.premortem
+  complements:
+    - thinking-framework-skills.red-team-light
+  overlaps_with: []
+  variants:
+    - "contrast: devil's advocacy (role-played, weaker per Nemeth)"
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - treating role-played or AI-generated dissent as authentic
+    - assigning a devil's advocate and assuming it delivers the benefit
+    - sidelining or punishing the real dissenter
+
+evidence:
+  evidence_tier: "S"
+  confidence: high; the authentic-vs-role-played result is well-established and bounds the AI use
+  transferred_evidence: true
+  lineage:
+    derived_from: [Nemeth minority dissent research]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+  risk_flags: [ai-cannot-supply-authentic-dissent]
+
+implementation:
+  skill_path: skills/tfs-authentic-dissent/SKILL.md
+  references_path: skills/tfs-authentic-dissent/references/
+  evidence_path: skills/tfs-authentic-dissent/evidence/dossier.md
+  evals_path: skills/tfs-authentic-dissent/eval/

--- a/skills/tfs-far-analogy-ideation/SKILL.md
+++ b/skills/tfs-far-analogy-ideation/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: tfs-far-analogy-ideation
+description: Generates novel solution candidates by stating a problem's deep relational structure, mapping it to distant source domains (nature, other industries, games), and transferring the mechanism rather than surface features, then adapting. Use when near, obvious solutions are exhausted and you need genuinely original approaches.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.far-analogy-ideation
+  family: divergent-ideation
+  evidence-tier: "S"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Far-Analogy Ideation
+
+Most ideation transfers solutions from near domains (products like yours), which yields obvious, low-novelty ideas. Far-analogy ideation deliberately reaches to distant domains - nature, other industries, games, history - and transfers the deep relational structure of a working solution there, not its surface features. The originality comes from the distance; the validity comes from mapping structure, not surface similarity. The output is a **far-analogy transfer sheet** of candidate mechanisms to adapt. The failure to avoid: surface-matching ("both involve networks"), which produces cute-but-useless analogies and carries none of the benefit.
+
+## When to Use
+
+- Near, obvious solutions are exhausted or all look alike.
+- You want genuinely original approaches, not incremental variations.
+- The problem has a clear underlying structure that can be stated abstractly.
+
+## When NOT to Use
+
+- An obvious near solution already exists and works (far analogy is overkill and riskier).
+- When you need to converge and decide (use a decision skill).
+- When only a surface match is available (a forced, surface-level analogy is worse than none).
+- Execution tasks with no real ideation need.
+
+## Instructions
+
+When asked to ideate by far analogy, follow these steps:
+
+1. **State the deep structure.** Abstract the problem to its relational core, stripped of domain surface ("an entity must attract the right partners at low cost, then convert low commitment to high"). This is the step that makes the analogy valid.
+2. **Reach to distant domains.** Find 2 to 3 domains far from the problem where that same structure is solved (biology, other industries, games, history). Deliberately avoid near, same-industry sources.
+3. **Map mechanism to mechanism.** For each, describe how that domain solves the structure - the mechanism, not the surface. Flag if a mapping is structural vs at risk of being surface-level.
+4. **Transfer and adapt.** Turn each mechanism into a concrete candidate idea for the actual problem.
+5. **Shortlist as candidates.** Select the most promising, flagged as candidates to test (not answers), noting what would have to be true.
+6. **Emit the transfer sheet** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the structure, the distant sources, the transferred mechanisms, and adapted candidates, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The deep relational structure is stated abstractly before any analogy.
+- [ ] Source domains are genuinely distant, not near/same-industry.
+- [ ] Mappings are mechanism-to-mechanism (structural), with surface-only matches flagged or rejected.
+- [ ] Each idea is a candidate to test, not presented as the answer.
+- [ ] The output is the transfer-sheet artifact, not prose.
+
+## Evidence
+
+Tier **S**. Distant analogies produce more original and novel solutions than near ones across creativity and design studies, and analogical transfer is a well-studied innovation mechanism (Gentner structure-mapping; Gick & Holyoak 1980; Dahl & Moreau). The honest failure mode is built in: surface-feature mapping carries none of the benefit and some risk, so the method requires mapping deep structure. Evidence is for human ideation, transferred to AI use, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed transfer sheet.

--- a/skills/tfs-far-analogy-ideation/eval/cases.md
+++ b/skills/tfs-far-analogy-ideation/eval/cases.md
@@ -1,0 +1,33 @@
+# Eval cases: tfs-far-analogy-ideation
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "Every growth idea we have is a variation of 'free tier or ads.' Give me genuinely different approaches from outside our industry."
+- "We're stuck. How would nature, or a totally different field, solve this retention problem?"
+- "Use far analogies to find novel mechanisms for getting qualified users to commit."
+- "Our near-domain options are exhausted. Reach to distant domains and transfer the mechanism, not the surface."
+- "I want original product ideas by analogy to how other systems solve 'attract the right partner cheaply.'"
+- "Map this onboarding problem to how games get players to invest, and pull out candidate mechanisms."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "We have a seed idea - run it through Substitute/Combine/Adapt to vary it." (near-miss: SCAMPER transforms an existing seed; this transfers from distant domains)
+- "Generate a broad set of ideas from several independent angles." (brainwriting; not specifically distant-analogy)
+- "Pick the best of these five growth options." (decision)
+- "There's a standard, obvious fix for this - just apply it." (near solution exists; far analogy is overkill)
+- "Reframe what problem we're actually solving." (problem-restatement)
+- "Summarize these analogies into a paragraph." (summarization)
+
+## Output checks (a good output must)
+
+- [ ] State the problem's deep relational structure abstractly BEFORE any analogy.
+- [ ] Use genuinely distant source domains, not near/same-industry ones.
+- [ ] Map mechanism-to-mechanism (structural), flagging or rejecting surface-only matches.
+- [ ] Present ideas as candidates to test, with what would have to be true, not as answers.
+- [ ] Be the transfer-sheet artifact (structure, sources, mechanisms, candidates), not prose.
+
+## Value vs unaided baseline
+
+Asked for "creative ideas by analogy," a strong model tends to produce surface-matched analogies ("it's like Uber for X") that share a label but not a mechanism, and presents them as suggestions. This skill forces stating the deep structure first, reaching to genuinely distant domains, mapping mechanism rather than surface, and flagging when a mapping is only surface-level - the discipline that separates evidenced far-analogy transfer from a party trick.

--- a/skills/tfs-far-analogy-ideation/evidence/dossier.md
+++ b/skills/tfs-far-analogy-ideation/evidence/dossier.md
@@ -1,0 +1,54 @@
+# Evidence Dossier: Far-Analogy Ideation
+
+> Single source of truth for the `far-analogy-ideation` skill. The SKILL.md, sidecar, and evals derive from this. A strong-evidence anchor and the first S-tier ideation method in the library.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.far-analogy-ideation` (installable name `tfs-far-analogy-ideation`) |
+| **Family** | divergent-ideation |
+| **Evidence tier** | **S** (cognitive science of analogical transfer) |
+| **Confidence** | High that distant analogies yield more original solutions; with a real failure mode (surface mapping) |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+Most ideation transfers solutions from *near* domains (other products like yours), which yields obvious, low-novelty ideas. Far-analogy ideation deliberately reaches to *distant* domains (nature, other industries, games, history) and transfers the **deep relational structure** of a working solution there, not its surface features. You map the problem's underlying structure ("X must attract the right Y at low cost, then convert low commitment to high"), find a distant domain where that same structure is solved (a coral cleaning station; a dating app's graduated reveal), transfer the mechanism, and adapt it. The originality comes from the distance; the validity comes from mapping *structure*, not surface similarity.
+
+## 2. Lineage
+
+- Dedre Gentner's structure-mapping theory of analogy; Gentner & Smith (2013) on analogical reasoning; Gick & Holyoak (1980) on analogical transfer (the radiation/fortress problem); Dahl & Moreau on far analogies producing more original new-product ideas.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Strongly supported (the S):** distant/far analogies produce more original and novel solutions than near analogies, across creativity and design studies. Analogical transfer is one of the better-studied mechanisms of innovation.
+
+**The honest failure mode (built into the method):** people (and models) tend to map on **surface features** ("both involve water") rather than deep structure, which produces cute-but-useless analogies or, worse, misleading ones. Far analogies are also harder to retrieve and transfer than near ones. So the evidence supports far analogy *done as structure-mapping*; a surface-matched analogy carries none of the benefit and some risk.
+
+## 4. Transferred-evidence flag
+
+The evidence is from human ideation and reasoning, not AI-augmented use. Transferred, not AI-validated. The AI value: a model is unusually good at retrieving distant domains (it has read everything) but also prone to surface-matching; this skill forces it to state the deep structure first and map mechanism to mechanism, and to flag ideas as candidates.
+
+## 5. When it works / when it fails
+
+**Works best when:** near, obvious solutions are exhausted or all look alike; you want genuinely original approaches; the problem has a clear relational structure to map.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **Surface-feature mapping** instead of structural - the central failure (matching "both are networks" rather than the actual mechanism).
+- Forcing a cute analogy that does not really transfer.
+- An obvious near solution already exists and works (far analogy is overkill and riskier).
+- Treating the analogy as the answer rather than a source of candidate mechanisms to adapt and test.
+- When you need to converge and decide (use a decision skill).
+
+## 6. Output artifact
+
+A **far-analogy transfer sheet**: the problem's deep relational structure stated abstractly; 2-3 distant source domains where that structure is solved; the mechanism each suggests; and the adapted candidate ideas (flagged as candidates to test, with a note on whether the mapping is structural or risks being surface).
+
+## 7. Sources
+
+1. Gentner, D. - structure-mapping theory; Gentner & Smith (2013).
+2. Gick, M., & Holyoak, K. (1980) - analogical problem solving (radiation/fortress).
+3. Dahl & Moreau - far analogies and originality in new-product ideation.
+
+> **Verification status:** the "distant analogies -> more original solutions" and "surface vs structural mapping" findings are well-attested in the analogy literature. Keep the surface-mapping failure mode prominent; it is what separates the evidenced method from a party trick.

--- a/skills/tfs-far-analogy-ideation/references/EXAMPLE.md
+++ b/skills/tfs-far-analogy-ideation/references/EXAMPLE.md
@@ -1,0 +1,32 @@
+# Far-Analogy Transfer Sheet - Worked Example
+
+A completed run of `tfs-far-analogy-ideation`, on the shared Northwind scenario. This is the quality bar a generated sheet should meet.
+
+> Northwind is a B2B SaaS whose growth ideas all look alike (free tier, ads, outbound). Here the skill reaches to distant domains for genuinely different acquisition mechanisms.
+
+---
+
+## Problem (surface)
+
+- How does Northwind get more qualified B2B accounts to adopt the product?
+
+## Deep relational structure (abstract, domain-stripped)
+
+- An entity must get the *right* partners to discover it, self-select as a good fit, and move from low commitment to high commitment, at low cost to the entity.
+
+## Distant sources and transferred mechanisms
+
+| Distant domain | How it solves the structure (mechanism) | Structural or surface? | Candidate idea (adapted) |
+|---|---|---|---|
+| Coral reef cleaning stations (biology) | A fish offers a *service* (cleaning) that attracts exactly the species that benefit; the service itself does the qualifying | Structural (the offer self-selects the right partner) | Ship a genuinely useful free *tool* (not a free tier) that only ICP-fit teams need - the tool self-qualifies users |
+| Open-source projects (other industry) | Convert users to contributors via a laddered path: use -> report -> contribute -> maintain; commitment rises in small steps | Structural (graduated commitment ladder) | A graduated adoption ladder: free utility -> shared template -> team workspace -> paid, each step a small commitment increase |
+| Apprenticeship/guilds (history) | High commitment is earned through staged proof and reputation, not bought upfront | Structural (earned access) | Invite/earn-based access that raises perceived value and filters for serious teams |
+
+## Shortlist (candidates to test)
+
+1. **Self-qualifying free tool (from the reef)** - a narrow tool only ICP teams need - would have to be true: such a tool exists cheaply and the teams who want it are our ICP. Stronger than an open free tier because the offer does the qualifying.
+2. **Graduated adoption ladder (from open source)** - would have to be true: each rung delivers standalone value and a measurable step-up in commitment.
+
+---
+
+*Note: the value is reaching past the near, same-industry options (everyone's "free tier") to a structural mechanism - the offer that self-selects the right partner - that reframes the whole acquisition approach. The mappings are structural (self-selection, graduated commitment), not surface ("coral is colorful like our brand"), which is what makes them worth testing rather than cute.*

--- a/skills/tfs-far-analogy-ideation/references/TEMPLATE.md
+++ b/skills/tfs-far-analogy-ideation/references/TEMPLATE.md
@@ -1,0 +1,28 @@
+# Far-Analogy Transfer Sheet - Template
+
+Fill this in. State the deep structure FIRST; map mechanism, not surface. Ideas are candidates to test, not answers.
+
+---
+
+## Problem (surface)
+
+- [the problem as normally stated]
+
+## Deep relational structure (abstract, domain-stripped)
+
+- [the relational core, e.g. "an entity must attract the right partners at low cost, then convert low commitment to high commitment"]
+
+## Distant sources and transferred mechanisms
+
+| Distant domain | How it solves the structure (mechanism) | Structural or surface? | Candidate idea (adapted) |
+|---|---|---|---|
+| | | | |
+| | | | |
+| | | | |
+
+(Reach far: biology, other industries, games, history. Reject surface-only matches.)
+
+## Shortlist (candidates to test)
+
+1. **[idea]** - from [domain]'s [mechanism] - would have to be true: [...].
+2. ...

--- a/skills/tfs-far-analogy-ideation/skill.meta.yml
+++ b/skills/tfs-far-analogy-ideation/skill.meta.yml
@@ -1,0 +1,76 @@
+# Rich sidecar for the tfs-far-analogy-ideation skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.far-analogy-ideation
+  slug: far-analogy-ideation
+  name: tfs-far-analogy-ideation
+  display_name: Far-Analogy Ideation
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: divergent-ideation
+  secondary_families: []
+  thinking_modes: [divergent, lateral, creative]
+  problem_contexts: [high-ambiguity]
+  use_cases:
+    - generate genuinely original solutions when near options are exhausted
+    - transfer a working mechanism from a distant domain to the problem
+  poor_fit_cases:
+    - an obvious near solution already exists and works
+    - converging or deciding among options
+    - only a surface-level analogy is available (worse than none)
+    - execution tasks with no ideation need
+
+interface:
+  required_inputs:
+    - a problem that can be abstracted to a relational structure
+  optional_inputs:
+    - near solutions already tried
+  primary_artifact_type: far-analogy-transfer-sheet
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.problem-restatement
+    - thinking-framework-skills.decision-option-review
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.problem-restatement
+  often_precedes:
+    - thinking-framework-skills.decision-option-review
+  complements:
+    - thinking-framework-skills.scamper
+    - thinking-framework-skills.brainwriting
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - surface-feature mapping instead of structural
+    - forcing a cute analogy that does not transfer
+    - treating the analogy as the answer rather than a candidate mechanism
+
+evidence:
+  evidence_tier: "S"
+  confidence: high that distant analogies yield more originality; surface mapping carries none of it
+  transferred_evidence: true
+  lineage:
+    derived_from: [Gentner structure-mapping, Gick and Holyoak analogical transfer]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-far-analogy-ideation/SKILL.md
+  references_path: skills/tfs-far-analogy-ideation/references/
+  evidence_path: skills/tfs-far-analogy-ideation/evidence/dossier.md
+  evals_path: skills/tfs-far-analogy-ideation/eval/

--- a/skills/tfs-natural-frequency-bayesian/SKILL.md
+++ b/skills/tfs-natural-frequency-bayesian/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tfs-natural-frequency-bayesian
+description: Converts a conditional-probability or base-rate question into natural frequencies over a concrete population (for example 9 of 1000) to compute the correct posterior and expose base-rate neglect, and refuses to proceed without real input rates. Use when interpreting a test result, screening signal, or any "given a positive, what is the real probability" question.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.natural-frequency-bayesian
+  family: reasoning-clarity
+  evidence-tier: "S"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Natural-Frequency Bayesian Framing
+
+People - including experts - reason badly about conditional probabilities stated as percentages, because they neglect the base rate. Re-expressing the same facts as natural frequencies over a concrete population makes the correct answer nearly visible: "Out of 1,000, 10 have it; 9 of those test positive; of the 990 without it, ~89 also test positive; so of ~98 positives, only 9 truly have it - about 9%." The format does the work by keeping the base rate in the counts. The output is a **natural-frequency breakdown**. Honest constraint: the base rate and hit rates must be real - the format makes correct reasoning tractable, it does not invent the inputs.
+
+## When to Use
+
+- Interpreting a test or screening result (medical, fraud, security, lead-scoring, A/B).
+- Any "given a positive signal, what is the actual probability the thing is true?" question.
+- Communicating risk to others so they do not over-read a positive.
+
+## When NOT to Use
+
+- When you do not have real input rates and would have to invent them.
+- When there is no conditional-probability structure to the question.
+- For general project forecasting (use reference-class forecasting).
+- When a single point estimate is wanted and the base-rate structure is irrelevant.
+
+## Instructions
+
+When asked to reason about a conditional probability, follow these steps:
+
+1. **State the question precisely.** What posterior is being asked - usually P(condition | positive signal). Distinguish it from P(positive | condition), which people confuse it with.
+2. **Gather the real inputs.** The base rate, the true-positive (hit) rate, and the false-positive rate. If any is unknown, say so and stop or clearly flag the estimate as illustrative - do not fabricate numbers.
+3. **Build a frequency tree over a concrete population.** Pick a round number (e.g., 1,000). Work out: how many have the condition; of those, how many test positive; of those without, how many also test positive.
+4. **Compute the posterior** as true positives / all positives, and state it plainly.
+5. **Name the wrong intuition it corrects.** State the answer most people give (usually near the hit rate) and why it is wrong (base-rate neglect).
+6. **Emit the natural-frequency breakdown** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the frequency tree, the posterior, and the plain-language meaning, not a bare percentage.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The question distinguishes P(condition | positive) from P(positive | condition).
+- [ ] The base rate, true-positive rate, and false-positive rate are real (or missing data is flagged, not invented).
+- [ ] A frequency tree over a concrete population is shown.
+- [ ] The posterior is computed as true positives / all positives.
+- [ ] The common wrong intuition (base-rate neglect) is named.
+- [ ] The output is the breakdown artifact, not a bare number.
+
+## Evidence
+
+Tier **S**. Presenting conditional-probability information as natural frequencies substantially improves Bayesian-inference accuracy - accuracy on these problems rises from roughly 10% to 50-90% with the same facts in frequency format (Gigerenzer & Hoffrage 1995; Sedlmeier & Gigerenzer 2001), replicated across populations including physicians. The format does not supply the inputs; real rates are required. Evidence is from human reasoners, transferred to AI use, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed breakdown.

--- a/skills/tfs-natural-frequency-bayesian/eval/cases.md
+++ b/skills/tfs-natural-frequency-bayesian/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-natural-frequency-bayesian
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "Our fraud model flags a transaction. It's 95% accurate and fraud is 0.5% of transactions. If it flags one, what's the real chance it's fraud?"
+- "A screening test is 90% sensitive with a 5% false-positive rate and the condition affects 2% of people. A patient tests positive - what's the actual probability they have it?"
+- "Sales treats every 'high-intent' flag from our model as a hot lead. Given the base rate, what does a flag actually mean?"
+- "Help me interpret this positive A/B signal given how rare a real effect is for us."
+- "Walk through this base-rate problem in frequencies so the team stops over-reading positives."
+- "Given a positive result, what's the chance it's a true positive? Lay it out as counts, not percentages."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "How long will the platform rewrite take, given our past projects?" (near-miss: reference-class forecasting / outside view, not a conditional-probability test result)
+- "What's our churn rate this quarter?" (a single statistic, no conditional structure)
+- "We don't know the base rate or the model's false-positive rate - just estimate the chance." (no real inputs; the skill must refuse to fabricate)
+- "Forecast next quarter's revenue with a range." (forecasting)
+- "Brainstorm reasons the model might be wrong." (ideation)
+- "Summarize the model's validation report." (summarization)
+
+## Output checks (a good output must)
+
+- [ ] Distinguish P(condition | positive) from P(positive | condition) explicitly.
+- [ ] Use real input rates with sources, or flag missing data and refuse to invent numbers.
+- [ ] Show a frequency tree over a concrete population (e.g., 1,000).
+- [ ] Compute the posterior as true positives / all positives.
+- [ ] Name the common wrong intuition (base-rate neglect) and why it is wrong.
+- [ ] Be the natural-frequency breakdown artifact, not a bare percentage.
+
+## Value vs unaided baseline
+
+Asked a base-rate question, an unaided model often answers near the hit rate (the same base-rate-neglect error humans make) or, when it lacks the inputs, invents plausible-sounding rates. This skill forces the natural-frequency tree that keeps the base rate in the counts (the format the evidence shows lifts accuracy from ~10% to 50-90%), distinguishes the two conditionals, and refuses to fabricate the input rates - producing an inspectable breakdown instead of a confident wrong number.

--- a/skills/tfs-natural-frequency-bayesian/evidence/dossier.md
+++ b/skills/tfs-natural-frequency-bayesian/evidence/dossier.md
@@ -1,0 +1,55 @@
+# Evidence Dossier: Natural-Frequency Bayesian Framing
+
+> Single source of truth for the `natural-frequency-bayesian` skill. The SKILL.md, sidecar, and evals derive from this. A strong-evidence anchor.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.natural-frequency-bayesian` (installable name `tfs-natural-frequency-bayesian`) |
+| **Family** | reasoning-clarity |
+| **Evidence tier** | **S** (well-replicated) |
+| **Confidence** | High - the format effect is one of the most robust findings in judgment research |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+People - including experts - reason badly about conditional probabilities when they are stated as percentages or probabilities. Given "the test is 90% sensitive, the condition affects 1%, the false-positive rate is 9%," most people (including doctors) wildly overestimate the chance that a positive result means the condition is present, because they neglect the base rate.
+
+Re-expressing the *identical* information as **natural frequencies over a concrete population** makes the correct answer almost visible: "Out of 1,000 people, 10 have the condition; of those, 9 test positive. Of the 990 without it, about 89 also test positive. So of ~98 positives, only 9 truly have it - about 9%." The format does the work: it preserves the base rate in the counts instead of hiding it in a rate. Accuracy on these problems jumps from roughly 10% to 50-90% when the same facts are presented as natural frequencies.
+
+## 2. Lineage
+
+- Gigerenzer & Hoffrage (1995) on how natural-frequency formats improve Bayesian reasoning; Sedlmeier & Gigerenzer (2001) on teaching it; widely applied in medical decision-making and risk communication.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Strongly supported (the S):** presenting conditional-probability information as natural frequencies substantially improves the accuracy of Bayesian inference (the ~10% to ~50-90% jump is well-replicated across studies and populations, including physicians).
+
+**What it does NOT do:** it does not invent the inputs. The base rate, the true-positive rate, and the false-positive rate must be real; the format makes correct reasoning *from* those numbers tractable, it does not supply them. And it applies only where there is genuine conditional-probability structure - it is not a general forecasting tool (that is reference-class forecasting).
+
+## 4. Transferred-evidence flag
+
+The evidence is from human reasoners. Transferred to AI use; the model can do the arithmetic, but the value is the same as for humans plus communication: it forces the base rate to be used (countering base-rate neglect in the model's own answers and in how it explains risk), and it produces an inspectable frequency breakdown rather than a bare percentage. It still must refuse to fabricate the input rates.
+
+## 5. When it works / when it fails
+
+**Works best when:** interpreting a test or screening result (medical, fraud, security, lead-scoring, A/B); any "given a positive signal, what is the real probability" question; communicating risk to others.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **No real input rates** - inventing the base rate or hit rate is worse than admitting they are unknown (the central failure for an AI).
+- Ignoring the base rate (base-rate neglect) - the very error the method exists to fix.
+- Confusing P(positive | condition) with P(condition | positive) - state which is which.
+- No conditional-probability structure (then this is the wrong tool).
+- General project forecasting (use reference-class forecasting).
+
+## 6. Output artifact
+
+A **natural-frequency breakdown**: the question; the inputs (base rate, true-positive rate, false-positive rate) with sources or an explicit missing-data flag; a frequency tree over a concrete population (e.g., 1,000); the computed posterior; and a plain-language statement of what it means plus the common wrong intuition it corrects.
+
+## 7. Sources
+
+1. Gigerenzer, G., & Hoffrage, U. (1995) - improving Bayesian reasoning with natural-frequency formats.
+2. Sedlmeier, P., & Gigerenzer, G. (2001) - teaching Bayesian reasoning (accuracy gains).
+
+> **Verification status:** the natural-frequency format effect and the rough 10%->50-90% accuracy gain are well-attested; confirm exact figures against the papers before a public quantified claim. The "must use real input rates" constraint is the honest core for AI use.

--- a/skills/tfs-natural-frequency-bayesian/references/EXAMPLE.md
+++ b/skills/tfs-natural-frequency-bayesian/references/EXAMPLE.md
@@ -1,0 +1,38 @@
+# Natural-Frequency Breakdown - Worked Example
+
+A completed run of `tfs-natural-frequency-bayesian`, on the shared Northwind scenario. This is the quality bar a generated breakdown should meet.
+
+> Northwind is a B2B SaaS. Sales treats every account its new model flags as "high-intent" as if it almost certainly is. This skill checks what a flag actually means.
+
+---
+
+## Question
+
+- **Posterior asked:** P(truly high-intent | flagged "high-intent") = ?
+- (This is NOT the model's 80% sensitivity, which is P(flagged | truly high-intent). Sales is confusing the two.)
+
+## Inputs (real, with source)
+
+- **Base rate** P(high-intent): 5% - source: historical share of accounts that became opportunities.
+- **True-positive (hit) rate** P(flagged | high-intent): 80% - source: model validation set.
+- **False-positive rate** P(flagged | not high-intent): 10% - source: model validation set.
+
+## Frequency tree (per 1,000 accounts)
+
+- Of 1,000: 50 are truly high-intent; 950 are not.
+  - Of the 50 high-intent: 40 are flagged (80%).
+  - Of the 950 not high-intent: ~95 are also flagged (10%).
+- Total flagged: 40 + 95 = 135.
+
+## Posterior
+
+- P(high-intent | flagged) = 40 / 135 = **~30%.**
+
+## What it means / the wrong intuition it corrects
+
+- Plain language: when the model flags an account, it is truly high-intent only about **30%** of the time - so roughly 2 of every 3 flagged accounts are not.
+- Common wrong answer: ~80% (people read the flag as the sensitivity). Wrong because it ignores that high-intent accounts are rare (5% base rate), so the many false positives from the large low-intent pool swamp the true positives.
+
+---
+
+*Note: the value is converting "the model is 80% accurate" into "a flag is right ~30% of the time," which completely changes how Sales should treat flags (triage, not trust). The honest constraint held: the three input rates came from real validation data, not invented numbers - without them the right output would have been "we cannot compute this yet."*

--- a/skills/tfs-natural-frequency-bayesian/references/TEMPLATE.md
+++ b/skills/tfs-natural-frequency-bayesian/references/TEMPLATE.md
@@ -1,0 +1,32 @@
+# Natural-Frequency Breakdown - Template
+
+Fill this in. The deliverable is the frequency tree, posterior, and plain-language meaning, not a bare percentage. Use real input rates; if any is unknown, flag it - do not invent.
+
+---
+
+## Question
+
+- **Posterior asked:** P([condition] | [positive signal]) = ?
+- (Note: this is NOT P([positive signal] | [condition]); state both to avoid the common confusion.)
+
+## Inputs (real, with source - or flagged missing)
+
+- **Base rate** P(condition): [x%] - source: [...]
+- **True-positive (hit) rate** P(positive | condition): [x%] - source: [...]
+- **False-positive rate** P(positive | no condition): [x%] - source: [...]
+
+## Frequency tree (per 1,000)
+
+- Of 1,000: [N] have the condition; [1000-N] do not.
+  - Of the [N] with it: [a] test positive.
+  - Of the [1000-N] without it: [b] also test positive.
+- Total positives: [a + b].
+
+## Posterior
+
+- P(condition | positive) = [a] / [a + b] = **[~Z%]**.
+
+## What it means / the wrong intuition it corrects
+
+- Plain language: [a positive result means the condition is present only ~Z% of the time].
+- Common wrong answer: [usually near the hit rate], wrong because [base-rate neglect].

--- a/skills/tfs-natural-frequency-bayesian/skill.meta.yml
+++ b/skills/tfs-natural-frequency-bayesian/skill.meta.yml
@@ -1,0 +1,75 @@
+# Rich sidecar for the tfs-natural-frequency-bayesian skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.natural-frequency-bayesian
+  slug: natural-frequency-bayesian
+  name: tfs-natural-frequency-bayesian
+  display_name: Natural-Frequency Bayesian Framing
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: reasoning-clarity
+  secondary_families: [decision-and-option-evaluation]
+  thinking_modes: [analytical, critical]
+  problem_contexts: [high-stakes, high-complexity]
+  use_cases:
+    - interpret a test or screening result correctly (medical, fraud, lead-scoring, A/B)
+    - compute "given a positive signal, what is the real probability"
+    - communicate risk so a positive is not over-read
+  poor_fit_cases:
+    - no real input rates available (do not invent them)
+    - no conditional-probability structure to the question
+    - general project forecasting (use reference-class forecasting)
+    - a single point estimate where base rates are irrelevant
+
+interface:
+  required_inputs:
+    - a conditional-probability question with a base rate and hit/false-positive rates
+  optional_inputs:
+    - the population size to frame over
+  primary_artifact_type: natural-frequency-breakdown
+  output_formats: [markdown]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.evidence-vs-inference-sort
+    - thinking-framework-skills.reference-class-forecasting
+
+relationships:
+  often_follows: []
+  often_precedes:
+    - thinking-framework-skills.decision-option-review
+  complements:
+    - thinking-framework-skills.reference-class-forecasting
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - inventing the base rate or hit rates when they are unknown
+    - base-rate neglect (the error the method fixes)
+    - confusing P(positive | condition) with P(condition | positive)
+
+evidence:
+  evidence_tier: "S"
+  confidence: high; the natural-frequency format effect is one of the most robust findings in judgment research
+  transferred_evidence: true
+  lineage:
+    derived_from: [Gigerenzer and Hoffrage natural frequencies]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-natural-frequency-bayesian/SKILL.md
+  references_path: skills/tfs-natural-frequency-bayesian/references/
+  evidence_path: skills/tfs-natural-frequency-bayesian/evidence/dossier.md
+  evals_path: skills/tfs-natural-frequency-bayesian/eval/

--- a/skills/tfs-woop/SKILL.md
+++ b/skills/tfs-woop/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: tfs-woop
+description: Produces a WOOP commitment card by working through Wish, Outcome, Obstacle, and Plan - contrasting the desired outcome against the main internal obstacle and binding an if-then response to it. Use when a goal is already chosen but follow-through keeps failing, or to close the gap between intention and action.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.woop
+  family: risk-and-resilience
+  evidence-tier: "S"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# WOOP (Mental Contrasting with Implementation Intentions)
+
+A decided goal often dies in the gap between intention and action. WOOP closes it with two evidence-backed moves: contrast the desired outcome against the obstacle in your way, then pre-bind an if-then response. Wish (specific, challenging, feasible), Outcome (vividly imagine the best result), Obstacle (the main internal obstacle in yourself), Plan (if [obstacle or its cue], then [action]). The output is a **WOOP card**. Critical: imagining the outcome *without* contrasting the obstacle measurably reduces follow-through - the obstacle and the if-then plan are mandatory, not decoration.
+
+## When to Use
+
+- A goal is already chosen and feasible, but follow-through keeps failing.
+- Closing a personal or single-owner intention-action gap.
+- Turning a commitment into something that survives the moment of temptation or friction.
+
+## When NOT to Use
+
+- To decide *what* to pursue (use a decision skill); WOOP commits to an already-chosen wish.
+- For multi-person project planning (it is about one actor's follow-through).
+- When the obstacle is an external blocker outside your control (WOOP works on internal obstacles).
+- As motivational positive-outcome talk: outcome-only, without the obstacle, backfires.
+
+## Instructions
+
+When asked to run WOOP, follow these steps:
+
+1. **Wish.** State the goal in one line. It should be specific, challenging, and genuinely feasible. If it is not feasible, say so - WOOP will surface disengagement, and that is honest, not a failure.
+2. **Outcome.** Name the single best result of fulfilling the wish, vividly and concretely. One line.
+3. **Obstacle.** Identify the main *internal* obstacle in yourself that stands in the way (a habit, fear, impulse, avoidance), not an external blocker. This is the step that does the work; do not skip it.
+4. **Plan.** Write one or more if-then statements: "If [obstacle or the situation that triggers it], then I will [specific, doable action]." Make the action concrete enough to execute without deciding again.
+5. **Emit the WOOP card** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the four-part card with a concrete if-then plan, not prose or a pep talk.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The Wish is specific, challenging, and feasible (or infeasibility is named honestly).
+- [ ] The Obstacle is internal and controllable, not an external blocker.
+- [ ] The Plan is a concrete if-then statement, not a vague intention.
+- [ ] The obstacle step is present (outcome-only is rejected because it backfires).
+- [ ] The output is the WOOP card artifact, not a motivational essay.
+
+## Evidence
+
+Tier **S**. Mental contrasting with implementation intentions improves goal attainment across 25+ randomized controlled trials in health, academic, and work domains (Oettingen; Gollwitzer; Wang et al. 2021 meta-analysis) - among the best-evidenced behavior-change methods. Note the honest inversion: positive outcome fantasy *without* the obstacle reduces follow-through, so the obstacle and if-then plan are mandatory. The evidence is for humans doing WOOP on their own goals, transferred to AI use, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed WOOP card.

--- a/skills/tfs-woop/eval/cases.md
+++ b/skills/tfs-woop/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-woop
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "I've decided to start exercising before work but I never actually do it. Help me make it stick."
+- "We agreed to run the pilot before building, but I know I'll cave under pressure and just approve the build. Help me commit to following through."
+- "I keep meaning to write the strategy doc and keep not doing it. Set me up to actually get it done this week."
+- "Help me turn 'I want to mentor my reports more' into something I'll actually follow through on."
+- "I want a WOOP plan for sticking to deep-work mornings."
+- "How do I close the gap between deciding to cut scope and actually saying no in the meeting?"
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "Should I learn Spanish or French this year? Help me decide which." (deciding what to pursue, not committing)
+- "Build a project plan with milestones and owners for the Q3 launch across the team." (multi-person planning)
+- "The thing blocking me is that legal won't approve the contract - how do I get them to move?" (external blocker, not internal)
+- "Pump me up - tell me how great it'll be when I hit this goal." (near-miss: outcome-only motivation, which the skill explicitly rejects because it backfires)
+- "Run a premortem on whether my fitness plan will fail." (risk analysis, not commitment)
+- "Summarize my goals for the quarter into a tidy list." (summarization)
+
+## Output checks (a good output must)
+
+- [ ] Produce the four-part card: Wish, Outcome, Obstacle, Plan.
+- [ ] Make the Wish specific, challenging, and feasible (or name infeasibility honestly).
+- [ ] Name an internal, controllable obstacle, not an external blocker.
+- [ ] Give a concrete if-then Plan binding an action to the obstacle/cue.
+- [ ] Include the obstacle step (reject outcome-only framing).
+- [ ] Be the WOOP card artifact, not a motivational essay.
+
+## Value vs unaided baseline
+
+Asked to help with a goal, a strong model defaults to encouraging, positive-outcome talk - which Oettingen's research shows actually *reduces* follow-through. This skill forces the move the model would skip: naming the internal obstacle and binding a concrete if-then plan to it, producing a usable commitment card rather than a pep talk. (Evidence is for humans doing WOOP on their own goals; transferred to AI, not AI-validated.)

--- a/skills/tfs-woop/evidence/dossier.md
+++ b/skills/tfs-woop/evidence/dossier.md
@@ -1,0 +1,64 @@
+# Evidence Dossier: WOOP (Mental Contrasting with Implementation Intentions)
+
+> Single source of truth for the `woop` skill. The SKILL.md, sidecar, and evals derive from this. One of the library's strongest-evidence anchors.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.woop` (installable name `tfs-woop`) |
+| **Family** | risk-and-resilience |
+| **Evidence tier** | **S** (strong; 25+ RCTs) |
+| **Confidence** | High - among the best-evidenced behavior-change methods |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+A decided goal often dies in the intention-action gap. WOOP closes it with two evidence-backed moves run in sequence: **mental contrasting** and **implementation intentions**.
+
+- **W - Wish:** a specific, challenging, and feasible goal.
+- **O - Outcome:** vividly imagine the best result of achieving it (this energizes).
+- **O - Obstacle:** identify the main *internal* obstacle in yourself that stands in the way (this is the move most people skip).
+- **P - Plan:** form an if-then implementation intention - "if [obstacle or its cue occurs], then I will [specific action]."
+
+The contrast between the desired outcome and the present obstacle is what produces energized commitment to feasible goals (and, usefully, disengagement from infeasible ones). The if-then plan pre-binds the response so it fires automatically when the obstacle appears.
+
+**Critical honest point:** positive fantasizing about the outcome *alone* (without contrasting the obstacle) measurably *reduces* follow-through in Oettingen's studies. The obstacle and the if-then plan are not optional - skipping them inverts the effect.
+
+## 2. Lineage
+
+- Gabriele Oettingen (mental contrasting) and Peter Gollwitzer (implementation intentions). "WOOP" is the public-facing name (woopmylife.org).
+
+No trademark on the mechanism. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Strongly supported (the S):** mental contrasting with implementation intentions improves goal attainment across 25+ randomized controlled trials spanning health, academic, and work domains (meta-analytic support, e.g. Wang et al. 2021). This is one of the most robustly evidenced personal behavior-change techniques.
+
+**Boundaries (honest):** the evidence is for *human* goal pursuit and personal behavior. It is a commitment/follow-through tool for a single actor, not a project-planning method for a team, and not a way to decide *what* to want. And the obstacle must be an internal, controllable one; WOOP does not move external blockers.
+
+## 4. Transferred-evidence flag
+
+The strong evidence is for humans doing WOOP on their own goals, not for an AI doing it. Transferred, not AI-validated. The AI value: a model defaults to motivational positive-outcome talk (the exact thing that backfires); this skill forces the obstacle and the if-then plan, and produces a concrete commitment card a person can actually use.
+
+## 5. When it works / when it fails
+
+**Works best when:** a goal is already chosen and feasible but follow-through keeps failing; a personal or single-owner commitment; closing the intention-action gap.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **Skipping the obstacle** and doing only Wish + Outcome - positive fantasy alone reduces action (the central failure mode).
+- Naming an external blocker instead of the internal, controllable obstacle.
+- A vague Plan that is not a concrete if-then.
+- Deciding *what* to pursue (use a decision skill); WOOP commits to an already-chosen wish.
+- Multi-person project planning (it is about one actor's follow-through).
+- An infeasible wish (WOOP will, correctly, surface disengagement - state that honestly rather than forcing commitment).
+
+## 6. Output artifact
+
+A **WOOP card**: Wish (specific, challenging, feasible), Outcome (the best result, vivid, one line), Obstacle (the single main internal obstacle), and Plan (one or more if-then statements binding a concrete action to the obstacle or its cue).
+
+## 7. Sources
+
+1. Oettingen, G. - mental contrasting; *Rethinking Positive Thinking* (2014).
+2. Gollwitzer, P. - implementation intentions.
+3. Wang, G. et al. (2021) - meta-analysis of mental contrasting with implementation intentions.
+
+> **Verification status:** the 25+ RCT / meta-analysis claim and the "positive fantasy alone backfires" finding are well-attested in Oettingen's program; confirm the Wang 2021 specifics against the paper before a public quantified claim.

--- a/skills/tfs-woop/references/EXAMPLE.md
+++ b/skills/tfs-woop/references/EXAMPLE.md
@@ -1,0 +1,32 @@
+# WOOP Card - Worked Example
+
+A completed run of `tfs-woop`, on the shared Northwind scenario. This is the quality bar a generated card should meet.
+
+> Northwind is a B2B SaaS. The analytical skills concluded: run a conversion pilot before building the free tier. Here WOOP commits the PM to actually doing that, against the pressure to just look decisive.
+
+---
+
+## W - Wish
+
+- Run the ICP free-to-paid conversion pilot and review its data before greenlighting any free-tier build - within the next two weeks. (Specific, challenging, feasible.)
+
+## O - Outcome
+
+- We commit budget knowing whether the economics actually work, instead of arguing from opinion under a deadline.
+
+## O - Obstacle
+
+- Internal: under board pressure I feel the pull to look decisive, and my impulse is to approve the build now to show momentum - skipping the pilot I just argued for.
+
+## P - Plan (if-then)
+
+- If I feel the urge to greenlight the build before the pilot data is in, then I will say "the pilot result lands Friday; we decide then" and put the Friday review on the calendar right now.
+- If a stakeholder pushes for a decision in a meeting, then I will point to the scheduled Friday review rather than improvising a yes.
+
+## Feasibility note
+
+- The wish is feasible (a two-week pilot is within reach). If it had not been - say the pilot genuinely could not run before the board date - WOOP would surface that the real choice is "decide without the data or move the date," which is the honest result rather than pretending a rushed pilot will inform the call.
+
+---
+
+*Note: the value is the obstacle step. A motivational version ("imagine the great growth a free tier brings!") would, per the evidence, actually make the PM *less* likely to follow through. Naming the internal obstacle (the pull to look decisive) and pre-binding the if-then response is what protects the decision the other skills reached.*

--- a/skills/tfs-woop/references/TEMPLATE.md
+++ b/skills/tfs-woop/references/TEMPLATE.md
@@ -1,0 +1,26 @@
+# WOOP Card - Template
+
+Fill this in. The deliverable is the four-part card with a concrete if-then plan, not prose. The Obstacle and Plan are mandatory; outcome-only backfires.
+
+---
+
+## W - Wish
+
+- [one line: specific, challenging, feasible. If not feasible, say so.]
+
+## O - Outcome
+
+- [the single best result of fulfilling the wish, vivid and concrete, one line]
+
+## O - Obstacle
+
+- [the main INTERNAL obstacle in yourself - a habit, fear, impulse, avoidance - not an external blocker]
+
+## P - Plan (if-then)
+
+- If [the obstacle, or the situation/cue that triggers it], then I will [a specific, doable action].
+- (Optional second if-then for a recurring cue.)
+
+## Feasibility note
+
+- [If the wish turned out infeasible: state that WOOP surfaced disengagement, and why that is the honest result rather than forcing commitment.]

--- a/skills/tfs-woop/skill.meta.yml
+++ b/skills/tfs-woop/skill.meta.yml
@@ -1,0 +1,77 @@
+# Rich sidecar for the tfs-woop skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.woop
+  slug: woop
+  name: tfs-woop
+  display_name: WOOP (Mental Contrasting + Implementation Intentions)
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: risk-and-resilience
+  secondary_families: [meta-thinking-and-reflection]
+  thinking_modes: [reflective, counterfactual]
+  problem_contexts: [high-friction]
+  use_cases:
+    - close the intention-action gap on an already-chosen goal
+    - turn a personal or single-owner commitment into something that survives friction
+    - pre-bind an if-then response to the main internal obstacle
+  poor_fit_cases:
+    - deciding what to pursue (use a decision skill)
+    - multi-person project planning
+    - obstacles that are external blockers outside one's control
+    - outcome-only positive fantasy (it backfires)
+
+interface:
+  required_inputs:
+    - an already-chosen, feasible goal/wish
+  optional_inputs:
+    - the known obstacle, the deadline
+  primary_artifact_type: woop-card
+  output_formats: [markdown]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.decision-option-review
+    - thinking-framework-skills.premortem
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.decision-option-review
+    - thinking-framework-skills.premortem
+  often_precedes: []
+  complements:
+    - thinking-framework-skills.premortem
+  overlaps_with: []
+  variants:
+    - "named protocol: WOOP (Wish-Outcome-Obstacle-Plan)"
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - skipping the obstacle (outcome-only positive fantasy, which backfires)
+    - naming an external blocker instead of the internal obstacle
+    - a vague plan that is not a concrete if-then
+
+evidence:
+  evidence_tier: "S"
+  confidence: high; among the best-evidenced behavior-change methods (25+ RCTs)
+  transferred_evidence: true
+  lineage:
+    derived_from: [Oettingen mental contrasting, Gollwitzer implementation intentions]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-woop/SKILL.md
+  references_path: skills/tfs-woop/references/
+  evidence_path: skills/tfs-woop/evidence/dossier.md
+  evals_path: skills/tfs-woop/eval/


### PR DESCRIPTION
Adds the 6 strongest-evidence methods the MVP skipped, taking the catalog to **20 skills, 9 at S/S-M tier**. This is the move the audit said hardens the moat: evidence-grading is the differentiator, and the MVP consensus roster had skipped the best-evidenced methods.

- **`tfs-argument-mapping`** (S; van Gelder ES ~0.7-0.85) - argument map; honest "single map != course effect" caveat.
- **`tfs-woop`** (S; Oettingen, 25+ RCTs) - commitment card; honest "outcome-only fantasy backfires" caveat; the library's first follow-through skill.
- **`tfs-authentic-dissent`** (S; Nemeth) - dissent audit; honest that an AI *cannot* supply authentic dissent (only engineer for it), complementing `red-team-light`'s constructed critique.
- **`tfs-after-action-review`** (S/M; Tannenbaum & Cerasoli ES ~0.79) - opens the reflection family.
- **`tfs-far-analogy-ideation`** (S; Gentner) - first S-tier ideation method; guards the surface-mapping failure mode.
- **`tfs-natural-frequency-bayesian`** (S; Gigerenzer) - refuses to fabricate input rates.

Each built through `AUTHORING.md` (6-file unit incl. eval cases), each on the shared Northwind thread, all validated `Tier universal, 0/0`. Backlog + AGENTS catalog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)