### PR TITLE
v0.4 coverage (8 skills -> 28) + master framework catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,16 @@ Each skill is built around four commitments, not just a prompt:
 | [`tfs-after-action-review`](skills/tfs-after-action-review/SKILL.md) | meta-thinking-and-reflection | S/M | after-action review |
 | [`tfs-far-analogy-ideation`](skills/tfs-far-analogy-ideation/SKILL.md) | divergent-ideation | **S** | far-analogy transfer sheet |
 | [`tfs-natural-frequency-bayesian`](skills/tfs-natural-frequency-bayesian/SKILL.md) | reasoning-clarity | **S** | natural-frequency breakdown |
+| [`tfs-issue-tree`](skills/tfs-issue-tree/SKILL.md) | reasoning-clarity | P | issue tree (MECE) |
+| [`tfs-affinity-mapping`](skills/tfs-affinity-mapping/SKILL.md) | synthesis | P | clustered theme map |
+| [`tfs-pyramid-principle`](skills/tfs-pyramid-principle/SKILL.md) | synthesis | P | answer-first pyramid |
+| [`tfs-abstraction-laddering`](skills/tfs-abstraction-laddering/SKILL.md) | problem-framing | P | abstraction ladder |
+| [`tfs-one-way-vs-two-way-door`](skills/tfs-one-way-vs-two-way-door/SKILL.md) | decision-and-option-evaluation | P | reversibility classification |
+| [`tfs-decision-journal`](skills/tfs-decision-journal/SKILL.md) | meta-thinking-and-reflection | P | decision journal entry |
+| [`tfs-iceberg-model`](skills/tfs-iceberg-model/SKILL.md) | systems-and-consequences | P | iceberg (4 levels) |
+| [`tfs-backcasting`](skills/tfs-backcasting/SKILL.md) | risk-and-resilience | P | backcast path |
 
-20 skills, 9 at **S**/S-M tier (the strong-evidence anchors). "(flag)" marks skills with a documented evidence or trademark caveat in their dossier.
+28 skills, 9 at **S**/S-M tier (the strong-evidence anchors). "(flag)" marks skills with a documented evidence or trademark caveat in their dossier. See `docs/internal/research/framework-catalog.md` for the full framework universe and roadmap.
 
 ## Recipes
 

--- a/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
+++ b/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
@@ -4,7 +4,7 @@ The single source of "what to build next." WIP = 1: build the **Now** skill end 
 
 ## Now
 
-> **20 skills shipped (MVP 14 + empirical core 6) + 4 recipes + eval cases for every skill, all validated (Tier universal, 0/0).** The empirical core is now complete: 9 of the 20 are S/S-M tier. Next build action: the **v0.4 coverage tranche** (fill the still-empty families - see below), and/or the Silver climb and the go-public flip (both gated on your go).
+> **28 skills shipped (MVP 14 + empirical core 6 + coverage 8) + 4 recipes + eval cases for every skill, all validated (Tier universal, 0/0).** 9 are S/S-M tier; the empty families (synthesis, reflection) are now filled. The skill build-out is essentially complete for v0.x. Next: the Silver climb and the go-public flip (both gated on your go). See `docs/internal/research/framework-catalog.md` for the full framework universe and what remains as future candidates.
 
 ## Build order
 

--- a/docs/internal/research/framework-catalog.md
+++ b/docs/internal/research/framework-catalog.md
@@ -1,0 +1,233 @@
+# Framework Catalog (master, prioritized)
+
+A single, simplified, complete, and prioritized list of every thinking framework in scope, synthesized from the discovery meta-analyses (`_local/initial-discovery/meta-analysis_claude-opus_*`) and the README candidate universe, then **expanded** with methods the meta-analyses did not cover.
+
+- **Taxonomy:** the 11 cognitive-operation families (Claude Opus's landscape, the recommended foundation).
+- **Evidence tiers (7-tier model):** **S** strong research · **M** moderate · **P** practitioner · **V** vendor/commercial · **A** anecdotal · **C** conceptually plausible, under-tested · **X** poor/contradictory.
+- **Status legend:**
+  - `[shipped]` - built and validated (28 skills, Tier universal 0/0).
+  - `[next]` - strongest unbuilt candidates (build these first; S/M evidence or cross-LLM consensus, and distinct).
+  - `[cand]` - candidate (clears the bar but lower priority / P-tier coverage).
+  - `[fold]` - subsumed: ship as a mode/sub-skill of an existing skill, not standalone.
+  - `[flag]` - include only with explicit "when not to use" / trademark / false-precision caveats.
+  - `[pm]` - defer to `pm-skills` (PM/domain-specific, not cross-domain cognitive).
+  - `[excl]` - exclude or workshop-reference only (weak evidence, social-only, or redundant).
+
+The honest core (from the meta-analyses): the field is a small **empirical core** surrounded by a large **practitioner ring** and a weak **outer ring**. The catalog labels which is which rather than flattening them.
+
+---
+
+## Priority summary (what to build next, in order)
+
+The skill build-out for v0.x is essentially complete (28 skills). If the catalog grows further, this is the recommended order:
+
+1. **Strong-evidence / consensus unbuilt `[next]`:** `stocks-and-flows-reasoning` (S, Sterman), `concept-mapping` (cross-LLM consensus first-class), `first-principles` (scope tightly), `causal-loop-diagrams` (M), `key-assumptions-check`, `fermi-estimation` (expansion), `double-crux` (expansion).
+2. **Solo-plus-AI reflection `[next]`:** `belief-update-routine`, `idea-quality-audit` (uniquely fit the primary user mode).
+3. **P-tier coverage `[cand]`:** the remaining `[cand]` rows below, as demand warrants.
+4. **Never (this repo):** the `[fold]`, `[flag]`, `[pm]`, and `[excl]` rows - documented here so the exclusion is deliberate, not accidental.
+
+The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference-class-forecasting, argument-mapping, WOOP/MCII, authentic-dissent, after-action-review, natural-frequency-bayesian, far-analogy-ideation, plus stocks-and-flows-reasoning and mechanical/linear-model aggregation (the last two unbuilt). **9 of 11 are shipped.**
+
+---
+
+## 1. Perspective-shifting and multi-lens
+
+| Framework | Mechanism (one line) | Tier | Status |
+|---|---|---|---|
+| Parallel Perspectives Review | examine a decision through separated lenses (facts/upside/risk/intuition/alternatives/process) | P | `[shipped]` |
+| Red Team / Blue Team | construct the strongest adversarial case against a thesis | P | `[shipped]` (as `red-team-light`) |
+| Stakeholder Lens Review | walk a proposal through each affected party's eyes | P | `[fold]` -> stakeholder mode of parallel-perspectives |
+| Steelmanning | state the strongest version of an opposing view before responding | P | `[fold]` -> core move of red-team-light |
+| Six Thinking Hats | branded parallel-thinking ritual | P/X | `[flag]` mechanism shipped as parallel-perspectives; trademark, weak branded evidence |
+| Role-storming | generate ideas while adopting another identity | P | `[cand]` |
+| Outside-in / Inside-out framing | alternate market view and capability view | P | `[cand]` |
+| Disney Creative Strategy | dreamer/realist/critic cycle | A | `[excl]` redundant with parallel-perspectives |
+
+## 2. Divergent ideation and idea expansion
+
+| Framework | Mechanism | Tier | Status |
+|---|---|---|---|
+| Brainwriting 6-3-5 / NGT | silent parallel written generation + build-on | **S** | `[shipped]` |
+| Far-analogy ideation | transfer deep structure from distant domains | **S** | `[shipped]` |
+| SCAMPER | seven transformation prompts on a seed idea | P | `[shipped]` |
+| Question Burst | rapid questions-only burst, then rank + pick | P | `[shipped]` |
+| Assumption Reversal | negate foundational premises to generate options | P | `[shipped]` |
+| Morphological analysis | enumerate the solution space by parameter combination | P | `[cand]` |
+| Worst possible idea / reverse brainstorming | generate bad ideas, then invert | P | `[cand]` (relates to inversion) |
+| Crazy 8s | eight sketches in eight minutes | P | `[fold]` -> a timeboxed mode of brainwriting/scamper |
+| Lotus Blossom | expand a center into 8 sub-themes, recurse | P | `[cand]` (spatial; markdown-limited) |
+| Forced connections / Random stimulus | pair the problem with an unrelated stimulus | P | `[fold]` -> a mode of far-analogy ideation |
+| Alternate uses / Constraint insertion-removal | loosen functional fixedness; add/strip a constraint | P | `[cand]` |
+
+## 3. Problem framing and reframing
+
+| Framework | Mechanism | Tier | Status |
+|---|---|---|---|
+| Problem Restatement | rewrite the problem several ways, pick a better frame | M/P | `[shipped]` |
+| Abstraction Laddering | move up (why) and down (how) to the right altitude | P | `[shipped]` |
+| First Principles Thinking | decompose to fundamental truths, reason up | P/C | `[next]` (scope tightly to avoid "think harder") |
+| How Might We | turn an insight into an opportunity question | P | `[fold]` -> output of problem-restatement |
+| Is / Is Not analysis | sharpen scope by what the problem is and is not | P | `[fold]` -> a problem-restatement move |
+| Frame storming | brainstorm the framing, not the solution | P | `[fold]` -> problem-restatement |
+| Five Whys | iterative why to trace a cause | P/X | `[flag]` simple linear failures only (Card 2017) |
+
+## 4. Assumption and belief challenge
+
+| Framework | Mechanism | Tier | Status |
+|---|---|---|---|
+| Argument Mapping | diagram claim, reasons, co-premises, objections | **S** | `[shipped]` |
+| Authentic Dissent | engineer for genuine minority dissent (not role-played) | **S** | `[shipped]` |
+| Natural-frequency Bayesian framing | re-express conditional probabilities as frequencies | **S** | `[shipped]` |
+| Evidence vs Inference Sort | label claims evidence / inference / assumption | P | `[shipped]` |
+| Ladder of Inference Check | reconstruct the climb from data to conclusion | P | `[shipped]` |
+| What Would Have to Be True | turn a claim into testable conditions | P | `[shipped]` (also family 5/7) |
+| Key Assumptions Check / Assumption Mapping | inventory and rank a plan's assumptions | P | `[next]` (intelligence-analysis staple; watch overlap with WWHTBT) |
+| Cognitive bias checklist | run a decision against relevant biases | P | `[cand]` |
+| Inversion | ask how to guarantee failure, then avoid it | P | `[cand]` (overlaps assumption-reversal + premortem) |
+| Counterfactual reasoning | examine "what if X had been different" | P | `[cand]` |
+| Devil's Advocacy | assign someone to argue against | P/X | `[flag]` role-played dissent underperforms (Nemeth); shipped intent via authentic-dissent |
+
+## 5. Risk, failure, and resilience
+
+| Framework | Mechanism | Tier | Status |
+|---|---|---|---|
+| Premortem | imagine the plan failed, work back to causes | S/M | `[shipped]` |
+| Reference Class Forecasting | anchor an estimate on the base rate of comparable cases | **S** | `[shipped]` |
+| WOOP / MCII | wish-outcome-obstacle-plan with an if-then | **S** | `[shipped]` |
+| Backcasting | from a desired future, work back to the path | P | `[shipped]` |
+| FMEA-lite | list failure modes by likelihood x severity x detection | P | `[cand]` (overlaps premortem) |
+| Kill criteria / Tripwires | pre-decided stop signals and conditions | P | `[fold]` -> inside premortem's register |
+| Regret minimization | choose the least-future-regret option | P | `[cand]` |
+| Pre-commitment / Ulysses contract | bind future behavior in advance | P | `[cand]` (expansion; relates to WOOP/tripwires) |
+
+## 6. Systems and consequences
+
+| Framework | Mechanism | Tier | Status |
+|---|---|---|---|
+| Futures Wheel | map first/second/third-order consequences outward | P | `[shipped]` |
+| Iceberg Model | events -> patterns -> structures -> mental models | P | `[shipped]` |
+| Stocks and Flows reasoning | reason about accumulations and rates | **S** | `[next]` (Sterman; people systematically misjudge these) |
+| Causal Loop Diagrams | diagram reinforcing/balancing feedback loops | M/C | `[next]` (visual; markdown approximates) |
+| Second-Order Effects | lightweight "and then what?" prompt | P | `[fold]` -> mode of futures-wheel |
+| Systems map / Leverage points | sketch elements/relationships; find intervention points | P/C | `[cand]` |
+| Three Horizons | present / transition / emerging future | C | `[cand]` (foresight) |
+| Causal Layered Analysis | litany / system / worldview / myth layers | C | `[cand]` (foresight) |
+| Theory of Constraints | find and exploit the system bottleneck | P | `[cand]` (expansion) |
+| Fishbone / Ishikawa | structured multi-cause diagram | P | `[cand]` (expansion; the meta-analysis's recommended why-chain upgrade) |
+
+## 7. Decision and option evaluation
+
+| Framework | Mechanism | Tier | Status |
+|---|---|---|---|
+| Decision Option Review | compare options against weighted criteria | P | `[shipped]` |
+| One-way vs Two-way Door | classify by reversibility, match deliberation | P | `[shipped]` |
+| Decision Journal | record decision + expectation + confidence for calibration | P | `[shipped]` (also family 11) |
+| Multi-Criteria Decision Analysis | weighted scoring across criteria | P | `[fold]` == decision-option-review |
+| Decision Brief / PR-FAQ | force a decision into a short structured memo | P | `[cand]` (overlaps pyramid-principle) |
+| Pairwise comparison | compare two at a time to rank fuzzy criteria | P | `[cand]` |
+| Expected-value / decision-tree | weigh outcomes by probability x magnitude | M | `[cand]` (expansion: formal EV/decision trees) |
+| Minimax regret | minimize worst-case regret | P | `[cand]` |
+| Fermi estimation | structured order-of-magnitude estimate from decomposition | P/M | `[next]` (expansion; high utility, no current coverage) |
+| Eisenhower / MoSCoW / Pareto | urgent-important triage; vital-few focus | P | `[cand]` (expansion; prioritization) |
+| Kepner-Tregoe | structured problem + decision analysis | P | `[cand]` (expansion) |
+| Cynefin | sort clear/complicated/complex/chaotic | C | `[flag]` cargo-cult risk; trademark |
+| ICE / RICE / WSJF | prioritization scores | V/P | `[flag]` false-precision warning |
+| OODA Loop | observe-orient-decide-act | P | `[excl]` better as agent loop architecture than a skill |
+
+## 8. Strategy and opportunity
+
+> This family is the weakest fit for a cross-domain cognitive library; most entries are PM/business-domain and defer to `pm-skills`.
+
+| Framework | Mechanism | Tier | Status |
+|---|---|---|---|
+| Opportunity-Solution Tree | outcome -> opportunities -> solutions | P | `[pm]` (Teresa Torres; product discovery) |
+| Value proposition contrast | sharpen vs the next-best alternative | P | `[pm]` |
+| White-space / adjacent-possible / 10x-vs-incremental | locate uncontested or reachable opportunity | P/C | `[cand]` |
+| Moat / defensibility lens | test what stops a competitor copying you | P | `[cand]` |
+| Scenario planning | construct multiple plausible futures (2x2) | C/M | `[cand]` (expansion; foresight; evidence thin) |
+| PEST(LE) | scan macro-environmental forces | P | `[cand]` (expansion) |
+| Jobs To Be Done | frame demand as progress sought | P | `[flag]` multi-school ambiguity; `[pm]` |
+| Wardley Mapping | value chain vs evolution | C | `[flag]` CC BY-SA; cargo-cult |
+| Blue Ocean tools | strategy canvas / four actions | V | `[flag]` registered marks |
+| Porter's Five Forces | competitive-structure scan | V/P | `[flag]` (expansion) `[pm]` |
+| SWOT | strengths/weaknesses/opportunities/threats | X | `[excl]` legacy reference only (Hill & Westbrook critique) |
+
+## 9. Synthesis and reasoning clarity
+
+| Framework | Mechanism | Tier | Status |
+|---|---|---|---|
+| Issue Trees | decompose a question into a MECE tree | P | `[shipped]` |
+| Affinity Mapping | cluster many notes into emergent themes (bottom-up) | P | `[shipped]` |
+| Pyramid Principle | answer-first governing thought + grouped support | P | `[shipped]` |
+| MECE decomposition | mutually-exclusive, collectively-exhaustive split | P | `[fold]` -> principle inside issue-tree |
+| Concept Mapping | diagram concepts and labeled relationships | M/P | `[next]` (cross-LLM consensus first-class) |
+| Dialectical synthesis | hold thesis/antithesis to a stronger synthesis | C | `[cand]` |
+| Contradiction / tension mapping | surface central tensions rather than smoothing | C | `[cand]` |
+| Insight statement generation | turn observations into sharp transferable insights | P | `[cand]` |
+| Sensemaking matrix | organize conflicting signals for interpretation | C | `[cand]` |
+
+## 10. Facilitation and group structures
+
+> Mostly NOT first-class agent skills: their value is in human social dynamics an AI cannot reproduce. A future "workshop-support" track could let the agent help with prep, capture, and synthesis.
+
+| Framework | Mechanism | Tier | Status |
+|---|---|---|---|
+| Silent writing before discussion | write independently first to prevent anchoring | M | `[fold]` -> the mechanism is in brainwriting |
+| Note-and-vote / Decider supervote | individual notes, then vote / weighted decider | P | `[cand]` (agent can support capture) |
+| Dot voting | allocate limited votes | P | `[flag]` herding caveats |
+| 1-2-4-All / Round-robin / Lean Coffee / World Cafe / Open Space | scaled-participation group formats | P | `[excl]` workshop-reference (social dynamics) |
+
+## 11. Meta-thinking and reflection
+
+| Framework | Mechanism | Tier | Status |
+|---|---|---|---|
+| After Action Review | expected vs actual -> why -> sustain/change | S/M | `[shipped]` |
+| Decision Journal | record now for honest later calibration | P | `[shipped]` |
+| Belief-update routine | periodically revisit and update key beliefs vs new evidence | P | `[next]` (solo-plus-AI fit) |
+| Idea-quality audit | score and pressure-test a batch of ideas (solo + AI) | P | `[next]` (solo-plus-AI fit) |
+| What / So What / Now What | observation -> meaning -> action | P | `[cand]` |
+| PDCA / A3 | plan-do-check-act improvement loop | P | `[cand]` (expansion; overlaps AAR) |
+| Socratic self-questioning | disciplined self-interrogation of a belief | P | `[cand]` (expansion) |
+| Plus/Delta · Start/Stop/Continue · Rose/Thorn/Bud | fast retro formats | A/P | `[fold]` -> retro modes (one skill or AAR variants) |
+
+---
+
+## Expansion: frameworks the meta-analyses did not cover
+
+Added here as genuinely additive (not folds of existing skills). Provisional tiers; each still has to clear the four commitments + the ~20% overlap ceiling before it ships.
+
+| Framework | Family | Mechanism | Tier | Note |
+|---|---|---|---|---|
+| Fermi estimation | decision | decompose an unknown into estimable factors for an order-of-magnitude answer | P/M | high utility for AI; no current coverage; `[next]` |
+| Double-crux | assumption-challenge | find the single belief whose change would flip each side of a disagreement | C/P | modern (CFAR); resolves disagreements; distinct from red-team/dissent |
+| Theory of Constraints | systems | find the binding bottleneck and exploit/elevate it | P | distinct systems-intervention lens |
+| Fishbone / Ishikawa | systems | structured multi-cause diagram (the meta-analysis's recommended Five-Whys upgrade) | P | fills the multi-cause gap Five-Whys leaves |
+| Scenario planning | strategy/foresight | construct 2-4 plausible distinct futures and stress strategy across them | C/M | distinct from futures-wheel (consequences) and backcasting (path); evidence thin |
+| Pre-commitment / Ulysses contract | risk | bind future behavior in advance against known weakness | P | complements WOOP and premortem tripwires |
+| Expected-value / decision trees | decision | formal probability x magnitude over branches | M | the quantitative complement to decision-option-review |
+| Eisenhower / Pareto / MoSCoW | decision | urgent-important and vital-few prioritization triage | P | simple, high-frequency; could be one "prioritization" skill |
+| PEST(LE) | strategy | scan macro forces (political/economic/social/technological/legal/environmental) | P | macro complement; partly `[pm]` |
+| Kepner-Tregoe | decision | structured situation/problem/decision/potential-problem analysis | P | comprehensive but heavy |
+| PDCA / A3 | reflection | structured improvement loop / one-page problem-solving | P | overlaps AAR; consider as AAR variants |
+| Mechanical / linear-model aggregation | decision | combine cues with a simple fixed formula instead of holistic judgment | **S** | named empirical core (Meehl lineage); strong evidence, unbuilt - promote to `[next]` |
+
+> Note: **mechanical/linear-model aggregation** is from the meta-analyses' named empirical core (it was in the landscape's core list), but no skill exists yet. Given its S-tier evidence (clinical-vs-actuarial judgment literature), it belongs in the `[next]` strong-evidence tier alongside stocks-and-flows.
+
+---
+
+## Deliberate exclusions (with reasons)
+
+Documented so the absence is a decision, not an oversight:
+
+- **SWOT** - weak/contradictory evidence (Hill & Westbrook 1997); legacy reference only.
+- **MBTI-style perspective frames** - psychometric validity critiques (Pittenger).
+- **Unstructured verbal brainstorming** - ~40 years of replication failure vs nominal/brainwriting groups.
+- **Buzan-brand mind mapping** - brain-hemisphere claims unsupported (Farrand 2002).
+- **Generic 2x2 strategy matrices** - low distinctiveness, false rigor.
+- **Most Liberating Structures rituals** (1-2-4-All, Open Space, Lean Coffee, World Cafe) - value is social; AI cannot reproduce it; workshop-reference track only.
+- **OODA Loop as a user skill** - more useful as the agent's own loop architecture.
+- **Opportunity-Solution Tree, JTBD, Value-Prop tools, Porter** - PM/business-domain; belong in `pm-skills` per the sibling split.
+
+---
+
+*Sources: `_local/initial-discovery/meta-analysis_claude-opus_{1-validation,2-landscape,3-architecture,4-portfolio,5-naming}.md` (the landscape file is the ~110-method master catalog + 7-tier model + named empirical core), the README candidate universe, and the shipped `skills/` tree. The raw corpus is kept private (see this folder's README); this catalog is the synthesized, committable view.*

--- a/library.json
+++ b/library.json
@@ -30,7 +30,15 @@
       { "name": "tfs-authentic-dissent", "path": "skills/tfs-authentic-dissent/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-after-action-review", "path": "skills/tfs-after-action-review/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-far-analogy-ideation", "path": "skills/tfs-far-analogy-ideation/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
-      { "name": "tfs-natural-frequency-bayesian", "path": "skills/tfs-natural-frequency-bayesian/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
+      { "name": "tfs-natural-frequency-bayesian", "path": "skills/tfs-natural-frequency-bayesian/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-issue-tree", "path": "skills/tfs-issue-tree/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-affinity-mapping", "path": "skills/tfs-affinity-mapping/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-pyramid-principle", "path": "skills/tfs-pyramid-principle/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-abstraction-laddering", "path": "skills/tfs-abstraction-laddering/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-one-way-vs-two-way-door", "path": "skills/tfs-one-way-vs-two-way-door/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-decision-journal", "path": "skills/tfs-decision-journal/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-iceberg-model", "path": "skills/tfs-iceberg-model/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-backcasting", "path": "skills/tfs-backcasting/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
     ]
   },
   "repository": "https://github.com/product-on-purpose/thinking-framework-skills",

--- a/skills/tfs-abstraction-laddering/SKILL.md
+++ b/skills/tfs-abstraction-laddering/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: tfs-abstraction-laddering
+description: Builds an abstraction ladder that moves a problem up ("why / to what end?") and down ("how / what specifically?") to locate the right altitude to work at, then marks one rung as the working level. Use when a problem is stated as a bare solution with an unstated purpose, as a vague aspiration with no concrete handle, when people are arguing past each other at different levels, or before committing effort at an altitude nobody chose on purpose.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.abstraction-laddering
+  family: problem-framing
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Abstraction Laddering
+
+Every problem arrives at some altitude, and the altitude is usually accidental: it is wherever someone happened to be standing when they noticed it. Too low and you optimize a detail that does not matter ("make the button blue"); too high and you produce a true but useless aspiration ("delight the customer"). Abstraction laddering moves the problem along one vertical axis - up by asking "why? / to what end?" and down by asking "how? / what specifically?" - to find the altitude at which it is actually workable. The output is an **abstraction ladder**, an ordered set of rungs with one chosen as the working level, not a discussion.
+
+## When to Use
+
+- A request names a bare solution ("add a dashboard", "build an integration") but the purpose it serves is unstated.
+- A problem is stated as a vague aspiration ("improve engagement", "be more strategic") with no concrete handle to act on.
+- People are arguing past each other and may simply be working at different levels of the same problem.
+- Before committing effort, to decide deliberately at what altitude to attack a problem rather than inheriting the accidental one.
+
+## When NOT to Use
+
+- **Altitude is not the issue.** If the problem needs a different kind of reframing - a stakeholder shift, an inversion, an is/is-not boundary, or weighing several rival framings - use `tfs-problem-restatement`, which generates those moves and converges on a chosen frame. This skill only moves up and down one axis.
+- **The right level is already clear and agreed.** Building a ladder for a well-located problem manufactures motion and wastes effort.
+- **To generate or choose solutions.** Going down lists more concrete sub-problems to consider, not a chosen solution. Use an ideation skill (Question Burst, SCAMPER) to generate and a decision skill (Decision Option Review) to choose.
+- **To decompose a problem into all its parts.** A ladder is a single vertical chain, not a branching breakdown. For that, use an issue tree.
+
+## Instructions
+
+When asked to find the right altitude for a problem, follow these steps:
+
+1. **Capture the entry rung.** Record the problem exactly as given, in one line. This is where the ladder starts; mark it as the entry rung. If the altitude is already clear and agreed, say so and stop.
+2. **Climb up: ask "why? / to what end?"** Repeatedly replace the current rung with the broader purpose it serves ("we do this so that..."). Each step up should be a genuine purpose, not a reword. Stop climbing when the next rung is so broad it would be true of almost any project (that rung is too high to work at).
+3. **Descend: ask "how? / what specifically?"** From the entry rung, repeatedly replace the current rung with a more concrete instance or sub-problem ("concretely, that means..."). Note where a rung has more than one plausible "how"; that fork is a signal there are options at that altitude. Stop descending when a rung is so specific it is a single implementation detail.
+4. **Lay out the ladder.** Order all rungs from most abstract (top) to most concrete (bottom) as a single vertical chain. Keep the why-relationship reading upward and the how-relationship reading downward explicit. Do not let it sprawl sideways into a pile of loosely related ideas; that is a different artifact.
+5. **Select the working altitude.** Choose exactly one rung as the level to actually work the problem at - high enough to leave room for real options, low enough to be actionable - and give a one- or two-sentence rationale tied to the user's actual goal. Converge; a ladder with no chosen rung is incomplete.
+6. **Emit the abstraction ladder.** Produce the artifact in `references/TEMPLATE.md`: a short summary above an ordered ladder with the entry rung marked and the working rung selected.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the filled ladder plus its summary, with one rung chosen as the working altitude, not a prose essay.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The entry rung (problem as given) is captured verbatim and marked on the ladder.
+- [ ] Up-steps are genuine purposes ("why / to what end"), not rewordings; down-steps are genuinely more concrete ("how / what specifically").
+- [ ] The ladder is a single vertical chain ordered abstract-to-concrete, not a sideways pile of related ideas or a branching decomposition.
+- [ ] Climbing stopped before the uselessly-universal rung, and descending stopped before bare implementation detail.
+- [ ] Exactly one rung is selected as the working altitude, with a rationale tied to the user's actual goal.
+- [ ] The output is the ladder artifact, not prose.
+- [ ] No overclaiming: the skill makes the altitude choice explicit and deliberate; it does not guarantee a better solution or a correct level (see `evidence/dossier.md`).
+
+## Evidence
+
+Tier **P** (practitioner). That how a problem is framed - including at what level of abstraction - affects the solutions found has moderate support in the problem-framing literature (problem-finding research; Nutt on decision failure from poor definition; Wedell-Wedellsborg, HBR 2017), and abstraction is a well-described dimension of language (Hayakawa, *Language in Thought and Action*, 1939). But there is **no controlled study** isolating "abstraction laddering" as a named technique against a baseline; it is a widely-taught design-facilitation method with face validity and a clear mechanism, not a measured one. The supporting evidence concerns framing in general, not this exercise specifically, and is transferred from human practice, not AI-validated. Full grading, sources, and caveats: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed abstraction ladder on a real decision.

--- a/skills/tfs-abstraction-laddering/eval/cases.md
+++ b/skills/tfs-abstraction-laddering/eval/cases.md
@@ -1,0 +1,33 @@
+# Eval cases: tfs-abstraction-laddering
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (a harness is deferred to the Silver climb); these are the cases to check by hand, or to wire into evals later.
+
+## Should trigger
+
+- "Leadership told us to 'build a mobile app.' I don't think that's really the problem - help me figure out what level we should actually be solving at."
+- "Our goal this quarter is 'improve engagement.' That's too vague to do anything with. Can we get it down to something concrete and actionable?"
+- "Engineering wants to talk about the caching layer and the execs want to talk about 'being more customer-centric.' We keep talking past each other - are we just at different levels of the same problem?"
+- "We've been handed 'add a dashboard' as the requirement. Before we scope it, I want to know what it's actually in service of and whether a dashboard is even the right altitude."
+- "Walk this problem up and down the abstraction ladder so I can pick the right level to attack it."
+- "Is 'launch a free tier' the actual problem, or a solution we've assumed? Move it up to the goal and down to specifics so I can see."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "This problem is fuzzy and I want a few genuinely different ways to frame it - shift the stakeholder, invert it, bound what it is and isn't - then pick one to work on." (near-miss: this is `tfs-problem-restatement`; it generates several framing moves and converges, while laddering only moves up and down the altitude axis.)
+- "We agree the problem is 'reduce checkout abandonment at the payment step' and that's the right level. Now break it into its component sub-problems so we can assign owners." (decomposition into all parts -> issue tree, not a single vertical chain.)
+- "We've settled on the right problem. Now give me a bunch of creative solution ideas for it." (ideation, not altitude.)
+- "We have three framings on the table and need to pick which one to fund." (decision/option comparison, not laddering.)
+- "Summarize what the team shipped this sprint for a status update." (unrelated.)
+
+## Output checks (a good output must)
+
+- [ ] Capture the problem as given, verbatim, and mark it as the entry rung on the ladder.
+- [ ] Climb up with genuine "why / to what end" purposes and descend with genuinely more concrete "how / what specifically" rungs, not rewordings.
+- [ ] Present a single vertical ladder ordered abstract-to-concrete, flagging the too-high (uselessly universal) and too-low (bare detail) rungs - not a sideways pile or a branching tree.
+- [ ] Select exactly one rung as the working altitude, with a rationale tied to the user's actual goal.
+- [ ] Deliver the abstraction-ladder artifact (ordered ladder + short summary), not prose.
+- [ ] Not claim a better solution or a guaranteed-correct level; limit the claim to making the altitude choice explicit and deliberate.
+
+## Value vs unaided baseline
+
+Unprompted, a strong model tends to accept the problem at the altitude it was handed and start solving there - designing the dashboard, listing engagement tactics - so it inherits the accidental level instead of choosing one. When it does abstract, it often drifts sideways into loosely related ideas rather than holding a clean why-up / how-down chain, and rarely commits to a single working rung. This skill forces the vertical interrogation in both directions, keeps the ladder a single ordered chain, marks the entry rung, requires selecting one working altitude with a goal-tied rationale, and holds the honest practitioner-grade caveat that it locates the level rather than guaranteeing the answer.

--- a/skills/tfs-abstraction-laddering/evidence/dossier.md
+++ b/skills/tfs-abstraction-laddering/evidence/dossier.md
@@ -1,0 +1,81 @@
+# Evidence Dossier: Abstraction Laddering
+
+> The single source of truth for the `abstraction-laddering` skill. The `SKILL.md`, the sidecar
+> (`skill.meta.yml`), and the eval cases all derive from this file. If a claim is not
+> here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.abstraction-laddering` (installable name `tfs-abstraction-laddering`) |
+| **Family** | problem-framing |
+| **Evidence tier** | **P** (practitioner; useful, limited controlled evidence - see "What the evidence shows") |
+| **Confidence** | Moderate that the move helps locate the working altitude; low that any specific effect size is established |
+| **Status** | draft (first authored 2026-05-31, against discovery corpus) |
+
+---
+
+## 1. The mechanism (what actually does the work)
+
+A problem is always stated at *some* altitude, and the altitude is usually accidental: it is wherever the person happened to be standing when they noticed the problem. Solve at too low an altitude and you optimize a detail that does not matter ("make the button blue"); reason at too high an altitude and you produce a true but useless aspiration ("delight the customer"). Abstraction laddering is a deliberate act of **moving the problem up and down a single vertical axis of abstraction to find the altitude at which it is actually workable.**
+
+Two complementary moves do the work:
+
+1. **Up the ladder - "why? / to what end?"** Each "why" replaces the current statement with the broader purpose it serves. Climbing reveals the goal the current framing is only one means to, and exposes whether the stated problem is really a presupposed solution.
+2. **Down the ladder - "how? / what specifically?"** Each "how" replaces the current statement with a more concrete instance or sub-problem. Descending turns an abstraction into something observable and actionable, and multiplies the options at a given level (there is usually more than one "how").
+
+The output is not a discussion; it is an **abstraction ladder**: an ordered set of rungs from most abstract (top) to most concrete (bottom), with the entry rung marked and one rung explicitly chosen as the working altitude, plus a one-line rationale. The mechanism is locating altitude, nothing more. It does not pick a solution and it does not generate the other framing moves (stakeholder, inversion); those belong to broader reframing.
+
+## 2. Lineage
+
+- **Abstraction as a vertical dimension of meaning:** Hayakawa, S. I. (1939, and later editions). *Language in Thought and Action* - the "ladder of abstraction," from concrete referents up to abstract terms. This is the conceptual root and is descriptive, not trademarked.
+- **As a design / problem-framing practice:** the "abstraction laddering" exercise popularized in UX and facilitation practice (for example, the Interaction Design Foundation and various design-sprint and facilitation toolkits), framed as asking "why" to go up and "how" to go down to find the right level for a "How Might We" question.
+- **Adjacent engineering lineage:** value engineering's function analysis and TRIZ "why-stop" / S-field abstraction use the same up-the-ladder move to separate the function wanted from the current implementation.
+
+No trademark. "Ladder of abstraction" (Hayakawa) and "abstraction laddering" (design practice) are generic descriptive terms; no attribution is required and none is claimed. The skill is named descriptively after the mechanism.
+
+## 3. What the evidence shows, and what it does NOT show
+
+This is the honest core of the dossier. The skill must not overclaim.
+
+**What is reasonably supported:**
+- That **how a problem is framed - including at what level of abstraction - affects the solutions found** has moderate support in the problem-finding and problem-framing literature (Getzels & Csikszentmihalyi on problem finding; Nutt on decisions that fail from poor problem definition; reframing practice such as Wedell-Wedellsborg, HBR 2017). Altitude is one well-attested lever inside that larger, supported claim.
+- That abstraction is a real, navigable dimension of language and concepts (the Hayakawa ladder) is uncontroversial as a descriptive model.
+
+**What is NOT shown (the caveats that keep the skill honest):**
+- There is **no controlled study** isolating "abstraction laddering" as a named technique and measuring its effect on decision or solution quality against a baseline. It is a **practitioner method**: widely taught and used in design facilitation, with face validity and a clear mechanism, but thin direct empirical support of its own.
+- The supportive framing evidence in the bullet above is about **framing in general**, not about this specific "why-up / how-down" exercise. It is suggestive, not confirmatory, for this skill. Do not present general framing research as if it validated the ladder technique itself.
+- The method does **not** guarantee a better solution or a correct altitude. It makes the altitude choice *explicit and deliberate* rather than accidental; the judgment about which rung to work at remains a human call.
+
+**Net grade: P (practitioner).** Clear mechanism and strong adoption in practice, supported indirectly by framing research, but lacking technique-specific controlled evidence. Claim "makes altitude explicit and helps locate a workable level"; do not claim measured improvement in outcomes.
+
+## 4. Transferred-evidence flag (required honesty for this library)
+
+All of the supporting evidence is from **human practice and human-subject framing research**, in design, facilitation, and decision settings. There is **no study** of abstraction laddering run by or with an AI agent, and none of whether an agent-built ladder improves a human's framing. The evidence is therefore **transferred from human practice, not validated for AI-augmented use.** The skill must say so. Treat the AI value as: the agent makes the up/down interrogation cheap and fast, resists stopping at the accidental entry rung, enforces a clean vertical ladder (not a sideways pile of related ideas), and produces a durable artifact that names the chosen working altitude - benefits that do not depend on any unproven outcome claim.
+
+## 5. When it works / when it fails (drives the eval negative cases and "When NOT to Use")
+
+**Works best when:**
+- A problem or request is stated at a suspicious altitude: a bare solution ("add a dashboard") whose purpose is unstated, or a vague aspiration ("improve engagement") with no concrete handle.
+- The team is arguing past each other and may simply be working at different levels.
+- You need to decide, explicitly, at what level to attack a problem before committing effort.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **Altitude is not the issue.** If the problem needs a different *kind* of reframing - a stakeholder shift, an inversion, an is/is-not boundary, or weighing several rival framings - use **problem-restatement**, which generates those moves and converges on a chosen frame. Abstraction laddering only moves up and down one axis. (Near-miss anti-trigger against the neighboring skill.)
+- **The right level is already clear and agreed.** Building a ladder for a well-located problem manufactures motion and wastes effort.
+- **Used to generate solutions.** Going "down" lists more concrete *sub-problems and options to consider*, not a chosen solution; it is not ideation (use Question Burst / SCAMPER) and not a decision tool (use Decision Option Review).
+- **Laddering to infinity.** Endlessly climbing to ever-grander purpose ("...to make the world better") or descending into ever-finer detail without ever marking a working rung produces a tall ladder and no decision. The skill must force selection of one rung.
+- **Confused with a decomposition tree.** A ladder is a single vertical line (one why/how chain), not a branching breakdown of all parts; if the task is to decompose a problem into its components, use an issue tree.
+
+## 6. Output artifact
+
+The skill must emit an **abstraction ladder**, not prose: an ordered, top-to-bottom set of rungs (most abstract to most concrete), each rung a one-line restatement of the problem at that altitude, with the original entry rung marked, the "why?" relationship going up and the "how?" relationship going down made explicit, and exactly one rung selected as the working altitude with a one- or two-sentence rationale. A short summary sits above the ladder. The artifact is the deliverable; the conversation is not.
+
+## 7. Sources
+
+1. Hayakawa, S. I. (1939). *Language in Thought and Action* - the ladder of abstraction (conceptual root).
+2. Getzels, J. W., & Csikszentmihalyi, M. (1976). *The Creative Vision: A Longitudinal Study of Problem Finding in Art* - problem finding and how problem formulation shapes outcomes.
+3. Nutt, P. C. (work on decision-making failures, e.g. *Why Decisions Fail*, 2002) - decisions that fail from poor problem definition / premature framing.
+4. Wedell-Wedellsborg, T. (2017). "Are You Solving the Right Problems?" *Harvard Business Review* - reframing practice; framing precedes good solutions.
+5. Interaction Design Foundation and design-facilitation toolkits - "abstraction laddering" as the why-up / how-down exercise to find the right altitude for a problem statement.
+
+> **Verification status:** Hayakawa (1) and Wedell-Wedellsborg (4) are well-attested. The problem-finding and decision-failure citations (2, 3) support framing *in general* and are drawn from secondary synthesis; they should be confirmed against the primary works before any public-facing claim, and they must not be presented as validating the ladder technique specifically. Citation 5 is practitioner literature, not peer-reviewed evidence. These are safe to use inside this dossier because the dossier's job is to be honest about exactly this gap.

--- a/skills/tfs-abstraction-laddering/references/EXAMPLE.md
+++ b/skills/tfs-abstraction-laddering/references/EXAMPLE.md
@@ -1,0 +1,37 @@
+# Abstraction Ladder - Worked Example
+
+A completed run of the `abstraction-laddering` skill on a real, consequential decision. This is the quality bar a generated ladder should meet.
+
+> Uses the shared recurring scenario (Northwind, a B2B SaaS weighing a self-serve free-tier launch) so examples across skills read as one coherent product. See `docs/internal/AUTHORING.md`.
+
+---
+
+## Problem under laddering
+
+- **Problem as given (entry rung):** "We need to launch a self-serve free tier."
+- **Who framed it / how it arrived:** Brought to the team by leadership as a pre-baked solution, attached to a Q3 board target for top-of-funnel growth. The altitude is accidental: it names *one mechanism*, not the goal, and not the only mechanism.
+- **The user's actual goal:** Grow qualified pipeline efficiently enough to hit the Q3 number without breaking the existing sales-led motion.
+
+## Summary (top of the artifact)
+
+The problem arrived two rungs too low: "launch a self-serve free tier" is a specific implementation, not the problem. Climbing reveals the real goal is "grow qualified pipeline efficiently," for which a free tier is only one of several "hows" (free trial, usage-based entry, partner-led, better paid funnel). Climbing one rung higher ("hit the Q3 growth number") is too broad to act on, and climbing to "grow the company" is uselessly universal. We choose to work at **"reduce the cost and friction of a prospect reaching first value"** as the working altitude: it is high enough that a free tier competes against cheaper alternatives instead of being assumed, and low enough to act on this quarter. A free tier may still win - but now it has to earn it.
+
+## The ladder (most abstract at top, most concrete at bottom)
+
+| Rung | Altitude | Statement of the problem at this level | Note |
+|---|---|---|---|
+| ^ why? | Highest | Grow the company / increase enterprise value | too high: true of almost any project, not workable |
+| | Higher | Hit the Q3 top-of-funnel growth target | a target, not a problem to solve; still too broad to act on |
+| | High | Grow qualified pipeline efficiently without breaking the sales-led motion | the user's actual goal - several "hows" live below it |
+| | **Working** | **Reduce the cost and friction of a prospect reaching first value** | **chosen working altitude** - leaves real options open, still actionable |
+| | Lower | Let prospects experience the product before talking to sales | more than one "how" here -> free tier, free trial, interactive demo, usage-based entry |
+| | (entry) | Launch a self-serve free tier | <- problem as given; one mechanism among several |
+| v how? | Lowest | Ship a free plan with feature gates, usage caps, and a self-serve signup form | too low: a single implementation detail of one mechanism |
+
+**Working altitude (chosen rung):** "Reduce the cost and friction of a prospect reaching first value."
+
+**Rationale:** This rung serves the actual goal (efficient qualified pipeline) while refusing to assume the answer is a free tier. At this altitude the free tier must compete against a free trial, an interactive demo, and a better-instrumented paid funnel on cost, conversion, and load on the sales motion - which is exactly the comparison leadership skipped by handing down a solution. It is concrete enough to scope work this quarter.
+
+---
+
+*Note how the value is in relocating the work: the problem arrived as "launch a free tier" (an answer), and the ladder moved it up to a level where the free tier is one competing option rather than a foregone conclusion - the move a naive prompt, which would have started designing the free tier, would miss.*

--- a/skills/tfs-abstraction-laddering/references/TEMPLATE.md
+++ b/skills/tfs-abstraction-laddering/references/TEMPLATE.md
@@ -1,0 +1,34 @@
+# Abstraction Ladder - Template
+
+Fill this in. The deliverable is the ordered ladder plus the summary above it, with one rung chosen as the working altitude, not prose.
+
+---
+
+## Problem under laddering
+
+- **Problem as given (entry rung):** [the request or problem, verbatim, in one line]
+- **Who framed it / how it arrived:** [a stakeholder, a symptom, a pre-baked solution - note the likely accidental altitude]
+- **The user's actual goal:** [what this is ultimately meant to achieve, as best understood]
+
+## Summary (top of the artifact)
+
+[3-5 sentences. State the altitude the problem arrived at, the altitude chosen to work at, and why that rung is the right level - high enough to leave room for real options, low enough to act on. A reader who stops here should know where to attack the problem.]
+
+## The ladder (most abstract at top, most concrete at bottom)
+
+| Rung | Altitude | Statement of the problem at this level | Note |
+|---|---|---|---|
+| ^ why? | Highest | | too high: true of almost any project |
+| | Higher | | |
+| | (entry) | | <- problem as given |
+| | Lower | | more than one "how" here -> options |
+| v how? | Lowest | | too low: single implementation detail |
+
+**Working altitude (chosen rung):** [name the one rung selected, restated in full]
+
+**Rationale:** [1-2 sentences: why this rung, tied to the user's actual goal - what it leaves open and what it makes actionable]
+
+**Column notes:**
+- **Altitude:** the relative height of the rung; the ladder is a single vertical chain, not a branching breakdown.
+- **Statement of the problem at this level:** the same problem re-expressed at that altitude (a "why" parent reading up, a "how" child reading down), not a different problem.
+- **Note:** flag the rungs that are too high (uselessly universal) or too low (bare detail), and any rung where multiple "hows" reveal real options.

--- a/skills/tfs-abstraction-laddering/skill.meta.yml
+++ b/skills/tfs-abstraction-laddering/skill.meta.yml
@@ -1,0 +1,86 @@
+# Rich sidecar for the tfs-abstraction-laddering skill.
+# DRAFT shape; reconciles with agent-skills-toolkit conventions later.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+#
+# Naming: id = thinking-framework-skills.abstraction-laddering;
+# slug = bare method = abstraction-laddering;
+# installable name = prefix + slug = tfs-abstraction-laddering (matches the skill directory).
+
+identity:
+  id: thinking-framework-skills.abstraction-laddering
+  slug: abstraction-laddering
+  name: tfs-abstraction-laddering
+  display_name: Abstraction Laddering
+  version: 0.1.0
+  status: draft        # draft | experimental | active | deprecated | archived
+  maturity: alpha
+
+classification:
+  primary_family: problem-framing
+  secondary_families: []
+  thinking_modes: [analytical, divergent, critical]
+  problem_contexts: [high-ambiguity]
+  use_cases:
+    - relocate a problem stated as a bare solution up to its real purpose
+    - give a vague aspiration a concrete, actionable handle by descending
+    - resolve a team arguing past each other at different levels of one problem
+    - choose deliberately at what altitude to attack a problem before committing effort
+  poor_fit_cases:
+    - altitude is not the issue (use problem-restatement for broader reframing)
+    - the right level is already clear and agreed
+    - generating solutions (use an ideation skill) or choosing among them (use a decision skill)
+    - decomposing a problem into all its parts (use an issue tree, not a single chain)
+
+interface:
+  required_inputs:
+    - a problem, request, or aspiration whose altitude is in question
+  optional_inputs:
+    - the user's stated underlying goal
+    - who framed the problem and how it arrived
+  primary_artifact_type: abstraction-ladder
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline                 # inline | forked
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.problem-restatement
+    - thinking-framework-skills.issue-tree
+    - thinking-framework-skills.question-burst
+
+relationships:
+  often_follows: []
+  often_precedes:
+    - thinking-framework-skills.problem-restatement
+    - thinking-framework-skills.issue-tree
+    - thinking-framework-skills.question-burst
+  complements:
+    - thinking-framework-skills.problem-restatement
+  overlaps_with:
+    - thinking-framework-skills.problem-restatement   # restatement uses altitude as ONE of several moves; this is the dedicated altitude-only tool
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - up-steps that reword instead of naming a genuine purpose; down-steps that are not actually more concrete
+    - laddering to infinity (uselessly-universal top or bare-detail bottom) without selecting a working rung
+    - sprawling sideways into a pile of related ideas or a branching decomposition instead of one vertical chain
+
+evidence:
+  evidence_tier: "P"
+  confidence: moderate that the move locates a workable altitude; low that any specific effect size is established
+  transferred_evidence: true       # human practice / framing research only; not AI-validated
+  lineage:
+    derived_from: [hayakawa ladder of abstraction, design-facilitation abstraction laddering, problem-framing research]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-abstraction-laddering/SKILL.md
+  references_path: skills/tfs-abstraction-laddering/references/
+  evidence_path: skills/tfs-abstraction-laddering/evidence/dossier.md
+  evals_path: skills/tfs-abstraction-laddering/eval/

--- a/skills/tfs-affinity-mapping/SKILL.md
+++ b/skills/tfs-affinity-mapping/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: tfs-affinity-mapping
+description: Produces a clustered theme map that groups many raw notes, observations, quotes, or data points bottom-up into a small set of named, traceable themes (the KJ method). Use when a scattered pile of dozens to hundreds of existing items needs to become a few emergent themes, such as synthesizing user-research notes, support tickets, survey free-text, or retro stickies, and the right structure should emerge from the data rather than be imposed.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.affinity-mapping
+  family: synthesis
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Affinity Mapping
+
+Affinity mapping takes a pile of many individual items - raw notes, observations, quotes, data points - and groups them *bottom-up by felt similarity* until a small set of emergent themes appears, then names each theme so the names become the structure. The load-bearing move is **deferred, bottom-up categorization**: you do not sort items into predefined buckets, you let the categories surface from the items themselves. This externalizes comparison so patterns hidden in a linear list become visible, resists the frame you walked in with, and compresses many items into a few themes while keeping every item traceable to its theme. The output is a **clustered theme map**, not a discussion.
+
+## When to Use
+
+- When dozens to hundreds of existing items - user-research notes, interview quotes, support tickets, survey free-text, retro stickies, workshop output - need to become a few themes.
+- When the right structure is not known in advance and should emerge from the data rather than be imposed.
+- When the items already exist and the job is synthesis, not generation.
+- When traceability matters: you want each theme to point back to the specific items that support it.
+
+## When NOT to Use
+
+- **When there are only a handful of items.** With a dozen or fewer you can reason about them directly; the clustering ceremony adds overhead without insight.
+- **When you need a top-down logical structure** - a question decomposed into MECE sub-questions or a hypothesis tree. That is top-down decomposition from a question; use an issue-tree skill. Affinity mapping is bottom-up, from items.
+- **When you need to generate ideas or options.** Affinity mapping only organizes items that already exist and produces no new ideas. Use an ideation skill (for example brainwriting) to create the items first, then affinity-map them.
+- **When the categories are already fixed and authoritative** (a required taxonomy, a compliance schema). Then you are coding into known buckets, not discovering emergent themes.
+- **As a ritual** - grouping into a few buckets and slapping confident names on them with no traceability is cargo-cult synthesis, not insight.
+
+## Instructions
+
+When asked to run an affinity map, follow these steps:
+
+1. **Frame the question and gather the items.** State in one sentence what synthesis is for (for example, "what is blocking free-tier activation?"), and assemble every item as a discrete, comparable unit. If there are only a handful of items, or the categories are already fixed, say so and stop.
+2. **Cluster before naming.** Place items that feel related together, bottom-up, by similarity. Do not start from predefined buckets and do not name groups yet. Let clusters form, split, and merge as items accumulate. This deferral is the mechanism; naming first defeats it.
+3. **Name each emergent theme from its contents.** Once clusters are stable, give each a short descriptive name that answers to the items inside it, not to your prior frame. A theme whose items do not cohere is a signal to split or dissolve it, not to force a label.
+4. **Keep every item traceable.** Each theme records the source items it contains (by list, or by count plus representative examples). Items that did not cluster go to an explicit outliers / parking lot, never silently dropped.
+5. **Weight and read the themes.** Note each theme's relative size or strength, and state what the map tells you - which themes dominate, which are thin, what surprised you. Size is a signal of salience, not of truth; flag thin or borderline clusters as tentative.
+6. **Emit the theme map and a short summary.** Produce the artifact in `references/TEMPLATE.md`: a one-paragraph "themes and what they tell us" summary above the named-theme table, with outliers kept visible.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the filled clustered theme map plus its summary, not a prose essay.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] Clustering happened before naming (themes emerged from items, not from predefined buckets).
+- [ ] Each theme has a short name that answers to the items inside it, not to a prior frame.
+- [ ] Every item is traceable to a theme, and items that did not cluster are kept in an explicit outliers / parking lot, not dropped.
+- [ ] Themes are weighted by relative size or strength, and thin or borderline clusters are flagged as tentative, not laundered by a confident label.
+- [ ] The output is the clustered theme map artifact, not prose.
+- [ ] No overclaiming: the skill organizes a scattered pile into named, traceable themes; it does not promise objectively better or bias-free themes (see `evidence/dossier.md`).
+
+## Evidence
+
+Tier **P** (practitioner). Affinity mapping is a long-standing, widely-taught practitioner standard for synthesizing large qualitative piles (the KJ method; Kawakita 1967), with a plausible cognitive basis in external representation and chunking. It does **not** have strong controlled evidence that it produces better, more accurate, or less biased themes than another synthesis method, and "group by similarity" remains a subjective judgment. The evidence is transferred from human practice and has not been validated for AI-augmented use. Full grading, sources, and caveats: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed run.

--- a/skills/tfs-affinity-mapping/eval/cases.md
+++ b/skills/tfs-affinity-mapping/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-affinity-mapping
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (a harness is deferred to the Silver climb); these are the cases to check by hand, or to wire into evals later.
+
+## Should trigger
+
+- "I have about 60 user-interview notes from our onboarding study. Help me find the themes in them."
+- "Here are 80-odd support tickets tagged 'evaluation.' What patterns are in this pile?"
+- "We ran a retro and there are 40 stickies. Cluster them into a few themes so we know what to act on."
+- "I pasted all the open-text survey answers below. Group them and tell me what people are actually saying, with the structure coming from the data, not my assumptions."
+- "We have a scattered mess of research observations and quotes. Synthesize them into named themes and keep each theme traceable back to the quotes."
+- "Take these 50 feature requests and find the natural groupings - I don't want to start from predefined buckets."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "Break down 'why is free-tier activation low?' into a structured tree of sub-questions to investigate." (near-miss: top-down decomposition from a question - that is an issue-tree, not bottom-up clustering of existing items)
+- "I need fresh feature ideas for next quarter. Generate a bunch of options for me." (near-miss: idea generation - affinity mapping organizes items that already exist, it does not create them; use brainwriting first)
+- "I have three customer quotes. What do they tell me?" (too few items - reason about them directly; the clustering ceremony adds overhead without insight)
+- "Sort each of these tickets into our fixed severity taxonomy: P0, P1, P2, P3." (coding into authoritative predefined buckets, not discovering emergent themes)
+- "We're about to launch the free tier next week. Stress-test it and tell me how it could fail." (risk tool - premortem, not synthesis)
+- "Write a project status update summarizing what the team shipped this sprint." (unrelated)
+
+## Output checks (a good output must)
+
+- [ ] Cluster the items before naming any theme, so the themes emerge from the items rather than from predefined buckets.
+- [ ] Give each theme a short name that answers to the items inside it, with a one-line statement of what unifies them.
+- [ ] Keep every item traceable to a theme (representative items shown) and put items that did not cluster in an explicit outliers / parking lot, not dropped.
+- [ ] Weight themes by relative size or strength and flag thin or borderline clusters as Tentative rather than laundering them with a confident label.
+- [ ] Deliver the clustered-theme-map artifact (named-theme table + a short "themes and what they tell us" summary), not a prose paragraph.
+- [ ] Not claim the themes are objectively better or bias-free; limit any claim to "organized, named, and traceable."
+
+## Value vs unaided baseline
+
+Unprompted, a strong model reads a large pile and returns a confident summary paragraph or a flat bullet list - it tends to impose a few obvious buckets, drop the long tail, and lose the trail from any theme back to the specific items that support it. This skill forces the bottom-up discipline (cluster before naming, so structure emerges from the data instead of confirming a prior frame), keeps every item traceable to its theme, preserves outliers, weights themes by salience, and flags thin clusters as tentative rather than dressing them up as findings - and it holds the honest practitioner-grade, no-overclaim caveat.

--- a/skills/tfs-affinity-mapping/evidence/dossier.md
+++ b/skills/tfs-affinity-mapping/evidence/dossier.md
@@ -1,0 +1,83 @@
+# Evidence Dossier: Affinity Mapping
+
+> The single source of truth for the `affinity-mapping` skill. The `SKILL.md`, the sidecar
+> (`skill.meta.yml`), and the eval cases all derive from this file. If a claim is not
+> here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.affinity-mapping` (installable name `tfs-affinity-mapping`) |
+| **Family** | synthesis |
+| **Evidence tier** | **P** (practitioner; limited controlled evidence) |
+| **Confidence** | Moderate that the mechanism organizes a scattered pile usefully; low that any specific quality or speed gain is established by controlled study |
+| **Status** | draft (first authored 2026-05-31, against discovery corpus) |
+
+---
+
+## 1. The mechanism (what actually does the work)
+
+Affinity mapping takes a pile of many individual items - raw notes, observations, quotes, data points, sticky-note ideas - and groups them **bottom-up by felt similarity** until a small set of emergent themes appears. Each theme is then named, and the names become the structure.
+
+The load-bearing move is **deferred, bottom-up categorization**. You do not start from predefined buckets and sort items into them. You start from the items, place ones that "feel related" together, and let the categories surface from the data. Three things follow:
+
+1. **It externalizes and parallelizes comparison.** A scattered list is hard to hold in mind; laying every item out as a peer and grouping by proximity turns an O(n) memory problem into a spatial one, so patterns that were invisible in a linear list become visible.
+2. **It resists premature structure.** Because the categories are discovered rather than imposed, the grouping is less likely to just confirm the frame you walked in with. The themes are answerable to the items.
+3. **It compresses without discarding.** Many items collapse into a few named themes, but every item stays attached to its theme, so the synthesis is traceable back to its evidence rather than replacing it.
+
+The mechanism is what we implement. The branded "KJ method" / "affinity diagram" ritual (sticky notes, silent sorting, dot voting) is the packaging; the durable move is bottom-up clustering of existing items into named, traceable themes.
+
+## 2. Lineage
+
+- **The KJ method**, the original formulation, named for its creator: Kawakita, Jiro (1967). *Hassoso* (Abduction / The Idea-Generation Method). Tokyo: Chuokoron-sha. Developed for synthesizing field-research data in cultural anthropology.
+- **Affinity diagram** as one of the "Seven Management and Planning Tools" in Japanese quality management, from which it entered Western quality and design practice (Mizuno, Shigeru, ed., *Management for Quality Improvement: The Seven New QC Tools*, 1988).
+- **Adoption in UX / design / product practice** as the standard way to synthesize user-research notes and workshop output into themes (widely documented by IDEO, the Nielsen Norman Group, and the design-sprint literature).
+
+"KJ Method" is associated with Jiro Kawakita and is sometimes treated as a registered designation in Japan. We name the skill descriptively (`affinity-mapping`) after the durable mechanism rather than the named method, cite the lineage here, and require no attribution.
+
+## 3. What the evidence shows, and what it does NOT show
+
+This is the honest core of the dossier. The skill must not overclaim.
+
+**What is reasonably supported (the practitioner basis):**
+- Affinity mapping is a **long-standing, widely-taught practitioner standard** for synthesizing large qualitative piles in anthropology, quality management, UX research, and facilitation. Its longevity and breadth of adoption are real and are the main evidence for it.
+- The underlying cognitive idea - that **externalizing items and grouping by similarity makes patterns easier to see than a linear list** - is consistent with well-established findings on external representation and chunking in cognition. That is supporting, not direct, evidence.
+
+**What is NOT shown (the caveat that keeps the skill honest):**
+- There is **no strong body of controlled evidence** that affinity mapping produces *better* themes, *more accurate* synthesis, or *better downstream decisions* than another synthesis method or than an expert reading the items closely. The claim for it is practitioner consensus and plausibility, not measured outcome.
+- The method is **sensitive to the grouper's bias.** "Group by similarity" is a subjective judgment; two people (or two runs) can produce different theme sets from the same items. Bottom-up framing reduces, but does not remove, the risk of the grouping merely re-encoding the analyst's prior frame.
+- **Theme names can launder weak groupings.** A confident label on a thin or incoherent cluster makes it look like a finding. The presence of named themes is not evidence that the themes are real.
+- It does **not** generate the items. Affinity mapping only organizes what is already in the pile; if the inputs are sparse, skewed, or low-quality, the themes inherit those defects.
+
+**Net grade: P.** Useful, durable, widely-practiced synthesis method with a plausible cognitive basis, but limited controlled evidence for any specific quality or speed gain. The skill should claim "organizes a scattered pile into a small set of named, traceable themes" and explicitly disclaim "produces objectively better or bias-free themes."
+
+## 4. Transferred-evidence flag (required honesty for this library)
+
+All of the basis above comes from **human practice and human-subject cognition research** in research-synthesis, quality, and design settings. There is **no direct study** of affinity mapping run by, or with, an AI agent, and none of whether an AGENT-produced affinity map improves a human's synthesis or decision. The evidence supporting this skill is therefore **transferred from human practice, not validated for AI-augmented use.** This skill must say so. Treat the AI value as: the agent makes the clustering cheap to run at scale, enforces the bottom-up discipline (cluster before naming), keeps every item traceable to its theme, and produces a durable, reusable artifact - benefits that do not depend on any contested quality claim.
+
+## 5. When it works / when it fails (drives the eval negative cases and "When NOT to Use")
+
+**Works best when:**
+- There are **many items** (roughly dozens to hundreds) - research notes, support tickets, survey free-text, retro stickies, interview quotes - that need to become a few themes.
+- The right structure is **not known in advance** and should emerge from the data rather than being imposed.
+- The items already exist; the job is synthesis, not generation.
+- Traceability matters: you want each theme to point back to the specific items that support it.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **Only a handful of items.** With a dozen or fewer items you can reason about them directly; the clustering ceremony adds overhead without insight. (Anti-trigger.)
+- **You need a top-down logical structure** - a question decomposed into MECE sub-questions or a hypothesis tree. That is **issue-tree** decomposition (top-down, from a question), not affinity mapping (bottom-up, from items). (Near-miss anti-trigger.)
+- **You need to generate ideas or options.** Affinity mapping organizes items that already exist; it produces no new ideas. Use an ideation method (for example brainwriting) to create the items first, then affinity-map them. (Near-miss anti-trigger.)
+- **The categories are already fixed and authoritative** (a required taxonomy, a compliance schema). Then you are coding/sorting into known buckets, not discovering emergent themes.
+- **Run as ritual** - grouping into a few buckets and slapping confident names on them with no traceability and no discipline against the analyst's prior frame produces cargo-cult themes. The skill must keep items attached to themes and force naming to come *after* grouping.
+
+## 6. Output artifact
+
+The skill must emit a **clustered theme map**, not prose: a small set of named themes, each with a one-line description of what unifies it, the list (or count plus representative examples) of source items it contains, and its relative size/weight, preceded by a short "themes and what they tell us" summary. Items that did not cluster ("outliers / parking lot") are kept visible, not silently dropped. The artifact is the deliverable; the conversation is not.
+
+## 7. Sources
+
+1. Kawakita, Jiro (1967). *Hassoso* - the original KJ method for synthesizing field data bottom-up.
+2. Mizuno, Shigeru, ed. (1988). *Management for Quality Improvement: The Seven New QC Tools* - affinity diagram in quality management.
+3. Nielsen Norman Group, "Affinity Diagramming: Collaboratively Sort UX Findings & Design Ideas" - the standard UX-practice description of the technique.
+4. Scupin, R. (1997). "The KJ Method: A Technique for Analyzing Data Derived from Japanese Ethnology." *Human Organization* 56(2):233-237 - documents the method's anthropological origin and use.
+
+> **Verification status:** citations 1-2 are the standard historical attributions and well-attested in the discovery corpus; the exact NN/g phrasing (citation 3) and the Scupin page reference (citation 4) were drawn from a secondary research synthesis and should be confirmed against the primary sources before they appear in any public-facing README. They are safe to use *inside this dossier* because the dossier's job is to be honest about exactly this uncertainty. The "limited controlled evidence" claim in section 3 is a deliberate statement of absence: it should stay phrased as "no strong controlled evidence found," not as a positive finding.

--- a/skills/tfs-affinity-mapping/references/EXAMPLE.md
+++ b/skills/tfs-affinity-mapping/references/EXAMPLE.md
@@ -1,0 +1,37 @@
+# Affinity Map (Clustered Theme Map) - Worked Example
+
+A completed run of the `affinity-mapping` skill on a real synthesis task. This is the quality bar a generated affinity map should meet.
+
+> Uses the shared recurring scenario: Northwind, a B2B SaaS weighing a self-serve free-tier launch. Here the team has already collected a large, scattered pile of qualitative signal and needs to turn it into a few themes before deciding. See `docs/internal/AUTHORING.md`.
+
+---
+
+## Synthesis subject
+
+- **Question:** What do prospects and trial users actually struggle with, so we know whether a self-serve free tier would help and where it must be strong?
+- **Source of items:** 38 sales-call notes from lost or stalled deals + 24 trial-user onboarding survey free-text answers + 19 support tickets tagged "evaluation."
+- **Item count:** 81 discrete items.
+
+## Themes and what they tell us (summary)
+
+The pile collapses into five themes. Two dominate: **time-to-first-value is too slow** (people cannot tell if Northwind works for them before their evaluation window or patience runs out) and **buyers cannot evaluate without committing** (procurement, seat minimums, and sales gating block hands-on trial). Both point the same way: a low-friction self-serve path that delivers value fast is responding to a real, repeated signal, not a hunch. A thinner but sharp theme, **wrong-fit prospects waste cycles**, is a warning that a free tier could amplify unqualified volume if there is no light qualification. The two smallest themes (integration gaps, pricing-page confusion) are real but secondary. The headline: demand for self-serve evaluation is well-evidenced; the risk is fit and activation speed, not appetite.
+
+## Theme map
+
+| # | Theme name | What unifies it (one line) | Size (item count) | Weight | Representative items | Confidence |
+|---|---|---|---|---|---|---|
+| 1 | Slow time-to-first-value | Users cannot reach a useful result before patience or the eval window runs out | 23 | H | "Spent the whole trial just importing data"; "couldn't get a real report out in two weeks"; "gave up before I saw anything work" | Firm |
+| 2 | Cannot evaluate without committing | Procurement, seat minimums, and sales gating block hands-on trial | 19 | H | "Wanted to just try it, got routed to a sales call"; "needed a PO before we could touch it"; "min 10 seats killed our pilot" | Firm |
+| 3 | Wrong-fit prospects waste cycles | People who were never a fit consumed trials and sales time | 14 | M | "Solo user, no team to collaborate with"; "expected a free CRM, we're not that"; "wrong industry, no use case" | Firm |
+| 4 | Integration gaps block adoption | A missing connector stalls the evaluation before value lands | 12 | M | "No Salesforce sync so we couldn't test the real workflow"; "needed our SSO before security would approve a trial" | Firm |
+| 5 | Pricing-page confusion | Prospects misread what each tier includes and disqualify wrongly | 7 | L | "Couldn't tell what was in the Pro plan"; "thought feature X was paid-only, it isn't" | Tentative |
+
+## Outliers / parking lot
+
+- "Loved the mobile app" - positive, off-question, not a struggle. One-off.
+- "Competitor offered a free migration" - a single competitive-loss note; could be an early signal of a switching-cost theme if more accumulate, but a singleton today.
+- "Asked for an on-prem option" - one regulated prospect; parked, not a pattern.
+
+---
+
+*Note how the value is in the deferred, bottom-up clustering with traceability: the themes emerged from 81 scattered items rather than from the team's prior assumptions, each theme points back to the verbatim signal that supports it, and the thin "pricing-page confusion" cluster is flagged Tentative rather than dressed up as a finding. A naive prompt would summarize the pile into a confident paragraph and lose both the weighting and the trail back to the evidence.*

--- a/skills/tfs-affinity-mapping/references/TEMPLATE.md
+++ b/skills/tfs-affinity-mapping/references/TEMPLATE.md
@@ -1,0 +1,34 @@
+# Affinity Map (Clustered Theme Map) - Template
+
+Fill this in. The deliverable is the named-theme table plus the summary above it, not prose.
+
+---
+
+## Synthesis subject
+
+- **Question:** [one sentence: what is this synthesis for, e.g. "what is blocking free-tier activation?"]
+- **Source of items:** [where the pile came from, e.g. "47 onboarding-interview notes + 30 support tickets"]
+- **Item count:** [how many discrete items went in]
+
+## Themes and what they tell us (summary)
+
+[3-5 sentences. Name the two or three dominant themes, say which are thin or surprising, and state the headline the map reveals. A reader who stops here should know what the pile is saying.]
+
+## Theme map
+
+| # | Theme name | What unifies it (one line) | Size (item count) | Weight (H/M/L) | Representative items | Confidence |
+|---|---|---|---|---|---|---|
+| 1 | | | | | | |
+| 2 | | | | | | |
+| 3 | | | | | | |
+
+**Column notes:**
+- **What unifies it:** the felt similarity that put these items together, stated so the grouping is self-explaining and answerable to the items (not to a prior frame).
+- **Size (item count):** how many source items landed in this theme. Size is a signal of salience, not of truth.
+- **Weight (H/M/L):** your read of how important this theme is to the question, which may differ from raw size.
+- **Representative items:** 2-3 verbatim or near-verbatim source items so the theme stays traceable to its evidence.
+- **Confidence:** Firm if the cluster coheres tightly; Tentative if it is thin, borderline, or could plausibly split or merge. Flag tentative themes; do not let a confident name launder a weak grouping.
+
+## Outliers / parking lot
+
+[Items that did not fit any theme, kept visible rather than forced or dropped. A singleton may be a one-off or an early signal of a theme that has not accumulated yet; note which.]

--- a/skills/tfs-affinity-mapping/skill.meta.yml
+++ b/skills/tfs-affinity-mapping/skill.meta.yml
@@ -1,0 +1,81 @@
+# Rich sidecar for the tfs-affinity-mapping skill.
+# DRAFT: shape is provisional and will be reconciled with agent-skills-toolkit
+# conventions once 2-3 skills exist. Evidence fields are a hand-authored summary
+# of evidence/dossier.md (the source of truth), not generated from it.
+#
+# Naming: id = <namespace>.<method> = thinking-framework-skills.affinity-mapping;
+# slug = bare method = affinity-mapping; installable name = prefix + slug = tfs-affinity-mapping
+# (the tfs- prefix avoids cross-plugin name collisions; see library.json "prefix").
+
+identity:
+  id: thinking-framework-skills.affinity-mapping
+  slug: affinity-mapping
+  name: tfs-affinity-mapping        # installable name (matches the skill directory)
+  display_name: Affinity Mapping
+  version: 0.1.0
+  status: draft        # draft | experimental | active | deprecated | archived
+  maturity: alpha
+
+classification:
+  primary_family: synthesis
+  secondary_families: []
+  thinking_modes: [synthetic, inductive, divergent-to-convergent]
+  problem_contexts: [high-volume, high-ambiguity, qualitative]
+  use_cases:
+    - synthesize many research notes, quotes, or tickets into a few emergent themes
+    - find structure in a scattered pile when the categories are not known in advance
+    - compress a large qualitative pile into named themes that stay traceable to the items
+  poor_fit_cases:
+    - only a handful of items (reason about them directly instead)
+    - needing a top-down logical structure from a question (use an issue-tree skill)
+    - needing to generate ideas or options (use an ideation skill such as brainwriting)
+    - sorting into fixed, authoritative categories (that is coding, not discovery)
+
+interface:
+  required_inputs:
+    - a pile of many discrete, existing items to synthesize (notes, quotes, tickets, data points)
+  optional_inputs:
+    - the question the synthesis is for
+    - any known constraints or a prior partial grouping
+  primary_artifact_type: clustered-theme-map
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline                 # inline | forked
+  subagent_suitable: true
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.brainwriting
+    - thinking-framework-skills.issue-tree
+
+relationships:
+  often_follows: [thinking-framework-skills.brainwriting]
+  often_precedes: [thinking-framework-skills.issue-tree]
+  complements: []
+  overlaps_with: []          # see dossier section 5: distinct from issue-tree (top-down) and brainwriting (generative)
+  variants: []
+
+quality:
+  trigger_eval_status: not-run     # see eval/ (harness deferred to the Silver climb)
+  output_eval_status: not-run
+  known_failure_modes:
+    - naming themes before clustering, so predefined buckets get confirmed instead of discovered
+    - confident labels laundering thin or incoherent clusters as findings
+    - dropping outliers or losing the trail from theme back to source items
+    - using it to generate ideas or to impose a top-down structure (wrong tool)
+
+evidence:
+  evidence_tier: "P"               # practitioner; limited controlled evidence; see dossier section 3
+  confidence: moderate on the mechanism; low on any specific quality or speed gain
+  transferred_evidence: true       # human practice + human cognition research; not AI-validated
+  lineage:
+    derived_from: [kj-method, affinity-diagram, ux-research-synthesis]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none   # "KJ Method" associated with Jiro Kawakita; skill named descriptively
+
+implementation:
+  skill_path: skills/tfs-affinity-mapping/SKILL.md
+  references_path: skills/tfs-affinity-mapping/references/
+  evidence_path: skills/tfs-affinity-mapping/evidence/dossier.md
+  evals_path: skills/tfs-affinity-mapping/eval/

--- a/skills/tfs-backcasting/SKILL.md
+++ b/skills/tfs-backcasting/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: tfs-backcasting
+description: Produces a backcast path by fixing a vivid desired future state and reasoning backward through the milestones and preconditions required to reach it, ending at the next concrete step available now. Use when planning toward a transformative or long-horizon goal that forward planning anchors too low, when a chosen future needs a route mapped back to today, or when milestones and dependencies between now and the goal must be made explicit.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.backcasting
+  family: risk-and-resilience
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Backcasting
+
+Forward planning anchors on today's constraints and tends to extrapolate the status quo. Backcasting reverses the direction: it fixes a vivid, concrete *desired future state* first, then reasons backward to the milestones and preconditions that must be true for that future to exist, link by link, until it reaches the next concrete step available now. The reversal is what does the work - it decouples the goal from present limits, forces each milestone to name what had to be true just before it, and connects an aspirational future to something executable today. The output is a **backcast path**, not a discussion. This is a route to a chosen success, not a forecast and not a test of whether the goal is right.
+
+## When to Use
+
+- Planning toward a transformative or longer-horizon goal where forward planning anchors too low and just extrapolates the present.
+- A desired future has been chosen and needs a route mapped backward to the next step today.
+- The milestones, dependencies, and sequencing between now and the goal need to be made explicit.
+- The desired end state can be described concretely (you can say what is true once you have succeeded).
+
+## When NOT to Use
+
+- **Near-term, simple plans.** When the path is short and obvious, forward planning is sufficient and the backward overhead buys nothing.
+- **When the goal is unsettled or unvalidated.** Backcasting assumes the endpoint; it does not choose or test it. Settle the goal first with a decision or option-evaluation skill. A clean path to the wrong goal is worse than no path.
+- **To imagine how the plan could fail.** That is a premortem (work back from *failure* to causes). Backcasting works back from *success* to the *path*.
+- **To trace forward consequences of a decision.** That is a futures wheel (first/second/third-order effects radiating outward), not a goal-first backward route.
+- **For personal follow-through on an already-chosen goal.** That is WOOP (an if-then plan for one actor's intention-action gap), not a route to a future.
+
+## Instructions
+
+When asked to backcast, follow these steps:
+
+1. **Fix the desired future state, vividly.** Describe success as if it already exists, in the definite present: "It is [horizon]. The following is true: ..." Make it concrete and observable, not "things are better." If the goal is unsettled or unvalidated, say so and stop - choose the goal first.
+2. **Name the success conditions.** List what is demonstrably true in that future (capabilities, metrics, states, relationships). These are the things the path must arrive at.
+3. **Step backward one milestone at a time.** Starting from the future, ask "what had to be true just before this for it to happen?" Record each milestone and, for each, its **preconditions** - the capability, decision, resource, or dependency that had to be in place first. Continue backward toward the present. Do not switch into forward order.
+4. **Check the chain for gaps and ordering.** Verify each milestone's preconditions are themselves produced by an earlier milestone or already exist today. Surface missing links and dependencies between branches; a dangling precondition is a gap to fill, not to hide.
+5. **Land on the next concrete step.** The final (earliest) link must be an action that can be taken now. This connection from vision to next move is mandatory; a future with milestones but no executable first step is not a backcast.
+6. **Emit the backcast path and a short summary.** Produce the artifact in `references/TEMPLATE.md`: a one-paragraph summary naming the future and the single most important near-term move, above the ordered milestone chain with preconditions.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the filled backcast path (future state, backward milestone chain with preconditions, next concrete step) plus its summary, not a prose essay.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The desired future is stated vividly and concretely as an already-true state with a horizon, not a vague aspiration.
+- [ ] The chain is built *backward* from the future, and each milestone names the preconditions that had to be true before it (not a forward to-do list relabeled).
+- [ ] Preconditions and dependencies are checked for gaps and ordering; dangling links are surfaced, not hidden.
+- [ ] The earliest link is a concrete next step that can be taken now.
+- [ ] The output is the backcast-path artifact, not prose.
+- [ ] No overclaiming: the path is a constructed route to a *chosen* future, not a forecast, not proof the goal is right, and not a guarantee of the outcome (see `evidence/dossier.md`).
+
+## Evidence
+
+Tier **P** (practitioner). Backcasting is a well-documented, widely adopted foresight and sustainability-planning method (Robinson 1982, 1990; Dreborg 1996; The Natural Step), valued for reframing planning around a desired endpoint and surfacing the preconditions a forward extrapolation would miss. Its validation is qualitative and case-based; there is **no strong controlled evidence** that it improves goals or outcomes, it does **not** validate whether the chosen future is right, and the backward chain is a structured hypothesis, not a forecast. The evidence is transferred from human practice, not AI-validated. Full grading, sources, and caveats: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed backcast path on a real decision.

--- a/skills/tfs-backcasting/eval/cases.md
+++ b/skills/tfs-backcasting/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-backcasting
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (a harness is deferred to the Silver climb); these are the cases to check by hand, or to wire into evals later.
+
+## Should trigger
+
+- "We've decided we want to be the default self-serve platform in our category in two years. Work backward from that and tell me what has to happen and what we do first."
+- "Picture our team three years out running fully on the new architecture. Map the milestones backward to where we are now."
+- "I keep planning forward from this quarter and we never get near the big goal. Start from the goal and reason back to the next step."
+- "We have a chosen 5-year carbon-neutral target. Lay out the path back from that future to today, with the preconditions at each stage."
+- "What would have to be true, in order, for us to reach a $50M ARR self-serve business - working back from there to what I should do this month?"
+- "Help me build a route from our desired end state to a concrete next action, surfacing the dependencies between milestones."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "We're about to launch the free tier. Imagine it's six months out and it failed badly - why did it fail and what do we watch for?" (near-miss: premortem - works back from *failure* to causes, not from *success* to the path)
+- "If we launch this free tier, what are the second- and third-order knock-on effects over time?" (futures wheel - forward consequences radiating outward, not a goal-first backward route)
+- "I've decided to ship daily code reviews but I keep skipping them. Help me actually follow through." (WOOP - personal intention-action gap, not a route to a future)
+- "Should we even build a self-serve free tier, or double down on sales-led? Help me decide." (the goal is unsettled - decision/option evaluation first; backcasting assumes the endpoint)
+- "I need to rename a staging environment - just a quick config change. What's the next step?" (near-term, trivial plan; forward planning is sufficient)
+- "Write a status update on what the team shipped this sprint." (unrelated)
+
+## Output checks (a good output must)
+
+- [ ] State the desired future vividly and concretely as an already-true state anchored to a horizon, not a vague aspiration like "things are better."
+- [ ] Build the chain *backward* from the future, with each milestone naming the preconditions that had to be true before it (not a forward to-do list relabeled as a backcast).
+- [ ] Check preconditions and dependencies for gaps and ordering, surfacing dangling links rather than hiding them.
+- [ ] Terminate at a concrete next step that can be taken now (the vision-to-action link is present).
+- [ ] Deliver the backcast-path artifact (future state, backward milestone chain with preconditions, next step + a short summary), not prose.
+- [ ] Not overclaim: present the path as a constructed route to a *chosen* future, not a forecast, not proof the goal is right, and not a guaranteed outcome.
+
+## Value vs unaided baseline
+
+Unprompted, a strong model produces a forward plan: it starts from today's constraints and lists steps in chronological order, which anchors on the status quo and quietly inverts real dependencies (it leads with the visible build work and discovers the binding constraint late). It also tends to leave the goal unexamined and the milestones without named preconditions. This skill forces the reversal (fix a vivid endpoint, derive milestones backward), requires each link to name the preconditions that had to be true before it, surfaces dependency gaps and the true starting constraint, lands on a concrete next step, and holds the honest caveat that the path is a route to a *chosen* future, not a forecast or a test of whether the goal is right.

--- a/skills/tfs-backcasting/evidence/dossier.md
+++ b/skills/tfs-backcasting/evidence/dossier.md
@@ -1,0 +1,84 @@
+# Evidence Dossier: Backcasting
+
+> The single source of truth for the `backcasting` skill. The `SKILL.md`, the sidecar
+> (`skill.meta.yml`), and the eval cases all derive from this file. If a claim is not
+> here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.backcasting` (installable name `tfs-backcasting`) |
+| **Family** | risk-and-resilience |
+| **Evidence tier** | **P** (practitioner method; useful, limited controlled evidence) |
+| **Confidence** | Moderate that the mechanism helps planning; low that any outcome improvement has been measured |
+| **Status** | draft (first authored 2026-05-31, against discovery corpus) |
+
+---
+
+## 1. The mechanism (what actually does the work)
+
+Backcasting starts from a vivid, concrete description of a **desired future state** and reasons *backward* to the milestones and preconditions that must be true for that future to exist, ending at the next concrete step that can be taken now. The load-bearing move is the **reversal of the planning direction**: instead of projecting forward from today's constraints ("given where we are, what can we do?"), it fixes the destination first and then asks, at each step, "what had to be true just before this for it to happen?"
+
+This does three things:
+
+1. **Decouples the goal from present constraints.** Forward planning anchors on what is currently feasible and tends to produce incremental extrapolation of the status quo. Fixing the endpoint first lets the path be derived from the goal rather than capped by today's limits, which is why backcasting is favored for transformative or long-horizon goals where the desirable end state is not reachable by extrapolation.
+2. **Exposes the necessary preconditions and their order.** Working backward forces each milestone to name what must already be in place before it - the dependency, the capability, the decision, the resource. Gaps and sequencing that a forward brainstorm glosses over become visible as missing backward links.
+3. **Connects an aspirational future to a concrete next action.** The chain does not stop at strategy; it terminates at the first move available now, so the vision is tied to something executable rather than left as a slogan.
+
+The mechanism is what we implement: fix a vivid endpoint, derive the milestone chain backward, surface preconditions at each link, and land on the next concrete step. The branded workshop "backcasting" framing is packaging; the durable move is goal-first backward derivation of a path.
+
+## 2. Lineage
+
+- Originates in **energy and sustainability scenario planning**. Coined as "backwards-looking analysis" by Amory Lovins (1976) in soft-energy-path work, and named **backcasting** and developed methodologically by John B. Robinson (1982, 1990) as a normative alternative to predictive forecasting.
+- Operationalized for organizations and sustainability transitions via **The Natural Step** framework (Holmberg & Robert, 2000), which formalized "backcasting from principles."
+- Widely used in **futures studies, transition management, and strategic foresight**; appears in foresight primers and corporate strategy practice as a standard normative-planning method.
+
+No trademark constrains the descriptive name. "Backcasting" is a generic methodological term in common use in the foresight and sustainability literatures; no attribution is required and none is claimed. We name the skill descriptively and cite the lineage here.
+
+## 3. What the evidence shows, and what it does NOT show
+
+This is the honest core of the dossier. The skill must not overclaim.
+
+**What is reasonably supported (practitioner-grade):**
+- Backcasting is a **well-documented, widely adopted method** in foresight, energy, and sustainability planning, with a clear methodological literature (Robinson; Dreborg 1996; The Natural Step) describing when and why it is preferred over forecasting: long horizons, transformative goals, and situations where the desirable future is not a simple extrapolation of present trends.
+- Its claimed value is **procedural and qualitative**: it reframes planning around a desired endpoint, surfaces preconditions and dependencies, and resists the status-quo anchoring of forward extrapolation. Practitioners report it produces clearer milestone structure and a more explicit path than open-ended forward planning.
+
+**What is NOT shown (the caveat that keeps the skill honest):**
+- There is **no strong body of controlled studies** showing that backcasting produces *better goals, better plans, or better outcomes* than forward planning. The evidence is method description, case studies, and practitioner experience, not randomized or controlled comparison. Tier **P**, not S or M.
+- Backcasting **does not validate the desired future**. If the endpoint is wrong, unrealistic, or undesirable, a clean backward path to it is a confident route to the wrong place. The method assumes the goal is worth reaching; it does not test that assumption.
+- The backward chain is **a constructed plausible path, not a forecast or a guarantee**. Naming the preconditions does not make them achievable, and the real world will not follow the chain in order. Treat the path as a structured hypothesis about what would have to happen, to be revised as reality diverges.
+- "Working backward improves thinking" is the kind of broad claim the foresight literature does not establish quantitatively; assume the benefit is structure and reframing, not measured decision quality.
+
+**Net grade: P.** A useful, established practitioner method with a sound rationale and broad adoption, but limited controlled evidence of effect. The skill should claim the procedural benefits (endpoint-first reframing, surfaced preconditions, a path to a next step) and explicitly disclaim outcome improvement and goal validation.
+
+## 4. Transferred-evidence flag (required honesty for this library)
+
+All of the support above comes from **human practitioners** in foresight, energy, sustainability, and corporate-strategy settings. There is **no direct study** of backcasting run by, or with, an AI agent, and none of whether an AGENT-produced backcast improves a human's planning. The evidence supporting this skill is therefore **transferred from human practice, not validated for AI-augmented use.** This skill must say so. Treat the AI value as: the agent makes the method cheap to run, enforces the backward direction and the precondition-naming at every link, and produces a durable, inspectable path artifact - benefits that do not depend on any unproven outcome claim.
+
+## 5. When it works / when it fails (drives the eval negative cases and "When NOT to Use")
+
+**Works best when:**
+- The goal is a **transformative or longer-horizon desired future** that is hard to reach by extrapolating current trends, where forward planning anchors too low.
+- The desired end state can be described **vividly and concretely** (you can say what is true when you have succeeded).
+- The value lies in surfacing **milestones, dependencies, and sequencing** between now and the goal, ending in a concrete next step.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **Near-term, simple plans** where forward planning is sufficient - backcasting's overhead buys nothing when the path is short and obvious. (Anti-trigger.)
+- **The goal is unsettled or unvalidated** - backcasting assumes the endpoint; it does not choose or test it. Use a decision or option-evaluation skill first. A confident path to the wrong goal is worse than no path.
+- **Imagining how the plan could fail** - that is a premortem (prospective hindsight, working back from *failure* to causes). Backcasting works back from *success* to the *path*. (Near-miss against tfs-premortem.)
+- **Tracing forward consequences of a decision** - that is a futures wheel (first/second/third-order effects radiating outward). Backcasting is goal-first and backward, not consequence-first and forward.
+- **Personal follow-through on an already-chosen goal** - that is WOOP (mental contrasting plus an if-then plan for one actor's intention-action gap). Backcasting builds the route to a future; it is not a personal commitment device.
+- **Run as ritual** - "imagine the future, then list some steps" with the steps in forward order and no preconditions named is not backcasting; it is a forward plan wearing the label. The skill must force the backward direction and precondition-naming.
+
+## 6. Output artifact
+
+The skill must emit a **backcast path**, not prose: a vivid statement of the desired future state, then an ordered chain of milestones working *backward* from that future to now, each milestone naming the preconditions that had to be true before it, terminating in the **next concrete step** available today. A short summary above the chain names the future and the single most important near-term move. The artifact is the deliverable; the conversation is not.
+
+## 7. Sources
+
+1. Lovins, A. B. (1976). "Energy Strategy: The Road Not Taken?" *Foreign Affairs*, 55(1) - early backwards-looking energy-path analysis.
+2. Robinson, J. B. (1982). "Energy backcasting: A proposed method of policy analysis." *Energy Policy*, 10(4):337-344 - names and defines backcasting.
+3. Robinson, J. B. (1990). "Futures under glass: A recipe for people who hate to predict." *Futures*, 22(8):820-842 - backcasting as normative alternative to forecasting.
+4. Dreborg, K. H. (1996). "Essence of backcasting." *Futures*, 28(9):813-828 - when backcasting is appropriate vs forecasting.
+5. Holmberg, J., & Robert, K-H. (2000). "Backcasting from non-overlapping sustainability principles." *International Journal of Sustainable Development & World Ecology*, 7(4) - The Natural Step operationalization.
+
+> **Verification status:** citations 1-5 are standard and well-attested references for backcasting's lineage, drawn from the discovery-corpus synthesis. The exact page numbers and the framing of each finding should be confirmed against the primary papers before they appear in any public-facing README. They are safe to use *inside this dossier* because the dossier's job is to be honest about exactly this uncertainty, and the evidence tier (P) is deliberately conservative.

--- a/skills/tfs-backcasting/references/EXAMPLE.md
+++ b/skills/tfs-backcasting/references/EXAMPLE.md
@@ -1,0 +1,50 @@
+# Backcast Path - Worked Example
+
+A completed run of the `backcasting` skill on a real, consequential goal. This is the quality bar a generated backcast should meet.
+
+---
+
+## Goal under backcast
+
+- **Desired future state:** It is 18 months from now. Northwind's self-serve free tier is the dominant top-of-funnel motion: a majority of new paid customers started self-serve, the free-to-paid path runs without sales touch for small accounts, and sales focuses on the larger deals that self-serve qualifies upward. The free tier pays for itself and the board target for self-serve-sourced revenue is met.
+- **Horizon:** 18 months from now.
+- **Goal status:** Chosen and validated. The decision to pursue a self-serve free tier has been made and compared against alternatives; this backcast maps the route to it, it does not re-litigate it.
+
+## Success conditions (what is true in that future)
+
+- A majority of new paid logos originate from self-serve, not outbound sales.
+- Free-to-paid conversion for small accounts is fully self-serve, with no human touch required to upgrade.
+- Self-serve-sourced revenue meets the board target, and gross margin on the free tier is positive after support and infra cost.
+- Sales operates on a redesigned motion: it works deals that self-serve usage flags as expansion-ready, and comp rewards that.
+
+## Summary (top of the artifact)
+
+The desired future is a self-serve-led growth motion that meets the board's revenue target with a free tier that pays for itself. Working backward, the path turns on three milestones: a **profitable, instrumented free-to-paid funnel** (B-1), which requires a **launched and stable self-serve product with usage-based upgrade prompts** (B-2), which requires a **redesigned sales motion and unit-economics model agreed before any build** (B-3). The single most important next move now is to model the free-tier unit economics and agree the sales comp redesign with leadership, because every later milestone depends on those being settled first.
+
+## Backcast path (future -> now)
+
+Ordered backward: row 1 is closest to the goal, the last row is the next step today. Each milestone names the preconditions that had to be true just before it.
+
+| Step (back) | Milestone (state reached) | Preconditions that had to be true first | Depends on | Owner |
+|---|---|---|---|---|
+| Future | Self-serve is the dominant motion; free tier pays for itself; board target met | - | - | - |
+| B-1 | Free-to-paid funnel is profitable and instrumented; majority of new paid logos self-serve-sourced | Reliable attribution from free signup to paid; positive margin per free user; usage-based upgrade prompts converting at the modeled rate | B-2 | PM (Growth) |
+| B-2 | Self-serve product launched and stable, with usage-based upgrade prompts live | A thin, secure self-serve signup/billing/upgrade flow shipped and load-tested; usage caps and cost controls in place; activation instrumented | B-3 | Eng lead + PM (Growth) |
+| B-3 | Sales motion redesigned and free-tier unit economics agreed, before build | Validated unit-economics model (cost per free user, breakeven conversion); sales comp and lead-routing redesigned and signed off; ICP-fit definition for self-serve agreed | B-4 | VP Sales + RevOps + Finance |
+| B-4 | Cross-functional commitment and a named owner secured | Exec sponsor; a growth PM with self-serve experience hired or assigned; success metrics and the board target made explicit | Now | Head of Product |
+| Now | **Next concrete step (do now):** model the free-tier unit economics and convene sales + finance to agree the comp redesign and breakeven conversion rate | Current cost data, the existing sales comp plan, and one week of leadership time are available today | - | Head of Product |
+
+**Column notes:**
+- **Preconditions that had to be true first:** the load-bearing column. Note that B-2 cannot start until B-3's unit-economics model exists, which is why a forward plan that began with "build the product" would invert the real dependency.
+- **Depends on:** each milestone points to the earlier (lower) milestone that produces its preconditions; the chain closes only because B-4 lands on an action available now.
+
+## Open gaps and assumptions
+
+- **Assumes the goal is right.** This backcast does not test whether self-serve is the correct strategy; that decision was made upstream. If it is wrong, this is a confident route to the wrong place.
+- **Open gap:** B-1 assumes upgrade prompts convert at the modeled rate, but that rate is itself an assumption until B-3's economics work produces it - flagged so it is fixed, not buried.
+- **Sequencing risk:** B-3 (economics + comp) is the true starting constraint, not the product build; if the org's instinct is to ship product first, the path will stall when economics turn out negative late.
+- The path is a plausible route, not a forecast. Reality will diverge; revise the chain as milestones land or slip.
+
+---
+
+*Note how the value is in the reversal: backcasting put the unit-economics-and-comp milestone (B-3) *before* the product build, exposing it as the real starting constraint. A naive forward plan would have led with "build the self-serve product" and discovered the broken economics only after sinking the build cost.*

--- a/skills/tfs-backcasting/references/TEMPLATE.md
+++ b/skills/tfs-backcasting/references/TEMPLATE.md
@@ -1,0 +1,42 @@
+# Backcast Path - Template
+
+Fill this in. The deliverable is the backward milestone chain plus the summary above it, not prose. Build the chain from the future down to today; the next concrete step is the last (earliest) row.
+
+---
+
+## Goal under backcast
+
+- **Desired future state:** [one or two vivid sentences, stated as already true: "It is [horizon]. ..." Concrete and observable, not "things are better."]
+- **Horizon:** [the future point at which this is true, e.g. "18 months from now"]
+- **Goal status:** [chosen and validated / still being decided - if unsettled, stop and choose the goal first; backcasting assumes the endpoint]
+
+## Success conditions (what is true in that future)
+
+- [observable condition 1: a capability, metric, state, or relationship]
+- [observable condition 2]
+- [observable condition 3]
+
+## Summary (top of the artifact)
+
+[3-5 sentences. Name the desired future, the two or three milestones the path turns on, and the single most important next move available now. A reader who stops here should know where this is headed and what to do first.]
+
+## Backcast path (future -> now)
+
+Ordered backward: row 1 is closest to the goal, the last row is the next step today. Each milestone names the preconditions that had to be true just before it.
+
+| Step (back) | Milestone (state reached) | Preconditions that had to be true first | Depends on | Owner |
+|---|---|---|---|---|
+| Future | [the desired future state, restated as the end of the chain] | - | - | - |
+| B-1 | | | | |
+| B-2 | | | | |
+| B-3 | | | | |
+| Now | **Next concrete step (do now):** | [what makes this step possible today] | - | |
+
+**Column notes:**
+- **Preconditions that had to be true first:** the capability, decision, resource, or dependency that must exist *before* this milestone can happen. This is the load-bearing column; a milestone with no named preconditions is a slogan, not a step in a path.
+- **Depends on:** which earlier milestone (further down the table, closer to now) produces this milestone's preconditions. Use this to catch gaps - a precondition that no earlier milestone produces and that does not exist today is an open gap to fill.
+- **Next concrete step:** the earliest link must be an action executable now. The path is not finished until it lands here.
+
+## Open gaps and assumptions
+
+[Preconditions not yet produced by any milestone, dependencies between branches, and assumptions the path rests on. Surface these honestly; backcasting builds a plausible route, it does not guarantee the future arrives in this order or that the goal is the right one.]

--- a/skills/tfs-backcasting/skill.meta.yml
+++ b/skills/tfs-backcasting/skill.meta.yml
@@ -1,0 +1,82 @@
+# Rich sidecar for the tfs-backcasting skill.
+# DRAFT: shape is provisional and will be reconciled with agent-skills-toolkit
+# conventions once 2-3 skills exist. Evidence fields are a hand-authored summary
+# of evidence/dossier.md (the source of truth), not generated from it.
+#
+# Naming: id = <namespace>.<method> = thinking-framework-skills.backcasting;
+# slug = bare method = backcasting; installable name = prefix + slug = tfs-backcasting
+# (the tfs- prefix avoids cross-plugin name collisions; see library.json "prefix").
+
+identity:
+  id: thinking-framework-skills.backcasting
+  slug: backcasting
+  name: tfs-backcasting        # installable name (matches the skill directory)
+  display_name: Backcasting
+  version: 0.1.0
+  status: draft        # draft | experimental | active | deprecated | archived
+  maturity: alpha
+
+classification:
+  primary_family: risk-and-resilience
+  secondary_families: [systems-and-consequences]
+  thinking_modes: [normative, counterfactual, systems]
+  problem_contexts: [high-ambiguity, high-complexity, long-horizon]
+  use_cases:
+    - map a route backward from a transformative or long-horizon desired future to the next step now
+    - decouple a goal from present constraints that forward planning would anchor on
+    - surface the milestones, preconditions, and dependencies between today and a chosen future
+  poor_fit_cases:
+    - near-term simple plans where forward planning is sufficient
+    - the goal is unsettled or unvalidated (choose/test it first; backcasting assumes the endpoint)
+    - imagining how the plan could fail (that is a premortem)
+    - tracing forward consequences of a decision (that is a futures wheel)
+    - personal follow-through on an already-chosen goal (that is WOOP)
+
+interface:
+  required_inputs:
+    - a chosen, describable desired future state (the goal/endpoint)
+  optional_inputs:
+    - a time horizon for the future state
+    - known constraints, resources, or current capabilities
+  primary_artifact_type: backcast-path
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline                 # inline | forked
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.decision-option-review
+    - thinking-framework-skills.premortem
+
+relationships:
+  often_follows: [thinking-framework-skills.decision-option-review]
+  often_precedes: [thinking-framework-skills.premortem]
+  complements: [thinking-framework-skills.futures-wheel]
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run     # see eval/ (harness deferred to the Silver climb)
+  output_eval_status: not-run
+  known_failure_modes:
+    - relabeling a forward to-do list as a backcast (no backward direction, no preconditions named)
+    - building a clean path to an unvalidated or wrong goal
+    - treating the backward chain as a forecast or guarantee rather than a structured hypothesis
+    - stopping at strategy without landing on a concrete next step available now
+
+evidence:
+  evidence_tier: "P"               # practitioner method; limited controlled evidence; see dossier section 3
+  confidence: moderate on the procedural mechanism; low that any outcome improvement has been measured
+  transferred_evidence: true       # human practitioner studies/cases only; not AI-validated
+  lineage:
+    derived_from: [backcasting (Robinson 1982/1990), soft-energy-path analysis (Lovins 1976), The Natural Step]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-backcasting/SKILL.md
+  references_path: skills/tfs-backcasting/references/
+  evidence_path: skills/tfs-backcasting/evidence/dossier.md
+  evals_path: skills/tfs-backcasting/eval/   # harness deferred to the Silver climb

--- a/skills/tfs-decision-journal/SKILL.md
+++ b/skills/tfs-decision-journal/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: tfs-decision-journal
+description: Produces a decision journal entry that records a consequential decision at the moment it is made - the decision, the rationale, the predicted outcome, an explicit confidence level, and the assumptions it rests on - so it can be honestly reviewed later against what actually happened. Use when committing to a consequential, uncertain decision (a launch, hire, investment, bet, or strategic choice) and you want to lock in the prediction now to defeat hindsight bias and build calibration, or when pairing a record-now step with a later review.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.decision-journal
+  family: meta-thinking-and-reflection
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Decision Journal
+
+A decision journal records a decision *at the moment it is made* - the decision, the rationale, the predicted outcome, an explicit confidence level, and the assumptions it rests on - so it can be reviewed later against what actually happened. The load-bearing move is **timing**: the prediction is fixed in place before the outcome is known, while the reasoning and the felt confidence are still uncontaminated by the result. That contemporaneous record is the one reliable defense against hindsight bias ("I knew it all along"), it separates decision quality from outcome quality, and it supplies the recorded-prediction half of a calibration loop. The output is a structured **decision journal entry**, not prose, designed to be reopened and scored later.
+
+## When to Use
+
+- At the point of committing to a consequential, genuinely uncertain decision: a launch, hire, investment, vendor choice, bet, or strategic direction.
+- When you can still state an honest prediction, confidence level, and set of assumptions before the outcome is known.
+- When you intend to review the decision later against reality - it pairs with an after-action review (record now, review later).
+- When you want to build calibration over many decisions, not judge a single one.
+
+## When NOT to Use
+
+- **To review a decision after the outcome is already known.** That is an after-action review (`tfs-after-action-review`); writing a "journal entry" after the result back-fits the prediction, the exact distortion this method exists to prevent.
+- **For trivial or fully reversible (two-way-door) decisions.** The capture overhead is not worth it for a cheaply undone choice with no real uncertainty.
+- **When no expectation can be honestly stated.** If there is no genuine prediction, confidence, or assumption to record, the entry is theater.
+- **To surface only the conditions that must hold for a choice to be right.** That is `tfs-what-would-have-to-be-true`; the journal captures the whole decision plus a predicted outcome and confidence for calibration.
+- **As a substitute for actually reviewing entries later.** A journal nobody revisits delivers no calibration; if there is no intent to review, skip it.
+
+## Instructions
+
+When asked to record a decision journal entry, follow these steps:
+
+1. **Confirm the decision is worth journaling, and not already resolved.** State the decision in one or two sentences. If it is trivial, fully reversible, or the outcome is already known, say so and stop (and for a known outcome, point to `tfs-after-action-review`).
+2. **Record the situation and the rationale.** The context as it stands *now*, and why this choice is being made. Capture the real reasoning, including what makes it a hard call.
+3. **Record the options considered and not taken.** The alternatives on the table and the short reason each was set aside. This is part of the rationale a later review will check.
+4. **State the predicted outcome and an explicit confidence.** What is expected to happen by a stated date, and a confidence as a percentage or band (for example, "70%"). The confidence must be explicit; a prediction without a stated confidence cannot be calibrated.
+5. **Name the assumptions the decision rests on.** The specific things being taken as true that, if wrong, would change the call. List them so they can be checked later, not left implicit.
+6. **Set a review date and the signals to check then.** A concrete date for an after-action review, and the observable signals that will tell you whether the prediction held. This is what makes the entry reviewable rather than a diary note.
+7. **Emit the decision journal entry** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the filled decision journal entry - dated, with a predicted outcome, an explicit confidence, named assumptions, and a review date - not a prose essay.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The entry is dated and written *before* the outcome is known (not a back-fitted record of a decision already resolved).
+- [ ] The predicted outcome is concrete and tied to a stated date.
+- [ ] Confidence is explicit (a percentage or band), so it can be scored later.
+- [ ] The assumptions the decision rests on are named specifically, not left implicit.
+- [ ] A review date and the signals to check then are set, so the entry is actually reviewable.
+- [ ] The output is the decision journal entry artifact, not prose.
+- [ ] No overclaiming: the entry enables honest review and calibration; it is not claimed to make the decision turn out better (see `evidence/dossier.md`).
+
+## Evidence
+
+Tier **P** (practitioner). The mechanism rests on well-supported findings - hindsight bias is real and hard to suppress by willpower (Fischhoff 1975), and recorded probabilistic predictions plus feedback improve calibration over time (Tetlock & Gardner 2015) - but the practice itself, popularized by practitioners (Duke 2018), has **limited controlled evidence** that journaling improves decision outcomes. The journal's value is in making later review honest and calibration possible, not in guaranteeing better results. The evidence is transferred from human studies and practice and has not been validated for AI-augmented use. Full grading, sources, and caveats: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed decision journal entry on a real decision.

--- a/skills/tfs-decision-journal/eval/cases.md
+++ b/skills/tfs-decision-journal/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-decision-journal
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (a harness is deferred to the Silver climb); these are the cases to check by hand, or to wire into evals later.
+
+## Should trigger
+
+- "We're committing to the self-serve free-tier launch today. Before we pull the trigger, I want to write down exactly what we expect and how confident we are, so we can judge it honestly in Q4."
+- "I'm about to make the offer to this VP of Sales candidate. Capture my reasoning and my prediction now so I don't kid myself later about what I knew going in."
+- "Record this decision: we're betting on the in-house build over the vendor. I want my confidence level and assumptions on the record before we find out."
+- "Help me log this investment decision at the moment I make it - the call, why, what I think happens, and how sure I am - so I can review it against reality later."
+- "We keep rewriting history after the fact. I want a contemporaneous record of this strategic bet, with a confidence number and a review date."
+- "I want to start getting better-calibrated on these big calls. Set up an entry for today's decision that I can score later."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "The free-tier launch happened last quarter and the results are in. Help me write up what we expected versus what actually happened and what to change." (near-miss: the outcome is already known - that is an after-action review, `tfs-after-action-review`; a "journal entry" written now would back-fit the prediction)
+- "Should I rename my staging environment? One-line config change I can revert anytime." (trivial / fully reversible - not worth a journal entry)
+- "What would have to be true for the in-house build to be the right call?" (near-miss: that is `tfs-what-would-have-to-be-true`, which surfaces conditions; the journal captures the whole decision plus a predicted outcome and confidence)
+- "Stress-test this launch plan by imagining it has already failed and list the risks." (that is a premortem, a risk tool, not a contemporaneous decision record)
+- "This decision is already locked by contract; just note it for the file." (no honest prediction or confidence to record - nothing to calibrate against)
+- "Write a project status update summarizing what the team shipped this sprint." (unrelated)
+
+## Output checks (a good output must)
+
+- [ ] Be dated and written before the outcome is known (a contemporaneous record, not a back-fitted one after the result).
+- [ ] State a concrete predicted outcome tied to a stated date.
+- [ ] Include an explicit confidence as a percentage or band, so the prediction can be scored later.
+- [ ] Name the specific assumptions the decision rests on, not leave them implicit.
+- [ ] Set a review date and the signals to check then, so the entry is actually reviewable (ideally pairing with an after-action review).
+- [ ] Deliver the decision-journal-entry artifact (header, rationale, options not taken, prediction, assumptions, review), not prose, and not claim journaling made the decision turn out better.
+
+## Value vs unaided baseline
+
+Unprompted, a strong model will discuss the decision and may list pros and cons, but it rarely fixes an explicit confidence number, names the assumptions as checkable items, or sets a review date - the three things that make a record calibratable later. It also tends to blur into either advising the decision or, if asked after the fact, quietly back-fitting what "we expected." This skill enforces contemporaneous capture (dated, before the outcome), a stated confidence and named assumptions, and a concrete review date that pairs with an after-action review, while holding the honest caveat that the entry enables honest review and calibration rather than guaranteeing a better outcome.

--- a/skills/tfs-decision-journal/evidence/dossier.md
+++ b/skills/tfs-decision-journal/evidence/dossier.md
@@ -1,0 +1,80 @@
+# Evidence Dossier: Decision Journal
+
+> The single source of truth for the `decision-journal` skill. The `SKILL.md`, the sidecar
+> (`skill.meta.yml`), and the eval cases all derive from this file. If a claim is not
+> here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.decision-journal` (installable name `tfs-decision-journal`) |
+| **Family** | meta-thinking-and-reflection |
+| **Evidence tier** | **P** (practitioner - useful method, limited controlled evidence; see "What the evidence shows") |
+| **Confidence** | Moderate that recording-at-decision-time defeats hindsight distortion; low that journaling alone improves decision outcomes |
+| **Status** | draft (first authored 2026-05-31, against discovery corpus) |
+
+---
+
+## 1. The mechanism (what actually does the work)
+
+A decision journal **records a decision at the moment it is made** - the decision itself, the rationale, the expected outcome, the confidence, and the assumptions it rests on - so that the decision can be reviewed later against what actually happened. The load-bearing move is **timing**: the record is written *before* the outcome is known, while the reasoning and the felt confidence are still intact and uncontaminated by the result. It does three things:
+
+1. **Defeats hindsight bias by pre-committing the prediction.** Once an outcome is known, memory silently rewrites what "we knew all along." A contemporaneous record fixes the prediction in place so the later review compares against what was actually expected, not a back-fitted version of it. This is the durable cognitive move; the notebook is just the means.
+2. **Makes confidence and assumptions explicit and checkable.** Forcing a stated confidence level and a list of named assumptions turns a vague feeling ("I'm pretty sure") into something that can later be scored, which is the raw material for calibration over many decisions.
+3. **Separates decision quality from outcome quality.** Because the rationale is recorded independent of the result, a later review can ask "was this a good decision given what was knowable then?" rather than only "did it work out?" - guarding against outcome bias (judging a good process by a bad roll of the dice, or vice versa).
+
+The mechanism is what we implement. "Decision journal" is the descriptive packaging; the durable move is contemporaneous capture of decision, rationale, predicted outcome, confidence, and assumptions, structured for honest later review.
+
+## 2. Lineage
+
+- **Decision journaling as a calibration practice** is most associated with poker player and decision researcher Annie Duke, *Thinking in Bets* (2018), and with investor/practitioner writing (e.g. Shane Parrish / Farnam Street's "decision journal" templates, drawing on Daniel Kahneman's advice to record reasoning at decision time).
+- **The cognitive bias it counters - hindsight bias** ("I knew it all along") is well-established in the psychology literature: Fischhoff, B. (1975), "Hindsight is not equal to foresight," *Journal of Experimental Psychology: Human Perception and Performance*, 1(3), 288-299; Roese, N. J., & Vihari, K. (2012), "Hindsight bias," *Perspectives on Psychological Science*, 7(5), 411-426.
+- **Calibration of subjective probability** through recorded prediction and feedback draws on the forecasting and calibration literature: Lichtenstein, Fischhoff & Phillips (1982); and the practice of scored forecasting (Tetlock & Gardner, *Superforecasting*, 2015), where writing down a probability and later scoring it is what makes calibration possible.
+
+No trademark. "Decision journal" is a generic, descriptive term in common practitioner use; no attribution is required and none is claimed. We name the skill descriptively and cite the lineage here.
+
+## 3. What the evidence shows, and what it does NOT show
+
+This is the honest core of the dossier. The skill must not overclaim.
+
+**What is reasonably supported:**
+- **Hindsight bias is real, robust, and hard to suppress by willpower.** Fischhoff (1975) and the subsequent literature show that once people know an outcome, they systematically misremember their prior predictions as closer to the truth. A contemporaneous record is one of the few reliable defenses, because it removes the need to remember the prediction at all.
+- **Calibration improves with recorded predictions and feedback.** The forecasting literature (Tetlock; Lichtenstein et al.) shows that people who record probabilistic predictions and then score them against outcomes can become measurably better calibrated over time. A decision journal supplies exactly the recorded-prediction half of that loop.
+
+**What is NOT shown (the caveat that keeps the skill honest):**
+- There is **no strong controlled evidence that keeping a decision journal improves decision outcomes.** The supported claims are about (a) the existence of hindsight bias and (b) calibration improving under recorded-prediction-plus-feedback regimes. The leap from "journaling defeats hindsight bias and enables calibration" to "journaling makes your decisions turn out better" is **plausible but not established by controlled study.** The journal's value is in making later review *honest* and calibration *possible*, not in guaranteeing better results.
+- Much of the practitioner enthusiasm (Duke, Parrish, investor blogs) is **experience-based, not experimental.** It is credible and internally consistent, but it is testimony, not a trial. Grade it as practitioner evidence, not strong evidence.
+- A journal **only pays off if it is actually reviewed later.** A drawer full of unreviewed entries delivers none of the calibration benefit; it is a cost with no return. The evidence for benefit is contingent on the review half of the loop happening.
+
+**Net grade: P (practitioner).** A genuinely useful method with a sound mechanistic rationale (hindsight bias is real; recorded predictions enable calibration) but **limited controlled evidence that the practice itself improves outcomes.** The skill should claim the honest-review and calibration-enabling benefits and explicitly disclaim a guaranteed-better-outcome benefit.
+
+## 4. Transferred-evidence flag (required honesty for this library)
+
+All of the evidence above comes from **human subjects and human practitioners** - lab studies of hindsight bias, forecasting tournaments, and the experience of human decision-makers keeping journals. There is **no direct study** of decision journals authored by, or with, an AI agent, and none of whether an AGENT-produced journal entry improves a human's later calibration. The evidence supporting this skill is therefore **transferred from human contexts, not validated for AI-augmented use.** This skill must say so. Treat the AI value as: the agent makes the capture cheap and immediate (the moment-of-decision friction is what kills the practice in humans), enforces the full structure (decision, rationale, predicted outcome, confidence, assumptions), and produces a durable, reviewable artifact - benefits that do not depend on the unproven outcome-improvement claim.
+
+## 5. When it works / when it fails (drives the eval negative cases)
+
+**Works best when:**
+- The decision is consequential and *not yet resolved*, so a genuine prediction can still be recorded before the outcome is known.
+- An honest expectation, confidence level, and set of assumptions can actually be stated (there is real uncertainty and a real basis for a prediction).
+- There is an intention to review the entry later, against the actual outcome (it pairs with an after-action review).
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **Reviewing a decision after the outcome is already known** - that is an after-action review (`tfs-after-action-review`), which compares expected-vs-actual *after the fact*. The decision journal records the expectation *at decision time* precisely so that the later AAR has something honest to compare against. Writing a "journal entry" after you know the result is back-fitting, the exact distortion the method exists to prevent. (Anti-trigger and the key near-miss.)
+- **Trivial or fully reversible (two-way-door) decisions** - the capture overhead is not worth it for a choice you can cheaply undo or that has no meaningful uncertainty.
+- **When no expectation can be honestly stated** - if there is no real prediction, confidence, or assumption to record (the outcome is already determined, or the "decision" is a formality), there is nothing to calibrate against and the entry is theater.
+- **Surfacing the conditions that must hold for a choice to be right** is a different tool (`tfs-what-would-have-to-be-true`); the journal captures the *whole* decision plus a *predicted outcome and confidence* for later calibration, not just the load-bearing conditions.
+- **As a substitute for actually reviewing entries** - a journal nobody revisits delivers no calibration. If there is no intent to review, the cost is unrecovered.
+
+## 6. Output artifact
+
+The skill must emit a **decision journal entry**, not prose: a dated, structured record with the decision, the situation/context, the rationale, the options considered and not taken, the **predicted outcome**, an explicit **confidence** (a percentage or band), the named **assumptions** the decision rests on, and a **review date** with the expected signals to check then. The artifact is the deliverable; a discursive write-up is not. It is designed to be reopened later (by an after-action review) and scored against reality.
+
+## 7. Sources
+
+1. Fischhoff, B. (1975), "Hindsight is not equal to foresight," *J. Experimental Psychology: Human Perception and Performance* 1(3):288-299 - establishes hindsight bias.
+2. Roese, N. J., & Vihari, K. (2012), "Hindsight bias," *Perspectives on Psychological Science* 7(5):411-426 - review of the robustness of the effect.
+3. Duke, A. (2018), *Thinking in Bets* - decision journaling, separating decision quality from outcome quality, practitioner source.
+4. Tetlock, P., & Gardner, D. (2015), *Superforecasting* - recorded probabilistic predictions plus scoring as the basis for calibration.
+5. Lichtenstein, S., Fischhoff, B., & Phillips, L. D. (1982), "Calibration of probabilities," in Kahneman, Slovic & Tversky (eds.), *Judgment under Uncertainty* - calibration literature.
+
+> **Verification status:** citations 1-2 and 4-5 are standard and well-attested. Citation 3 (Duke) and the Parrish/Farnam Street decision-journal templates are practitioner sources, credible but experience-based; they are cited as lineage and as the origin of the practice, not as controlled evidence of outcome improvement. The "no strong controlled evidence that journaling improves outcomes" statement in section 3 reflects the absence of such a study in the discovery corpus as of authoring; it should be re-checked before any public-facing claim, but the honest default is to not claim outcome improvement.

--- a/skills/tfs-decision-journal/references/EXAMPLE.md
+++ b/skills/tfs-decision-journal/references/EXAMPLE.md
@@ -1,0 +1,48 @@
+# Decision Journal Entry - Worked Example
+
+A completed run of the `decision-journal` skill on a real, consequential decision, recorded at the moment of commitment. This is the quality bar a generated entry should meet. Note that it is written *before* the outcome is known - there is no hindsight in it.
+
+---
+
+## Entry header
+
+- **Date recorded:** 2026-05-31
+- **Decision:** Launch a self-serve free tier of Northwind (our B2B SaaS) in 6 weeks to accelerate top-of-funnel growth ahead of the Q3 board target, rather than doubling down on the existing sales-led motion.
+- **Decided by / owner:** VP Product (with sign-off from CEO and VP Sales)
+- **Reversibility:** One-way door in practice. Pulling a free tier after launch is possible but damages trust and is publicly visible, so we are treating it as hard to reverse.
+
+## Situation and rationale
+
+Sales-led growth is hitting a ceiling; pipeline is flat quarter over quarter and the Q3 board target assumes a step change in top-of-funnel volume that the current motion will not deliver. A self-serve free tier is the fastest lever we believe we have to widen the funnel. We are choosing it now, over the safer alternatives, because we judge the growth risk of doing nothing to be larger than the cannibalization risk of acting, and because the window to show movement before the Q3 board meeting is closing. It is a hard call: the team is split on whether free will feed paid or eat it.
+
+## Options considered and not taken
+
+| Option | Why set aside |
+|---|---|
+| Launch a self-serve free tier in 6 weeks (chosen) | Fastest path to the funnel step change the board target needs; we judge upside to outweigh cannibalization risk |
+| Double down on sales-led motion (hire 3 more reps) | Slower ramp, will not move top-of-funnel volume in time for Q3; ceiling concern unaddressed |
+| Time-limited free trial instead of a free tier | Lower cannibalization risk but weaker top-of-funnel pull; team judged it insufficient for the target |
+| Do nothing this quarter, revisit in Q4 | Misses the board target window; the growth risk of inaction is the thing we are most worried about |
+
+## Prediction
+
+- **Predicted outcome:** By 6 months after launch (end of Q4), self-serve drives 3x sign-up volume and a measurable, positive lift in net-new paid conversions, *without* a net decline in sales-led paid MRR.
+- **Confidence:** 60%. (We are genuinely split; the 60% reflects real disagreement, not a round-number placeholder.)
+- **What would surprise me:** Net-new paid MRR falling below the pre-launch trend - that would mean free cannibalized paid rather than feeding it, and would prove the cautious half of the team right.
+
+## Assumptions this rests on
+
+1. The free tier can be scoped so that the highest-value features stay behind paid, so free feeds paid rather than replacing it.
+2. Support and infrastructure cost per free user stays within the modeled ceiling (free users do not swamp the team or blow the unit economics).
+3. Sales comp and lead-routing are redesigned before launch, so reps do not undercut or resent the motion.
+4. The 6-week timeline is enough to ship a thin but secure self-serve billing-and-auth path.
+5. "Free" attracts users who fit our ICP, not a different, never-converting segment.
+
+## Review
+
+- **Review date:** 2026-11-30 (end of Q4, 6 months post-launch). Reopen this entry via an after-action review.
+- **Signals to check then:** net-new paid MRR trend vs pre-launch; free-to-paid conversion rate among ICP-fit users; support tickets and cloud cost per free user vs the model; sales-team behavior and pipeline complaints; whether sign-up volume actually hit 3x.
+
+---
+
+*Value added: recorded at commitment, this entry fixes a 60% confidence and five named assumptions in place* before *the outcome is known. When the Q4 after-action review reopens it, the team will compare results against what they actually predicted - not a hindsight-rewritten version where "we always knew free would work" or "it was obviously a mistake." That honest expected-vs-actual comparison, and the calibration it feeds over many such decisions, is the value; the entry makes no claim that journaling made the launch itself succeed.*

--- a/skills/tfs-decision-journal/references/TEMPLATE.md
+++ b/skills/tfs-decision-journal/references/TEMPLATE.md
@@ -1,0 +1,48 @@
+# Decision Journal Entry - Template
+
+Fill this in *at the moment the decision is made*, before the outcome is known. The deliverable is the structured entry, not prose. It is designed to be reopened later (by an after-action review) and scored against reality.
+
+---
+
+## Entry header
+
+- **Date recorded:** [the date the decision is being made - this is load-bearing; the entry must predate the outcome]
+- **Decision:** [one or two sentences: what is being committed to]
+- **Decided by / owner:** [who owns this decision]
+- **Reversibility:** [one-way door / two-way door - if fully reversible and low stakes, a journal entry may not be warranted]
+
+## Situation and rationale
+
+[The context as it stands now, and why this choice is being made. Capture the real reasoning, including what makes it a hard call. A reader six months from now should understand the world you were deciding in, with no benefit of hindsight.]
+
+## Options considered and not taken
+
+| Option | Why set aside |
+|---|---|
+| [the chosen option, restated] | [chosen because ...] |
+| [alternative considered] | [set aside because ...] |
+| [alternative considered] | [set aside because ...] |
+
+## Prediction
+
+- **Predicted outcome:** [what is expected to happen, concretely, by the review date]
+- **Confidence:** [an explicit percentage or band, e.g. "70%" - a prediction without a stated confidence cannot be calibrated]
+- **What would surprise me:** [the result that would make me say I was wrong]
+
+## Assumptions this rests on
+
+[The specific things being taken as true that, if wrong, would change the call. List them so they can be checked later, not left implicit.]
+
+1. [assumption]
+2. [assumption]
+3. [assumption]
+
+## Review
+
+- **Review date:** [a concrete date to reopen this entry, ideally via an after-action review]
+- **Signals to check then:** [the observable signals that will tell you whether the prediction held]
+
+**Field notes:**
+- **Confidence** is what makes the entry calibratable. Over many entries, comparing stated confidence to actual hit rate is the calibration signal; a single entry cannot give it to you.
+- **Review date** is what turns the entry from a diary note into a tool. An entry that is never reopened delivers no calibration. Pair this with `tfs-after-action-review` when the review date arrives.
+- Do not edit the prediction, confidence, or assumptions after the outcome is known. The point of the record is that it is fixed; rewriting it reintroduces the hindsight bias the entry exists to defeat.

--- a/skills/tfs-decision-journal/skill.meta.yml
+++ b/skills/tfs-decision-journal/skill.meta.yml
@@ -1,0 +1,86 @@
+# Rich sidecar for the tfs-decision-journal skill.
+# DRAFT: shape is provisional and will be reconciled with agent-skills-toolkit
+# conventions once 2-3 skills exist. Evidence fields are a hand-authored summary
+# of evidence/dossier.md (the source of truth), not generated from it.
+#
+# Naming: id = <namespace>.<method> = thinking-framework-skills.decision-journal;
+# slug = bare method = decision-journal; installable name = prefix + slug =
+# tfs-decision-journal (the tfs- prefix avoids cross-plugin name collisions;
+# see library.json "prefix").
+
+identity:
+  id: thinking-framework-skills.decision-journal
+  slug: decision-journal
+  name: tfs-decision-journal   # installable name (matches the skill directory)
+  display_name: Decision Journal
+  version: 0.1.0
+  status: draft        # draft | experimental | active | deprecated | archived
+  maturity: alpha
+
+classification:
+  primary_family: meta-thinking-and-reflection
+  secondary_families: [risk-and-resilience]
+  thinking_modes: [reflective, metacognitive, probabilistic]
+  problem_contexts: [high-stakes, high-ambiguity]
+  use_cases:
+    - record a consequential decision at the moment it is made, before the outcome is known
+    - lock in a predicted outcome, confidence, and assumptions to defeat hindsight bias
+    - build calibration over many decisions by recording the prediction half of the loop
+    - pair a record-now step with a later after-action review
+  poor_fit_cases:
+    - reviewing a decision after the outcome is known (use after-action-review)
+    - trivial or fully reversible (two-way-door) decisions
+    - when no honest expectation, confidence, or assumption can be stated
+    - surfacing only the conditions that must hold (use what-would-have-to-be-true)
+    - keeping entries with no intention of ever reviewing them
+
+interface:
+  required_inputs:
+    - a specific, not-yet-resolved decision being committed to
+  optional_inputs:
+    - a target date for the predicted outcome
+    - known constraints, options considered, or prior reasoning
+  primary_artifact_type: decision-journal-entry
+  output_formats: [markdown]
+
+execution:
+  mode: inline                 # inline | forked
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.after-action-review
+    - thinking-framework-skills.premortem
+    - thinking-framework-skills.one-way-vs-two-way-door
+
+relationships:
+  often_follows: [thinking-framework-skills.decision-option-review, thinking-framework-skills.premortem]
+  often_precedes: [thinking-framework-skills.after-action-review]
+  complements: [thinking-framework-skills.after-action-review]
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run     # see eval/ (harness deferred to the Silver climb)
+  output_eval_status: not-run
+  known_failure_modes:
+    - back-fitting an entry after the outcome is known (reintroduces hindsight bias)
+    - omitting an explicit confidence, so the prediction cannot be calibrated
+    - leaving assumptions implicit rather than naming them for later checking
+    - setting no review date, so the entry is never reopened and delivers no calibration
+    - overclaiming that journaling improves the decision outcome itself
+
+evidence:
+  evidence_tier: "P"               # practitioner; useful method, limited controlled evidence; see dossier section 3
+  confidence: moderate on the hindsight/calibration mechanism; low on outcome improvement
+  transferred_evidence: true       # human-subject studies and practitioner experience only; not AI-validated
+  lineage:
+    derived_from: [hindsight-bias research, calibration/forecasting practice, decision-journaling practitioner method]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-decision-journal/SKILL.md
+  references_path: skills/tfs-decision-journal/references/
+  evidence_path: skills/tfs-decision-journal/evidence/dossier.md
+  evals_path: skills/tfs-decision-journal/eval/

--- a/skills/tfs-iceberg-model/SKILL.md
+++ b/skills/tfs-iceberg-model/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: tfs-iceberg-model
+description: Produces an iceberg that moves a problem down four levels of causation - from the visible event, to the pattern over time, to the underlying structures, to the mental models that hold them in place - pairing each level with the intervention it implies to find systemic causes and higher-leverage fixes. Use when a problem keeps recurring despite event-level fixes, when a symptom is being treated as a one-off, or when the question is why this keeps happening and where to actually intervene.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.iceberg-model
+  family: systems-and-consequences
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Iceberg Model
+
+The default response to a problem is to react to the visible **event**. The iceberg model resists that by moving the problem down four levels, from the tip toward the mass under the water: the **event** (what just happened), the **pattern** (what has been happening over time), the **structures** (the policies, incentives, resource flows, and feedback loops that generate the pattern), and the **mental models** (the beliefs and assumptions that hold those structures in place). Descending past the event is the work, because structure and mindset are where higher-leverage interventions sit. Each level is paired with the intervention it implies: event-level fixes are reactive and low-leverage, structure- and model-level fixes are higher-leverage and slower. The output is an **iceberg**, not a discussion.
+
+## When to Use
+
+- A problem keeps recurring despite repeated event-level fixes, hinting at a structural cause.
+- A symptom is being treated as a one-off when it is the latest instance of a pattern.
+- The real question is "why does this keep happening, and where do we actually intervene?"
+- There is appetite to consider structural or mindset interventions, not only quick reactive fixes.
+
+## When NOT to Use
+
+- **A simple, linear, single-cause problem.** One event, one obvious cause, a known fix. Forcing four levels manufactures false depth; say it is a simple cause and stop.
+- **Mapping forward consequences** ("if we do this, then what happens next?"). That is the futures wheel, which maps outward to effects. The iceberg maps downward to causes.
+- **Auditing one person's reasoning** from data to conclusion. That is the ladder of inference check. The iceberg is about systemic levels of causation, not one person's inference chain.
+- **As a ritual** that fills four labeled boxes with no honest descent and no intervention paired to each level. A tidy diagram with no leverage is theater.
+
+## Instructions
+
+When asked to build an iceberg, follow these steps:
+
+1. **State the event.** Name the visible occurrence in one or two sentences, as it would be reported. If it is a genuine one-off with a single obvious cause, say so and stop; the iceberg is the wrong tool here.
+2. **Find the pattern.** Ask "what has been happening over time?", not "what just happened?". Describe the trend, frequency, or history this event belongs to. If there is no pattern, recheck whether this is really a systemic problem.
+3. **Surface the structures.** Identify the policies, incentives, comp plans, resource flows, ownership boundaries, and feedback loops that would generate that pattern. This is the load-bearing level; do not skip it to get to mindset.
+4. **Name the mental models.** Surface the beliefs, assumptions, and shared stories that make the structures feel normal and keep them in place. State them as the system would, even when uncomfortable.
+5. **Pair each level with an intervention and its leverage.** For each level, name the intervention it implies and tag its leverage: event-level is reactive/low, pattern-level is managerial, structure- and model-level are higher and slower. Call out the highest-leverage intervention.
+6. **Emit the iceberg and a short summary.** Produce the artifact in `references/TEMPLATE.md`: a one-paragraph "what is really going on, and where to intervene" summary above the four-level iceberg with its paired interventions.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the filled four-level iceberg plus its summary, not a prose essay.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] All four levels are present and distinct: event, pattern, structures, mental models (not the same idea reworded four times).
+- [ ] The descent actually reaches structures and mental models; it does not stop at event or pattern.
+- [ ] Mental models are stated as honest beliefs/assumptions, including uncomfortable ones, not restated structures.
+- [ ] Each level is paired with the intervention it implies, tagged by leverage, and the highest-leverage intervention is called out.
+- [ ] If the problem is genuinely a simple single cause, the skill said so and stopped rather than manufacturing depth.
+- [ ] The output is the iceberg artifact, not prose.
+- [ ] No overclaiming: leverage is a judgment for argument, not a measured or proven effect (see `evidence/dossier.md`).
+
+## Evidence
+
+Tier **P**. The iceberg is an established systems-thinking and organizational-learning tool (Senge, *The Fifth Discipline*, 1990; Meadows on leverage points, 1999/2008), valued for pushing analysis below the event level to structure and mindset, where higher-leverage interventions sit. Its validation is qualitative and pedagogical; there is no strong controlled evidence that it produces better outcomes than ordinary root-cause analysis, and "higher-leverage" is a judgment, not a measurement. Evidence is transferred from human practice, not AI-validated. Full grading, sources, and caveats: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed iceberg on a real decision.

--- a/skills/tfs-iceberg-model/eval/cases.md
+++ b/skills/tfs-iceberg-model/eval/cases.md
@@ -1,0 +1,35 @@
+# Eval cases: tfs-iceberg-model
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (a harness is deferred to the Silver climb); these are the cases to check by hand, or to wire into evals later.
+
+## Should trigger
+
+- "Enterprise accounts keep churning inside 90 days and the save calls aren't working. Why does this keep happening, and where do we actually intervene?"
+- "We keep firefighting the same production incidents every few weeks. I want to get below the latest outage to whatever structure is causing the pattern."
+- "Support keeps escalating the same complaint. Treating each ticket as a one-off isn't fixing it - help me see the events, the pattern, the structures, and the beliefs underneath."
+- "Our sales reps keep sandbagging forecasts. Move this from the symptom down to the incentives and mental models that produce it."
+- "Build me an iceberg on why our onboarding handoff keeps failing for new accounts."
+- "Every quarter we miss the same deadline and every quarter we blame the quarter. What's the systemic cause beneath this recurring miss?"
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "We're about to launch a self-serve free tier. Map the knock-on effects over time - if we ship it, then what happens next across the business?" (near-miss vs futures-wheel: maps forward/outward to consequences, not downward to causes)
+- "My PM concluded the feature failed because users hate it. Walk back how she got from the data to that conclusion and test an alternative reading." (near-miss vs ladder-of-inference-check: one person's data-to-conclusion reasoning, not systemic levels of causation)
+- "The deploy failed because the cert expired at midnight. Renew it and we're done." (simple, linear, single cause - no iceberg needed)
+- "Brainstorm names for our new free tier." (ideation, not causal analysis)
+- "Summarize this 10-page incident report into a paragraph." (summarization)
+- "We've decided to rebuild checkout in-house; this is the last gate before we commit budget. Surface what could blow up." (premortem: risk on a forward decision, not the causes of a recurring problem)
+
+## Output checks (a good output must)
+
+- [ ] Be a four-level iceberg artifact (event, pattern, structures, mental models), not prose.
+- [ ] Actually descend to structures and mental models, not stop at event or pattern.
+- [ ] Distinguish the four levels as different things, not the same idea reworded four times.
+- [ ] State mental models as honest beliefs/assumptions (including uncomfortable ones), not restated structures.
+- [ ] Pair each level with the intervention it implies, tag its leverage, and call out the single highest-leverage intervention.
+- [ ] Either confirm the problem is systemic (a real pattern) or, if it is a genuine single-cause one-off, say so and stop rather than manufacturing depth.
+- [ ] Not present the leverage ranking as a measured or proven effect (it is a judgment for argument).
+
+## Value vs unaided baseline
+
+Asked the same question, a frontier model tends to react at the event level - diagnose the latest incident and propose a direct fix - or, at best, name a single root cause without separating the pattern over time, the structures generating it, and the mental models holding those structures in place. This skill forces the full downward descent through all four levels, pairs each with the intervention it implies, surfaces uncomfortable beliefs the baseline glosses, and calls out a higher-leverage structural or mindset intervention than another reactive fix - while honestly framing leverage as a judgment, not a validated measurement (its evidence is transferred systems-thinking practice, not AI-validated outcome data).

--- a/skills/tfs-iceberg-model/evidence/dossier.md
+++ b/skills/tfs-iceberg-model/evidence/dossier.md
@@ -1,0 +1,77 @@
+# Evidence Dossier: Iceberg Model
+
+> Single source of truth for the `iceberg-model` skill. The SKILL.md, sidecar, and evals derive from this. If a claim is not here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.iceberg-model` (installable name `tfs-iceberg-model`) |
+| **Family** | systems-and-consequences |
+| **Evidence tier** | **P** (systems-thinking practitioner; conceptual model, limited controlled evidence) |
+| **Confidence** | Moderate that reacting to events alone misses systemic causes; the four levels are a useful lens, not a validated instrument |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+The default response to a problem is to react to the **event**: the visible thing that just happened. The iceberg model resists that by moving the problem down four levels, from the tip toward the mass under the water:
+
+1. **Event** - the single visible occurrence. ("Three enterprise accounts churned this month.")
+2. **Patterns / trends** - the same kind of event seen over time. ("Enterprise churn has crept up every quarter for a year.") Asking "what has been happening?" instead of "what just happened?" is the first real move.
+3. **Structures** - the relationships, policies, incentives, resource flows, and feedback loops that generate the pattern. ("Onboarding is owned by sales, who are comped on new logos, not retention, so new accounts are handed off without a success plan.") This is where leverage lives.
+4. **Mental models** - the beliefs, assumptions, and shared stories that hold the structures in place and make them feel normal. ("We believe growth comes from new logos; retention is 'customer success's problem,' not ours.")
+
+The work is done by two disciplines the bare label does not guarantee. First, **descending** all four levels rather than stopping at the event or pattern: most analysis halts before structure, which is exactly where higher-leverage interventions sit. Second, **pairing each level with the intervention it implies** and noting that event-level fixes are low-leverage and reactive while structure- and model-level fixes are higher-leverage and slower. The payoff is naming a systemic cause and a higher-leverage intervention than "react to the event."
+
+The mechanism is what we implement. "Iceberg" is the packaging; the durable move is descending levels of causation from symptom to structure to mindset.
+
+## 2. Lineage
+
+- The iceberg / "levels of perspective" model is a staple of the **systems-thinking** and **organizational-learning** tradition, associated with Peter Senge's *The Fifth Discipline* (1990) and the Society for Organizational Learning, and taught widely by systems-education groups (for example, the Waters Center for Systems Thinking and Donella Meadows' work on leverage points).
+- The "mental models" level draws on Senge's discipline of surfacing mental models; the "leverage" framing draws on Meadows, *Leverage Points: Places to Intervene in a System* (1999) and *Thinking in Systems* (2008).
+
+No trademark. The iceberg model is a generic, widely taught diagram; named descriptively here, lineage cited rather than branded.
+
+## 3. What the evidence shows, and what it does NOT show
+
+This is the honest core. The skill must not overclaim.
+
+**Supported (practitioner / conceptual):**
+- The iceberg is an established, widely taught systems-thinking tool, valued precisely because it pushes analysis below the event level to structure and mindset, where systems thinkers locate higher-leverage interventions (Meadows on leverage points).
+- The underlying claim that durable problems often recur because of structures and incentives, not one-off events, is broadly accepted in systems thinking and organizational learning, and is consistent with everyday observation of recurring failures.
+
+**NOT shown (the caveat that keeps the skill honest):**
+- There is **no strong controlled evidence** that running an iceberg analysis produces better outcomes than ordinary root-cause analysis. Its validation is qualitative, pedagogical, and case-based, not experimental.
+- "Higher-leverage" is a **judgment, not a measurement.** The model does not quantify leverage or rank interventions by measured effect; it offers a lens for argument, and the structure/model levels it surfaces can be speculative.
+- The model can **invite overreach**: not every event has a deep systemic cause, and forcing a four-level descent onto a genuinely one-off or single-cause problem manufactures false structure. The skill must allow stopping early and saying "this is a simple cause."
+
+**Net grade: P.** A useful practitioner lens with limited controlled evidence. Claim that it surfaces systemic causes and candidate higher-leverage interventions that event-level reaction misses; do not claim it produces measurably better decisions or that its leverage judgments are validated.
+
+## 4. Transferred-evidence flag (required honesty for this library)
+
+All of the support above comes from **human** systems-thinking practice, education, and case writing. There is **no direct study** of an iceberg analysis run by, or with, an AI agent, and none of whether an agent-produced iceberg improves a human's intervention choice. The evidence is therefore **transferred from human practice, not validated for AI-augmented use.** The skill must say so. Treat the AI value as: a model defaults to reacting at the event level, so forcing the descent to patterns, structures, and mental models, and pairing each level with its leverage, is a direct counter that produces a durable artifact - benefits that do not depend on any unproven outcome claim.
+
+## 5. When it works / when it fails (drives the eval negative cases and "When NOT to Use")
+
+**Works best when:**
+- A problem keeps **recurring** despite event-level fixes, suggesting a structural cause.
+- A symptom is being treated as a one-off when it is really the latest instance of a pattern.
+- The question is "why does this keep happening, and where do we actually intervene?" rather than "what just happened?"
+- There is appetite to consider structural or mindset interventions, not only quick reactive fixes.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **A genuinely simple, linear, single-cause problem** - one event with one obvious cause and a known fix. Forcing four levels manufactures false depth. (Anti-trigger.)
+- **Mapping forward consequences** ("if we do this, then what happens next?") - that is the futures wheel, which maps *outward/forward* to effects. The iceberg maps *downward* to causes. (Near-miss anti-trigger.)
+- **Auditing one person's reasoning** - how an individual climbed from data to a conclusion is the ladder of inference check. The iceberg is about *systemic levels of causation*, not one person's inference chain. (Near-miss anti-trigger.)
+- **Run as ritual** - filling four labeled boxes with no honest descent and no intervention paired to each level produces a tidy diagram and no leverage. The skill must force the level-to-intervention pairing.
+- **As prediction or measurement** - the leverage ranking is a judgment for argument, not a measured effect; presenting it as proven misleads.
+
+## 6. Output artifact
+
+The skill must emit an **iceberg**, not prose: the problem placed at the event level, then the pattern over time, then the underlying structures, then the mental models, each level paired with the candidate intervention it implies and a note on that intervention's leverage (reactive/low at the event level, higher and slower at the structure and model levels), with the highest-leverage intervention called out. A short "what is really going on, and where to intervene" summary sits above it.
+
+## 7. Sources
+
+1. Senge, P. (1990). *The Fifth Discipline: The Art and Practice of the Learning Organization* - systems thinking, the discipline of surfacing mental models, levels of perspective.
+2. Meadows, D. (1999). *Leverage Points: Places to Intervene in a System*; and Meadows, D. (2008). *Thinking in Systems: A Primer* - structures, feedback loops, and where intervention has the most leverage.
+3. Waters Center for Systems Thinking (and related systems-education materials) - the iceberg as a teaching tool for moving from events to patterns to structures to mental models.
+
+> **Verification status:** the Senge and Meadows attributions are standard and well-attested; the specific framing of the four-level iceberg as a teaching diagram is drawn from systems-education practice and a secondary research synthesis and should be confirmed against primary curricula before any public-facing claim. Do not attach outcome-improvement or measured-leverage claims; the method's validation is qualitative and pedagogical.

--- a/skills/tfs-iceberg-model/references/EXAMPLE.md
+++ b/skills/tfs-iceberg-model/references/EXAMPLE.md
@@ -1,0 +1,32 @@
+# Iceberg - Worked Example
+
+A completed run of `tfs-iceberg-model`, on the shared Northwind scenario. This is the quality bar a generated iceberg should meet.
+
+> Northwind is a B2B SaaS weighing a self-serve free-tier launch. Here the skill is pointed at a problem that keeps recurring in the run-up to that launch: newly signed accounts keep churning fast, and reacting account-by-account has not stopped it. The iceberg moves that event downward to its systemic causes, rather than forward to consequences (that is the futures wheel's job).
+
+---
+
+## Problem under examination
+
+- **Event:** Three enterprise accounts signed in the last two quarters churned within 90 days, the latest one this month after a single escalation.
+- **Why now:** It keeps happening, and the reactive fix (a manager jumps on a save call) is not landing. Leadership is about to add a self-serve free tier, which will pour even more new accounts into the same funnel.
+- **One-off check:** Not a one-off. This is the latest instance of a repeating pattern, so the iceberg is the right tool.
+
+## What is really going on, and where to intervene (summary)
+
+The churned account is the visible tip; the pattern is that fast enterprise churn has crept up every quarter for a year. Beneath it sits the load-bearing structure: onboarding is owned by Sales, who are comped on new logos and not on retention, so accounts are handed off at signature with no success plan and no owner for the first 90 days. Holding that structure in place is the mental model that "growth comes from new logos, and retention is Customer Success's problem, not ours." Reacting to each churn (the save call) is the lowest-leverage move and explains why nothing changes. The highest-leverage intervention is structural: give the first 90 days a named owner and tie part of Sales comp to retained revenue, not just bookings - and do it before the free tier multiplies the inflow.
+
+## The iceberg
+
+| Level | What is going on at this level | Intervention it implies | Leverage |
+|---|---|---|---|
+| **Event** (what just happened) | An enterprise account churned within 90 days after one unresolved escalation | Run a save call; fix that customer's specific complaint | Reactive / low |
+| **Pattern** (what has been happening over time) | Fast (<90-day) enterprise churn has risen every quarter for a year; saves rarely stick | Track 90-day churn as a standing metric; staff a recovery playbook | Managerial / medium |
+| **Structures** (policies, incentives, resource flows, feedback loops) | Onboarding owned by Sales; reps comped on new logos, not retention; no owner for the first 90 days; CS engages only after a ticket escalates | Give the first 90 days a named owner; tie part of Sales comp to retained revenue; trigger CS at signature, not at escalation | Higher / slower |
+| **Mental models** (beliefs and assumptions holding the structures in place) | "Growth comes from new logos." "Retention is Customer Success's problem, not Sales's." "A signed contract means the deal is won." | Reframe the goal as retained revenue, not bookings; treat signature as the start of the sale, not the end; make retention a shared accountability | Highest / slowest |
+
+**Highest-leverage intervention:** Restructure ownership and incentives for the first 90 days - a named owner plus Sales comp tied to retained revenue - so accounts are not handed off into a vacuum. This is slower than a save call but is the only level that stops the pattern from recurring, and it must land before the free tier multiplies the number of new accounts entering the same broken handoff.
+
+---
+
+*Note: the value is the descent. A naive pass reacts at the event level (fix this customer's complaint) and never asks why churn keeps happening; the iceberg exposes a comp-and-ownership structure and a "retention is not our job" mental model as the real causes, and points to a higher-leverage fix than another save call - which a forward-looking consequence map would have missed entirely.*

--- a/skills/tfs-iceberg-model/references/TEMPLATE.md
+++ b/skills/tfs-iceberg-model/references/TEMPLATE.md
@@ -1,0 +1,32 @@
+# Iceberg - Template
+
+Fill this in. The deliverable is the four-level iceberg plus the summary above it, not prose.
+
+---
+
+## Problem under examination
+
+- **Event:** [the visible occurrence, in one or two sentences, as it would be reported]
+- **Why now:** [what prompted the look - a recurrence, a surprise, a metric move]
+- **One-off check:** [is this a genuine single-cause one-off? If yes, the iceberg is the wrong tool - say so and stop]
+
+## What is really going on, and where to intervene (summary)
+
+[3-5 sentences. Name the pattern beneath the event, the structure that looks load-bearing, the mental model holding it in place, and the single highest-leverage intervention. A reader who stops here should know the systemic cause and the best place to act.]
+
+## The iceberg
+
+| Level | What is going on at this level | Intervention it implies | Leverage |
+|---|---|---|---|
+| **Event** (what just happened) | | | Reactive / low |
+| **Pattern** (what has been happening over time) | | | Managerial / medium |
+| **Structures** (policies, incentives, resource flows, feedback loops) | | | Higher / slower |
+| **Mental models** (beliefs and assumptions holding the structures in place) | | | Highest / slowest |
+
+**Highest-leverage intervention:** [name the one intervention, usually at the structure or mental-model level, that would do the most to stop the pattern recurring, and what it would take]
+
+**Column notes:**
+- **Pattern:** the trend, frequency, or history this event belongs to - the answer to "what has been happening?", not "what just happened?".
+- **Structures:** the relationships and rules that would generate the pattern: incentives, comp plans, ownership boundaries, resource flows, feedback loops. This is the load-bearing level; do not skip it.
+- **Mental models:** the beliefs and shared stories that make the structures feel normal. State them as the system would, including the uncomfortable ones.
+- **Leverage:** a judgment for argument, not a measured value. Event-level fixes are quick but recur; structure- and model-level fixes are slower but address the cause.

--- a/skills/tfs-iceberg-model/skill.meta.yml
+++ b/skills/tfs-iceberg-model/skill.meta.yml
@@ -1,0 +1,83 @@
+# Rich sidecar for the tfs-iceberg-model skill.
+# DRAFT: shape is provisional and will be reconciled with agent-skills-toolkit
+# conventions once 2-3 skills exist. Evidence fields are a hand-authored summary
+# of evidence/dossier.md (the source of truth), not generated from it.
+#
+# Naming: id = <namespace>.<method> = thinking-framework-skills.iceberg-model;
+# slug = bare method = iceberg-model; installable name = prefix + slug = tfs-iceberg-model
+# (the tfs- prefix avoids cross-plugin name collisions; see library.json "prefix").
+
+identity:
+  id: thinking-framework-skills.iceberg-model
+  slug: iceberg-model
+  name: tfs-iceberg-model        # installable name (matches the skill directory)
+  display_name: Iceberg Model
+  version: 0.1.0
+  status: draft        # draft | experimental | active | deprecated | archived
+  maturity: alpha
+
+classification:
+  primary_family: systems-and-consequences
+  secondary_families: [problem-framing]
+  thinking_modes: [systems, causal, critical]
+  problem_contexts: [high-complexity, recurring-problem]
+  use_cases:
+    - move a recurring problem from the visible event down to its systemic causes
+    - find structure- and mindset-level interventions higher-leverage than reacting to the event
+    - reframe a symptom treated as a one-off as the latest instance of a pattern
+  poor_fit_cases:
+    - a simple, linear, single-cause problem with an obvious fix
+    - mapping forward consequences of a decision (that is futures-wheel)
+    - auditing one person's data-to-conclusion reasoning (that is ladder-of-inference-check)
+    - ritual box-filling with no honest descent and no intervention paired to each level
+
+interface:
+  required_inputs:
+    - a problem or symptom, ideally one that recurs
+  optional_inputs:
+    - history or trend data for the pattern level
+    - known policies, incentives, or org structure for the structures level
+  primary_artifact_type: iceberg
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline                 # inline | forked
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.futures-wheel
+    - thinking-framework-skills.premortem
+
+relationships:
+  often_follows: []
+  often_precedes: [thinking-framework-skills.futures-wheel]
+  complements: [thinking-framework-skills.premortem]
+  overlaps_with: []            # distinct from futures-wheel (forward/outward to effects)
+                               # and ladder-of-inference-check (one person's inference, not systemic levels)
+  variants: []
+
+quality:
+  trigger_eval_status: not-run     # see eval/ (deferred to the Silver climb)
+  output_eval_status: not-run
+  known_failure_modes:
+    - stopping at the event or pattern level, never reaching structures
+    - restating structures as "mental models" instead of surfacing real beliefs
+    - filling four boxes with no intervention paired to each level (ritual, no leverage)
+    - forcing four levels onto a genuine single-cause problem (false depth)
+    - presenting the leverage judgment as a measured or proven effect
+
+evidence:
+  evidence_tier: "P"               # practitioner; limited controlled evidence; see dossier section 3
+  confidence: moderate on the lens; low that it yields measurably better outcomes
+  transferred_evidence: true       # human systems-thinking practice only; not AI-validated
+  lineage:
+    derived_from: [systems-thinking iceberg model, Senge levels of perspective, Meadows leverage points]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-iceberg-model/SKILL.md
+  references_path: skills/tfs-iceberg-model/references/
+  evidence_path: skills/tfs-iceberg-model/evidence/dossier.md
+  evals_path: skills/tfs-iceberg-model/eval/   # deferred to the Silver climb

--- a/skills/tfs-issue-tree/SKILL.md
+++ b/skills/tfs-issue-tree/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: tfs-issue-tree
+description: Produces an issue tree that decomposes one big, ambiguous question top-down into a mutually-exclusive, collectively-exhaustive (MECE) set of smaller sub-questions, branch by branch, until the leaves are small enough to answer with data or judgment. Use when a question is too broad or multi-cause to answer as posed (for example "why is churn rising?", "where is margin leaking?", "should we launch a free tier?"), when analysis work must be split into non-overlapping parts, or when coverage matters and missing a whole category would be costly. Not for evaluating a given argument's soundness (use argument-mapping) or clustering existing notes (use affinity-mapping).
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.issue-tree
+  family: reasoning-clarity
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Issue Tree
+
+A big question like "why are sales down?" cannot be answered as posed; it has to be broken into parts. An issue tree decomposes one question top-down into a structured set of sub-questions, recursively, until the leaves are small enough to answer directly. The load-bearing constraint is **MECE**: at every branch the children must be Mutually Exclusive (no two overlap) and Collectively Exhaustive (together they cover the whole parent, with nothing important left outside). That discipline forces coverage, prevents double-counting, and makes the decomposition inspectable - a reader can challenge one branch instead of arguing a wall of prose. The output is an **issue tree**, not a discussion, and it restructures the question rather than answering it.
+
+## When to Use
+
+- A question is too broad, ambiguous, or multi-cause to answer as posed ("why is churn rising?", "where is our margin leaking?", "should we launch a free tier?").
+- Analysis must be split so work can be parallelized or prioritized across non-overlapping branches.
+- Coverage matters: missing a whole category of cause or option would be costly, so collective-exhaustiveness has real value.
+- Early in a diagnosis or strategy workflow, to turn an unanswerable prompt into a tractable set of answerable parts.
+
+## When NOT to Use
+
+- **The question is simple or already has an obvious structure.** Decomposing a one-step question into a tree is overhead and false rigor.
+- **To evaluate whether a given argument or recommendation is sound.** That is reasoning over an answer that already exists - use `tfs-argument-mapping`. An issue tree decomposes a question top-down *before* any answer exists; an argument map lays out the support and objections for an answer already on the table.
+- **To organize existing notes, findings, or observations bottom-up into themes.** That is clustering from the data - use `tfs-affinity-mapping`. An issue tree imposes a top-down split before gathering; affinity mapping discovers structure from what is already gathered.
+- **As the answer.** A clean tree restructures the question; it does not resolve it. Stopping at a pretty tree without driving the leaves to data or judgment is the central misuse.
+
+## Instructions
+
+When asked to build an issue tree, follow these steps:
+
+1. **State the root question precisely.** One clear question at the top. If it is already simple or one-step, say so and stop - a tree is not warranted.
+2. **Choose the top-level split axis, and justify it.** Decide the single dimension to break the root on (for example: by component, by cause type, by stage of the funnel, by lever). Name the axis and say in one line why this split is the material one. The wrong axis produces a tidy, useless tree.
+3. **Split into MECE children.** Make the children mutually exclusive (no two overlap) and collectively exhaustive (together they cover the whole parent). If exhaustiveness is hard, add an explicit "other / remainder" branch rather than silently dropping coverage.
+4. **Recurse until leaves are answerable.** Break each child the same way, stopping a branch when its leaf is small enough to answer directly with data or judgment. Keep depth proportional to the stakes; do not over-split.
+5. **Make each leaf actionable.** For every leaf, state what would answer it: the data, metric, owner, or judgment call required. A leaf nobody can answer is not yet a leaf.
+6. **Prune and prioritize.** Cut branches that are exhaustive but not material. Mark the two or three leaves most likely to carry the answer, so the tree drives effort, not just coverage.
+7. **Emit the issue tree and a short summary.** Produce the artifact in `references/TEMPLATE.md`: a one-paragraph summary (root question, top-level split and why, which leaves matter most) above the tree.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the filled issue tree plus its summary, not a prose essay.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The root is a single, clearly stated question, and a tree is actually warranted (not a simple one-step question).
+- [ ] The split axis at each level is named, and the top-level axis has a one-line justification for why it is the material split.
+- [ ] At every branch the children are mutually exclusive (no overlap) and collectively exhaustive (an explicit remainder branch if needed).
+- [ ] Leaves are driven down far enough to be answerable, and each names the data, metric, owner, or judgment that would answer it.
+- [ ] Branches that are exhaustive but immaterial are pruned, and the two or three highest-value leaves are flagged.
+- [ ] The output is the issue-tree artifact, not prose.
+- [ ] No overclaiming: the skill structures the question for coverage and tractability; it does not claim to produce a better answer (see `evidence/dossier.md`).
+
+## Evidence
+
+Tier **P** (practitioner). The issue tree is a widely taught, widely adopted structured-problem-solving method (Minto's *Pyramid Principle*; the McKinsey logic-tree tradition), and decomposition as a cognitive aid is plausible and partly supported in adjacent decision-analysis work. There is **no body of controlled studies** showing that drawing an issue tree produces measurably better or faster answers than not drawing one, and a MECE-clean tree split on the wrong axis can be tidy and useless. The value is coverage, tractability, and inspectability, not a proven lift in answer quality. Evidence is transferred from human practice, not AI-validated. Full grading, sources, and caveats: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed issue tree on a real decision.

--- a/skills/tfs-issue-tree/eval/cases.md
+++ b/skills/tfs-issue-tree/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-issue-tree
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (a harness is deferred to the Silver climb); these are the cases to check by hand, or to wire into evals later.
+
+## Should trigger
+
+- "Churn jumped last quarter and nobody can say why. Help me break 'why is churn rising?' into parts we can actually investigate."
+- "Our gross margin is slipping but it's a mush. I want a structured breakdown of everywhere margin could be leaking so we don't miss a whole category."
+- "Should we launch a self-serve free tier? It's too big a question - help me decompose it into the things that would actually have to be true."
+- "Split this analysis into non-overlapping workstreams so growth, finance, and sales can each own a branch without stepping on each other."
+- "I keep going in circles on 'how do we grow revenue?' Give me a MECE tree of the levers down to things I can measure."
+- "Break 'why are deploys failing more often?' into a logic tree, exhaustive, no double-counting, down to questions an owner can answer."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "Here's the team's recommendation to build the integration in-house. Walk through whether the argument actually holds up." (near-miss: evaluating a given argument's soundness, not decomposing a question - use argument-mapping)
+- "We ran 40 user interviews and have a pile of sticky notes. Help me group them into themes." (bottom-up clustering of existing notes - use affinity-mapping)
+- "Should I merge this branch now or wait an hour? Quick gut check." (simple, one-step question; a tree is false rigor)
+- "Rename the 'why churn is rising' doc to something punchier." (trivial wording task, no decomposition)
+- "The free-tier launch shipped and went badly. Help me run a postmortem on what happened." (after-the-fact analysis of a known outcome, not decomposing an open question)
+- "Write the board update summarizing this quarter's results." (unrelated reporting task)
+
+## Output checks (a good output must)
+
+- [ ] State a single, precise root question and confirm a tree is warranted (not a simple one-step question).
+- [ ] Name the split axis at each level, with a one-line justification for why the top-level axis is the material split (not merely a tidy one).
+- [ ] Keep children MECE at every branch: mutually exclusive (no overlap or double-count) and collectively exhaustive (an explicit remainder branch where coverage is at risk).
+- [ ] Drive leaves down until answerable, with each leaf naming the data, metric, owner, or judgment that would answer it.
+- [ ] Flag the two or three highest-value leaves and prune branches that are exhaustive but immaterial.
+- [ ] Deliver the issue-tree artifact (root question, branching tree, leaf register, MECE check) plus a short summary, not prose, and not claim the tree is the answer.
+
+## Value vs unaided baseline
+
+Unprompted, a strong model tends to answer a big question directly with a fluent narrative, or to produce a flat bulleted list of "factors" that quietly overlap and miss whole categories, and it rarely names the split axis or checks exhaustiveness. This skill forces a single material top-level split with a justification, enforces mutual-exclusivity and collective-exhaustiveness at every branch (including an explicit remainder), drives leaves down to questions that name what data would answer them, and prunes to the few leaves that carry the decision - while holding the honest caveat that a tidy MECE tree restructures the question but does not by itself produce a better answer.

--- a/skills/tfs-issue-tree/evidence/dossier.md
+++ b/skills/tfs-issue-tree/evidence/dossier.md
@@ -1,0 +1,79 @@
+# Evidence Dossier: Issue Tree
+
+> The single source of truth for the `issue-tree` skill. The `SKILL.md`, the sidecar
+> (`skill.meta.yml`), and the eval cases all derive from this file. If a claim is not
+> here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.issue-tree` (installable name `tfs-issue-tree`) |
+| **Family** | reasoning-clarity |
+| **Evidence tier** | **P** (practitioner; limited controlled evidence) |
+| **Confidence** | Moderate that the mechanism makes a big question tractable; low that any published number proves it improves answers |
+| **Status** | draft (first authored 2026-05-31, against discovery corpus) |
+
+---
+
+## 1. The mechanism (what actually does the work)
+
+An issue tree takes one big, ambiguous question and **decomposes it top-down into a structured set of smaller sub-questions**, recursively, until the leaves are small enough to answer directly with data or judgment. The load-bearing constraint is **MECE** - at every branch, the children must be **Mutually Exclusive** (no two overlap) and **Collectively Exhaustive** (together they cover the whole parent, nothing important falls outside). The tree does three things:
+
+1. **Converts an unanswerable question into answerable parts.** "Why are sales down?" cannot be answered as posed; "is the decline in volume or in price, and within volume is it fewer customers or lower frequency?" can be, branch by branch.
+2. **Forces coverage and prevents double-counting.** The exhaustiveness side stops the analysis from missing a whole category of cause; the exclusivity side stops two branches from secretly measuring the same thing, which would distort any weighting later.
+3. **Makes the decomposition inspectable.** Because the structure is explicit, a reader can challenge a single branch ("you split by region but the real split is by product line") instead of arguing about a wall of prose.
+
+The mechanism we implement is **MECE top-down decomposition of a question into a tree of sub-questions.** The popular "issue tree" / "logic tree" packaging is the ritual; the durable move is the disciplined, non-overlapping, gap-free split.
+
+## 2. Lineage
+
+- **Issue trees and the MECE principle** are core consulting-firm problem-structuring tools, most associated with McKinsey. Minto, B. (2009/1987). *The Pyramid Principle: Logic in Writing and Thinking.* (Minto coined "MECE" and the grouping discipline.)
+- **Hypothesis and issue trees in structured problem solving:** Rasiel, E. (1999). *The McKinsey Way*; Rasiel & Friga (2001), *The McKinsey Mind* - describe issue trees as the standard decomposition device.
+- **Generalized structured problem solving / decision frameworks:** Hammond, Keeney & Raiffa (1999), *Smart Choices* - structuring a problem before solving it; and the broad design-and-analysis literature on decomposition.
+
+No trademark. "Issue tree," "logic tree," and "MECE" are generic descriptive terms in common professional use; no attribution is required and none is claimed. We name the skill descriptively (`issue-tree`) and absorb MECE as the principle the tree must satisfy, rather than branding it.
+
+## 3. What the evidence shows, and what it does NOT show
+
+This is the honest core of the dossier. The skill must not overclaim.
+
+**What is reasonably supported:**
+- Issue trees are a **widely taught, widely used practitioner method** with decades of adoption in management consulting, analytics, and engineering problem-solving. Their staying power across firms and curricula is real signal that practitioners find the decomposition tractable and communicable.
+- **Decomposition as a general cognitive aid is plausible and partly supported** in adjacent literatures: breaking a complex judgment into components and reasoning about the parts (decision analysis, work-breakdown structures, divide-and-conquer estimation) tends to reduce omission errors and make reasoning auditable. This supports the *direction* of the mechanism.
+
+**What is NOT shown (the caveats that keep the skill honest):**
+- There is **no body of controlled studies** establishing that drawing an issue tree produces measurably better answers, faster, than not drawing one. The support is practitioner adoption plus general decomposition reasoning, not head-to-head experiments on issue trees specifically. This is why the tier is **P**, not S or M.
+- **MECE is a discipline, not a guarantee.** A tree can be perfectly mutually-exclusive and collectively-exhaustive and still be **decomposed along the wrong axis** (splitting by geography when the real structure is by product), producing a tidy, exhaustive, and useless tree. Exhaustiveness is checkable; *relevance of the chosen split* is a judgment the method does not supply.
+- A tree does **not answer the question.** It restructures the question into answerable parts. Confusing "I have a clean MECE tree" with "I have an answer" is the central misuse.
+
+**Net grade: P.** A useful, durable practitioner method whose value is structuring and coverage, not a proven lift in answer quality. The skill claims tractability, coverage, and inspectability, and explicitly disclaims any proven improvement in the final answer.
+
+## 4. Transferred-evidence flag (required honesty for this library)
+
+All of the support above comes from **human practitioner use and adjacent human-subject decomposition research.** There is **no direct study** of issue trees built by, or with, an AI agent, and none of whether an AGENT-produced issue tree improves a human's subsequent analysis. The evidence is therefore **transferred from human practice, not validated for AI-augmented use,** and the practitioner tier means even the human evidence is adoption-and-plausibility, not controlled measurement. The skill must say so. Treat the AI value as: the agent makes a disciplined MECE decomposition cheap to produce, enforces the exhaustiveness and non-overlap checks that humans skip under time pressure, and emits a durable, inspectable artifact - benefits that do not depend on any unproven answer-quality claim.
+
+## 5. When it works / when it fails (drives the eval negative cases and "When NOT to Use")
+
+**Works best when:**
+- The question is **big, ambiguous, or multi-cause** and cannot be answered as posed ("why is churn rising?", "should we launch a free tier?", "where is our margin leaking?").
+- A team needs **shared structure** so that work can be split, parallelized, or prioritized across non-overlapping branches.
+- Coverage matters: missing a whole category of cause or option would be costly, so collective-exhaustiveness has real value.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **The question is simple or already has an obvious structure** - decomposing a one-step question into a tree is overhead and false rigor. (Anti-trigger.)
+- **The task is to evaluate an existing argument or recommendation for soundness** - that is reasoning over a *given* claim, not decomposing a question. Use `tfs-argument-mapping`. An issue tree decomposes top-down before any answer exists; an argument map lays out the support and objections for an answer that already exists. (Near-miss anti-trigger.)
+- **The inputs are existing notes, findings, or observations to be organized bottom-up into themes** - that is clustering, which builds structure up from the data. Use `tfs-affinity-mapping`. Issue trees impose a top-down split *before* gathering; affinity maps discover structure *from* what is already gathered.
+- **Decomposed along an irrelevant axis** - a MECE-clean tree split on the wrong dimension is tidy and worthless. The method must justify *why this split* and prune branches that are exhaustive but not material.
+- **Treated as the answer** - stopping at a pretty tree without driving the leaves to data/judgment is the central misuse; the tree restructures the question, it does not resolve it.
+
+## 6. Output artifact
+
+The skill must emit an **issue tree**, not prose: the root question, then a top-down branching structure whose children at each node are labeled and checked for mutual-exclusivity and collective-exhaustiveness, down to answerable leaf sub-questions. Each leaf should state what would answer it (data, owner, or judgment), and the split axis at each level should be named so the decomposition is inspectable. A short summary above the tree states the root question, the chosen top-level split and why, and which leaves matter most. The artifact is the deliverable; the conversation is not.
+
+## 7. Sources
+
+1. Minto, B. (1987/2009), *The Pyramid Principle* - origin of MECE and the grouping/decomposition discipline.
+2. Rasiel, E. (1999), *The McKinsey Way*; Rasiel & Friga (2001), *The McKinsey Mind* - issue trees / logic trees as the standard structured-problem-solving device.
+3. Hammond, Keeney & Raiffa (1999), *Smart Choices* - structuring a problem into its parts before solving.
+4. Adjacent decomposition support: decision-analysis and divide-and-conquer estimation literatures (cited as plausibility, not as direct issue-tree evidence).
+
+> **Verification status:** citations 1-3 are standard and well-attested attributions for issue trees and MECE. The phrasing of the adjacent decomposition support in section 3 (citation 4) is drawn from secondary synthesis and should be confirmed against primary sources before any public-facing claim. The dossier states the tier as **P** precisely because the issue-tree-specific controlled evidence is thin; that honesty is the point.

--- a/skills/tfs-issue-tree/references/EXAMPLE.md
+++ b/skills/tfs-issue-tree/references/EXAMPLE.md
@@ -1,0 +1,86 @@
+# Issue Tree - Worked Example
+
+A completed run of the `issue-tree` skill on a real, ambiguous decision question. This is the quality bar a generated issue tree should meet.
+
+> Uses the shared recurring scenario: Northwind, a B2B SaaS weighing a self-serve free-tier launch. See `docs/internal/AUTHORING.md`.
+
+---
+
+## Root question
+
+- **Question:** Should Northwind launch a self-serve free tier?
+- **Why it cannot be answered as posed:** It bundles at least four separate judgments (will it grow the funnel, will it convert, can we afford it, will it harm the existing sales motion) into one yes/no, so a direct answer would hide which part is actually in doubt.
+- **A tree is warranted because:** the decision is consequential and multi-cause, and the team needs to split the analysis so growth, finance, sales, and product can each work a non-overlapping branch.
+
+## Summary (top of the artifact)
+
+The root "should we launch a free tier?" is broken on a single material axis: **the conditions that must all hold for the launch to be worth it** - demand, conversion economics, cost to serve, and effect on the existing sales-led motion. These four are mutually exclusive (each measures a different thing) and collectively exhaustive (a positive answer needs all four; a clear "no" on any one kills it). The leaves most likely to carry the decision are **free-to-paid conversion among ICP-fit users** (1B2) and **whether the free tier cannibalizes paid** (4A1): the first is the upside the whole bet rests on, the second is the fastest way the bet turns negative. Demand (branch 1A) is least in doubt and is deprioritized.
+
+## Issue tree
+
+```
+Should Northwind launch a self-serve free tier?
+- Top-level split axis: the conditions that must ALL hold for launch to be worth it
+  (chosen because the decision is a conjunction of independent tests, not a single estimate)
+
+  1. Will a free tier bring in enough of the RIGHT demand?
+     - Split axis: volume vs. fit
+       - 1A  Volume - do enough prospects want a self-serve entry point?
+             answered by: top-of-funnel demand signals, search/intent data, waitlist test
+       - 1B  Fit - are the free sign-ups ICP-shaped, not tire-kickers?
+             answered by: firmographics of a sign-up pilot vs. current ICP
+
+  2. Will free users convert to paid at a rate the model needs?
+     - Split axis: trigger vs. friction
+       - 2A  Value trigger - does free usage hit a moment that motivates upgrade?
+             answered by: instrumented free-to-paid funnel; which feature limits bite
+       - 2B  Friction - is the upgrade path low-friction (billing, gating, prompts)?
+             answered by: checkout/upgrade UX test; trial-to-paid benchmarks
+
+  3. Can Northwind afford to serve free users at scale?
+     - Split axis: variable cost vs. support load
+       - 3A  Infra cost per free user vs. the modeled ceiling
+             answered by: load test + unit-cost model with hard usage caps
+       - 3B  Support load from unqualified free users
+             answered by: tickets-per-100-free-users from a pilot; deflection via docs
+
+  4. Will launch harm the existing sales-led motion?
+     - Split axis: revenue effect vs. organizational effect
+       - 4A1 Cannibalization - do paying/prospective customers downgrade to free?
+             answered by: feature-gating analysis; net-new paid MRR vs. pre-launch trend
+       - 4A2 Channel conflict - do reps resent or undercut the motion (comp, routing)?
+             answered by: sales-leadership sign-off; rules of engagement; comp redesign
+
+  - Other / not covered above: legal, brand-perception, and compliance effects
+    answered by: a quick screen; surfaced here so the level stays exhaustive, low priority
+```
+
+## Leaf register (the answerable parts)
+
+| Leaf sub-question | Parent branch | What would answer it | Priority |
+|---|---|---|---|
+| Free-to-paid conversion among ICP-fit users | 1B / 2A (value) | Instrumented funnel on a 6-week pilot; conversion vs. breakeven in the model | H |
+| Does free cannibalize paid? | 4A1 | Feature-gating analysis + net-new paid MRR vs. pre-launch trend during pilot | H |
+| Infra cost per free user vs. ceiling | 3A | Load test + unit-cost model with usage caps in place | M |
+| Sales sign-off / channel conflict | 4A2 | Written rules of engagement and comp redesign agreed with VP Sales | M |
+| Top-of-funnel demand for self-serve | 1A | Intent data + a waitlist/landing-page test | L |
+| Upgrade-path friction | 2B | Checkout/upgrade UX test against trial-to-paid benchmarks | M |
+
+**Column notes:**
+- **What would answer it:** the concrete data, metric, owner, or judgment needed to resolve the leaf. Each leaf here is small enough that a single team can return a number or a yes/no.
+- **Priority:** 1B/2A and 4A1 are flagged High because the bet's upside and its fastest downside live there; demand (1A) is deprioritized as least in doubt.
+
+## MECE check
+
+- **Mutually exclusive:** the four top branches measure different things (demand, conversion, cost, motion-effect); no leaf is counted twice. Watched borderline: 1B (fit) and 2A (conversion) are adjacent, so fit is scoped to *who signs up* and conversion to *whether they upgrade* to keep them exclusive.
+- **Collectively exhaustive:** a "yes" requires all four conditions; the explicit "Other" branch holds legal/brand/compliance so nothing material falls outside the level.
+- **Split-axis sanity:** the top split is on the conjunction of conditions that gate the decision, which is the material axis - a tidier split (for example "by department") would have scattered cannibalization and conversion across owners and hidden the real tests.
+
+## Pruned / out-of-scope branches
+
+- Pricing-page redesign and packaging tiers - downstream execution, not part of the go/no-go question; cut.
+- Competitor free-tier moves - relevant context but not a condition for *Northwind's* launch to be worth it; noted, not branched.
+
+---
+
+*Note how the value is in the structure: the vague "should we launch a free tier?" becomes four independent, MECE tests, each with a leaf that names exactly what data would answer it - so the team learns the decision hinges on conversion (2A) and cannibalization (4A1), not on the demand question they were debating. A naive prompt would have argued the yes/no directly and never isolated which condition was actually in doubt.*

--- a/skills/tfs-issue-tree/references/TEMPLATE.md
+++ b/skills/tfs-issue-tree/references/TEMPLATE.md
@@ -1,0 +1,56 @@
+# Issue Tree - Template
+
+Fill this in. The deliverable is the tree plus the summary above it, not prose.
+
+---
+
+## Root question
+
+- **Question:** [the single big question being decomposed, stated precisely]
+- **Why it cannot be answered as posed:** [one line: what makes it too broad, ambiguous, or multi-cause]
+- **A tree is warranted because:** [one line - or, if the question is simple/one-step, stop here and say so]
+
+## Summary (top of the artifact)
+
+[3-5 sentences. State the root question, the top-level split axis chosen and why it is the material one, and which two or three leaves are most likely to carry the answer. A reader who stops here should know how the question was broken down and where to look first.]
+
+## Issue tree
+
+State the split axis at each level, and keep children MECE (mutually exclusive, collectively exhaustive). Use a remainder branch ("Other / not covered above") wherever exhaustiveness is otherwise at risk.
+
+```
+Root question
+- Top-level split axis: [the single dimension the root is broken on, and why]
+  - Branch A  [child 1]
+    - Split axis: [...]
+      - Leaf A1 - answered by: [data / metric / owner / judgment]
+      - Leaf A2 - answered by: [...]
+  - Branch B  [child 2, exclusive of A]
+    - Leaf B1 - answered by: [...]
+    - Leaf B2 - answered by: [...]
+  - Branch C  [child 3]
+    - ...
+  - Other / not covered above  [explicit remainder, so the level is exhaustive]
+```
+
+## Leaf register (the answerable parts)
+
+| Leaf sub-question | Parent branch | What would answer it (data / metric / owner / judgment) | Priority (H/M/L) |
+|---|---|---|---|
+| | | | |
+| | | | |
+| | | | |
+
+**Column notes:**
+- **What would answer it:** the concrete data, metric, owner, or judgment call needed to resolve the leaf. A leaf nobody can answer is not yet a leaf - split it further or restate it.
+- **Priority:** mark the two or three leaves most likely to carry the answer, so the tree drives effort, not just coverage.
+
+## MECE check
+
+- **Mutually exclusive:** [confirm no two branches at any level overlap or double-count; note any borderline split.]
+- **Collectively exhaustive:** [confirm the children at each level cover the whole parent; name the remainder branch used, if any.]
+- **Split-axis sanity:** [one line: is each split on a *material* axis, or merely a tidy one? Note any branch kept only because it was easy to name.]
+
+## Pruned / out-of-scope branches
+
+[Branches that are exhaustive but not material to the root question, listed so the reader sees they were considered and deliberately cut, not missed.]

--- a/skills/tfs-issue-tree/skill.meta.yml
+++ b/skills/tfs-issue-tree/skill.meta.yml
@@ -1,0 +1,81 @@
+# Rich sidecar for the tfs-issue-tree skill.
+# DRAFT: shape is provisional and will be reconciled with agent-skills-toolkit
+# conventions once 2-3 skills exist. Evidence fields are a hand-authored summary
+# of evidence/dossier.md (the source of truth), not generated from it.
+#
+# Naming: id = <namespace>.<method> = thinking-framework-skills.issue-tree;
+# slug = bare method = issue-tree; installable name = prefix + slug = tfs-issue-tree
+# (the tfs- prefix avoids cross-plugin name collisions; see library.json "prefix").
+
+identity:
+  id: thinking-framework-skills.issue-tree
+  slug: issue-tree
+  name: tfs-issue-tree        # installable name (matches the skill directory)
+  display_name: Issue Tree
+  version: 0.1.0
+  status: draft        # draft | experimental | active | deprecated | archived
+  maturity: alpha
+
+classification:
+  primary_family: reasoning-clarity
+  secondary_families: [problem-framing]
+  thinking_modes: [analytical, systems, convergent]
+  problem_contexts: [high-ambiguity, high-complexity]
+  use_cases:
+    - decompose a big, ambiguous, multi-cause question into answerable sub-questions
+    - impose MECE structure so analysis can be split across non-overlapping branches
+    - guarantee coverage when missing a whole category of cause or option would be costly
+  poor_fit_cases:
+    - a simple question that already has an obvious one-step structure (false rigor)
+    - evaluating whether a given argument is sound (use argument-mapping)
+    - clustering existing notes or findings bottom-up into themes (use affinity-mapping)
+    - decomposing along an irrelevant axis, or stopping at the tree as if it were the answer
+
+interface:
+  required_inputs:
+    - a single big or ambiguous question to decompose
+  optional_inputs:
+    - a candidate split axis or known constraints
+    - existing data sources that could answer leaves
+  primary_artifact_type: issue-tree
+  output_formats: [markdown-tree, markdown-table]
+
+execution:
+  mode: inline                 # inline | forked
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.problem-restatement
+    - thinking-framework-skills.argument-mapping
+
+relationships:
+  often_follows: [thinking-framework-skills.problem-restatement]
+  often_precedes: [thinking-framework-skills.argument-mapping]
+  complements: [thinking-framework-skills.affinity-mapping]
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run     # see eval/cases.md (harness deferred to Silver)
+  output_eval_status: not-run
+  known_failure_modes:
+    - MECE-clean tree decomposed along an irrelevant axis (tidy but useless)
+    - leaves left too coarse to answer, or with no named data/owner/judgment
+    - branches that overlap (double-count) or silently miss a category (no remainder)
+    - treating the finished tree as the answer rather than as a restructured question
+
+evidence:
+  evidence_tier: "P"               # practitioner; limited controlled evidence (dossier section 3)
+  confidence: moderate on tractability/coverage; low that any number proves better answers
+  transferred_evidence: true       # human practitioner use only; not AI-validated
+  lineage:
+    derived_from: [MECE / Minto Pyramid Principle, McKinsey issue/logic trees]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-issue-tree/SKILL.md
+  references_path: skills/tfs-issue-tree/references/
+  evidence_path: skills/tfs-issue-tree/evidence/dossier.md
+  evals_path: skills/tfs-issue-tree/eval/

--- a/skills/tfs-one-way-vs-two-way-door/SKILL.md
+++ b/skills/tfs-one-way-vs-two-way-door/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: tfs-one-way-vs-two-way-door
+description: Produces a reversibility classification that triages a decision before any analysis - labeling it a reversible two-way door or a hard-to-reverse one-way door - and matches the deliberation and sign-off level to that verdict, so reversible calls are made fast and irreversible ones get real rigor. Use when it is unclear how much process a decision deserves, when a team is about to rubber-stamp something irreversible or convene a committee over something trivially reversible, or when a chronically slow org needs a defensible reason to move fast or slow down.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.one-way-vs-two-way-door
+  family: decision-and-option-evaluation
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# One-Way vs Two-Way Door
+
+This is a meta-decision tool: a triage that runs *before* any option comparison and asks one question - how reversible is this decision? - then matches the deliberation and sign-off to the answer. A **two-way door** is reversible (walk back cheaply), so decide it fast, low, and light. A **one-way door** is hard or expensive to reverse, so give it real rigor and senior sign-off. The load-bearing move is separating the reversibility judgment from the decision itself, which routes scarce deliberation toward the irreversible few and licenses speed on the reversible many. The output is a **reversibility classification plus a matched deliberation level** - it says how much machinery the choice deserves, never which option to pick.
+
+## When to Use
+
+- A decision is on the table and it is unclear how much process it deserves.
+- Someone is about to rubber-stamp something irreversible, or convene a committee over something trivially reversible.
+- A team or org is chronically slow, applying the same heavyweight approval to everything regardless of stakes.
+- You want an explicit, defensible reason - decided before deliberation starts - to either move fast or slow down.
+
+## When NOT to Use
+
+- **When the decision is already known to be high-stakes and is being analyzed.** Triage already happened; you are past this tool. Use a risk tool (premortem) or an option comparison, not a classifier that confirms what you know.
+- **When you need to actually compare options against criteria.** That is `tfs-decision-option-review` (a criteria-weighted option matrix). This skill triages *before* any comparison how much analysis the decision warrants; it never scores or recommends an option.
+- **As a license for speed alone.** If the irreversible-but-inconvenient consequences (trust, legal, path-dependence) get waved away, the classification is motivated, not honest.
+- **As theater to bless a fast decision** by labeling a one-way door a two-way door. The verdict has to be defensible.
+- **For a routine, obviously reversible call with no meaningful reversibility question.** Just decide; classifying it is its own small over-process.
+
+## Instructions
+
+When asked to triage a decision by reversibility, follow these steps:
+
+1. **State the decision in one line.** Name the specific choice being made. If it is already known to be high-stakes and under analysis, or if the request is to compare options, say so and point to the right tool (premortem or `tfs-decision-option-review`) instead of classifying.
+2. **Test reversibility against named dimensions.** For each, state what it would cost to walk the decision back: money, time, trust/reputation, legal/contractual, and foreclosed future options (path-dependence). Do not accept the convenient label; a decision that feels reversible can carry one-way consequences.
+3. **Render the verdict.** One-way door or two-way door. For borderline cases, state which way it *leans* and the single dimension that decides it. The verdict follows from step 2, not from how fast someone wants to move.
+4. **Match the deliberation level.** Two-way door: who can decide it now, with what light analysis, and why slowing it is the real cost. One-way door: the rigor and sign-off it warrants, and a pointer to the heavier tool it should go to next (option comparison, premortem).
+5. **Emit the classification artifact and a one-line summary.** Produce the artifact in `references/TEMPLATE.md`. It routes the decision; it does not make it.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the filled classification (verdict, reversibility dimensions, matched deliberation level) plus a one-line summary, not a prose essay and not a recommendation about which option to choose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] Reversibility was tested against multiple named dimensions (cost, time, trust, legal, path-dependence), not asserted from the convenient label.
+- [ ] The verdict follows from those dimensions, and borderline cases say which way they lean and why.
+- [ ] The matched deliberation level is concrete: who decides, how much analysis, what sign-off.
+- [ ] A one-way door points to the heavier tool it should now go to (option comparison, premortem); the triage does not pretend to be the analysis.
+- [ ] The output recommends a *level of process*, never which option to pick.
+- [ ] No overclaiming: the skill claims better-calibrated effort, not a better outcome (see `evidence/dossier.md`).
+
+## Evidence
+
+Tier **P** (practitioner). The framing comes from Bezos / Amazon shareholder letters and broad management practice; it is internally coherent and targets a real pathology (uniform heavyweight process applied to reversible decisions). There is **no controlled evidence** that the two-bucket classification improves decision outcomes, speed, or quality versus any other rule, and reversibility is often misjudged. The evidence is transferred from human practice, not AI-validated; the AI value is making the triage cheap, forcing the reversibility question explicit, and producing a durable classification. Full grading, sources, and caveats: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed classification on a real decision.

--- a/skills/tfs-one-way-vs-two-way-door/eval/cases.md
+++ b/skills/tfs-one-way-vs-two-way-door/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-one-way-vs-two-way-door
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (a harness is deferred to the Silver climb); these are the cases to check by hand, or to wire into evals later.
+
+## Should trigger
+
+- "Before we spend three weeks debating this, is it even the kind of decision that deserves three weeks? Help me figure out how much process it needs."
+- "Everything here goes through the same five approvals and we're drowning. Help me sort which of these calls are actually reversible so we can stop over-processing them."
+- "The team wants to just ship the new onboarding flow this week. Is that a decision we can make fast and back out of, or one we need to think hard about first?"
+- "We're about to sign a two-year vendor contract and people are treating it like a routine purchase. Is this reversible or not, and who should really be signing off?"
+- "Classify this: rolling out a company-wide rename of our core product. One-way door or two-way door, and what level of rigor does it warrant?"
+- "I keep convening committees over tiny config changes and rubber-stamping the big irreversible stuff. Help me match the deliberation to how reversible each decision actually is."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "We've already agreed this acquisition is huge and irreversible. Now stress-test the plan for what could go wrong." (near-miss: triage is done, the decision is known high-stakes and under analysis - use premortem)
+- "We're down to three CI/CD vendors and keep going in circles. Lay out the tradeoffs against what matters and recommend one." (near-miss against the overlapping neighbor: this is comparing options against criteria - use `tfs-decision-option-review`, not a reversibility triage)
+- "Score these three onboarding-redesign approaches on the criteria that matter and tell me which to pick." (option comparison, not triage; this skill never recommends an option)
+- "Should I rename my staging environment? One-line config I revert anytime - just confirm." (no meaningful reversibility question; over-processing to classify it)
+- "Run a premortem on the free-tier launch plan." (risk surfacing, not reversibility triage)
+- "Write a status update summarizing what the team shipped this sprint." (unrelated)
+
+## Output checks (a good output must)
+
+- [ ] Test reversibility against multiple named dimensions (money, time, trust/reputation, legal, path-dependence), not assert it from the convenient label.
+- [ ] Render a verdict (one-way / two-way door) that follows from those dimensions, and for borderline cases name which way it leans and the single dimension that decides it.
+- [ ] State a concrete matched deliberation level: who decides, how much analysis, what sign-off.
+- [ ] For a one-way door, point to the heavier tool the decision should go to next (option comparison, premortem), rather than performing that analysis itself.
+- [ ] Recommend a *level of process*, never which option to choose.
+- [ ] Deliver the classification artifact (verdict + reversibility dimensions + matched deliberation level + one-line summary), not prose, and not overclaim a better outcome - only better-calibrated effort.
+
+## Value vs unaided baseline
+
+Unprompted, a strong model tends to skip triage entirely: it either dives straight into analyzing or recommending the decision (over-processing a reversible call) or waves a hard-to-reverse decision through as "we can always change it later," accepting the convenient reversibility label. This skill forces the reversibility question to be answered explicitly *first*, tests it against multiple dimensions so one-way consequences on trust and path-dependence are not buried, and outputs a matched level of process - who decides and how much rigor - while deliberately stopping short of the analysis itself and handing one-way doors to the right heavier tool.

--- a/skills/tfs-one-way-vs-two-way-door/evidence/dossier.md
+++ b/skills/tfs-one-way-vs-two-way-door/evidence/dossier.md
@@ -1,0 +1,78 @@
+# Evidence Dossier: One-Way vs Two-Way Door
+
+> The single source of truth for the `one-way-vs-two-way-door` skill. The `SKILL.md`,
+> the sidecar (`skill.meta.yml`), and the eval cases all derive from this file. If a
+> claim is not here, it does not belong in the skill. Author this FIRST.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.one-way-vs-two-way-door` (installable name `tfs-one-way-vs-two-way-door`) |
+| **Family** | decision-and-option-evaluation |
+| **Evidence tier** | **P** (practitioner; limited controlled evidence - see "What the evidence shows" below) |
+| **Confidence** | Moderate that the triage move prevents real waste; low that the specific two-bucket framing is the optimal taxonomy or that it improves outcomes in controlled study |
+| **Status** | draft (first authored 2026-05-31, against discovery corpus) |
+
+---
+
+## 1. The mechanism (what actually does the work)
+
+This is a **meta-decision** tool: a triage that runs *before* any option comparison and asks one question - how reversible is this decision? - then matches the amount of deliberation and the level of sign-off to the answer.
+
+- A **two-way door** is reversible: if the choice turns out wrong, you walk back through with little cost. Such decisions should be made fast, by the people closest to them, with light deliberation. Slowing them down is the real cost.
+- A **one-way door** is hard or expensive to reverse: walking back is costly, slow, or impossible. Such decisions warrant real rigor and senior sign-off before committing.
+
+The load-bearing move is **separating the reversibility judgment from the decision itself**. Most decision processes apply one uniform level of care to everything, which over-deliberates the reversible many and under-deliberates the irreversible few. By forcing an explicit reversibility classification first, the method routes effort where it pays off and licenses speed where it does not. The output is a **classification plus a matched deliberation level**, not a recommendation about the decision's content - this skill never says which option to pick; it says how much machinery the choice deserves.
+
+The classification is deliberately coarse (two buckets, with a "lean" verdict for borderline cases) because its job is routing, not analysis. The moment you are doing the analysis, you are past this tool's job.
+
+## 2. Lineage
+
+- **Bezos shareholder letters.** The "Type 1 / Type 2 decision" and "one-way door / two-way door" framing was popularized by Jeff Bezos in Amazon's 1997 and especially the 2015 and 2016 Amazon shareholder letters, arguing that as organizations grow they tend to apply heavyweight Type 1 (irreversible) process to Type 2 (reversible) decisions, producing slowness and risk-aversion.
+- **Related decision-theory roots.** The value of preserving reversibility connects to the economics of irreversibility and option value (the cost of foreclosing future choices), but Bezos's framing is a practitioner heuristic, not a formalization of that literature.
+
+No trademark. "One-way door / two-way door" and "Type 1 / Type 2 decision" are descriptive phrases in common business use; no attribution is required and none is claimed. We name the skill descriptively by its mechanism (reversibility-based triage) and cite the lineage here rather than branding it.
+
+## 3. What the evidence shows, and what it does NOT show
+
+This is the honest core of the dossier. The skill must not overclaim.
+
+**What is reasonably supported (the practitioner basis):**
+- The framing is widely adopted in practice and is internally coherent: matching process weight to reversibility is a sensible allocation of scarce deliberation, and the failure it targets (uniform heavyweight process applied to reversible decisions) is a real and commonly observed organizational pathology.
+- As a forcing function, an explicit reversibility check reliably *changes behavior*: it gives teams permission to decide reversible things fast, and a defensible reason to slow down on irreversible ones. That behavioral effect does not depend on any outcome study.
+
+**What is NOT shown (the caveats that keep the skill honest):**
+- There is **no controlled evidence** that this two-bucket classification improves decision outcomes, speed, or quality versus any other triage rule (or versus no triage). The support is practitioner testimony and a single influential source (Bezos), not experiment.
+- **Reversibility is often misjudged.** Decisions framed as two-way doors can carry one-way consequences (reputational, trust, legal, path-dependence, sunk learning) that the speedy bucket hides. The binary tempts people to under-classify genuinely irreversible calls as reversible because reversible is the convenient answer.
+- It is a **triage, not an analysis.** It says how much rigor a decision deserves; it does not perform the rigor, surface risks, or compare options. Treating the classification as if it resolved the decision is a category error.
+- The "fast = good" reading is a misuse. The method's value is *calibration*, not speed for its own sake; speeding up a misclassified one-way door is exactly the harm it is meant to prevent.
+
+**Net grade: P.** Useful practitioner method with a clear mechanism and a real failure mode it addresses; thin controlled evidence. The skill should claim the calibration/forcing-function value and explicitly disclaim any outcome-quality guarantee.
+
+## 4. Transferred-evidence flag (required honesty for this library)
+
+The basis for this skill is **human organizational practice** (Bezos / Amazon and broad management adoption), not controlled studies, and certainly **not any study of AI-augmented use**. There is no evidence on whether an AI agent classifies reversibility well, or whether an agent-produced classification improves a human's decision routing. The evidence is therefore **transferred from human practice, not AI-validated.** This skill must say so. Treat the AI value as: the agent makes the triage cheap and habitual, forces the reversibility question to be answered explicitly before effort is spent, names the dimensions that make something hard to reverse (so reversibility is judged, not assumed), and produces a durable, inspectable classification artifact. None of that depends on the unproven outcome claim.
+
+## 5. When it works / when it fails (drives the eval negative cases and "When NOT to Use")
+
+**Works best when:**
+- A decision is on the table and it is unclear how much process it deserves - someone is about to either rubber-stamp something irreversible or convene a committee over something trivially reversible.
+- A team or org is chronically slow, applying the same heavyweight approval to everything regardless of stakes.
+- You want an explicit, defensible reason to either move fast or slow down, decided before the deliberation starts.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **The decision is already known to be high-stakes and is being analyzed.** Triage has already happened; you are past this tool. Use a risk tool (premortem) or an option comparison, not a classifier that will just tell you what you already know. (Anti-trigger.)
+- **You need to actually compare options against criteria.** That is `tfs-decision-option-review` (a criteria-weighted option matrix). This skill triages *before* any comparison how much analysis the decision even warrants; it never scores or recommends an option. (Near-miss anti-trigger against the overlapping neighbor.)
+- **Reversibility is treated as a license for speed alone**, with the irreversible-but-inconvenient consequences waved away. The method must test reversibility against multiple dimensions (cost, time, trust, legal, path-dependence), not accept the convenient label.
+- **Used as theater** to bless a decision someone already wants to make fast, by labeling a one-way door a two-way door. The classification has to be defensible, not motivated.
+- **For a decision with no meaningful reversibility difference** (a routine, repeated, obviously-reversible operational call) - just decide; classifying it is its own small over-process.
+
+## 6. Output artifact
+
+The skill must emit a **reversibility classification plus a matched deliberation level**, not prose and not a recommendation about the decision's content. Concretely: the decision stated in one line; a verdict (one-way door / two-way door, or "leans" with the reason for borderline cases); the reversibility tested against named dimensions (what it would cost in money, time, trust/reputation, legal, and foreclosed future options to walk it back); the matched deliberation level (who decides, how much analysis, what sign-off); and, for one-way doors, a pointer to the heavier tool the decision should now go to (option comparison, premortem). The artifact is the deliverable; it routes the decision, it does not make it.
+
+## 7. Sources
+
+1. Bezos, J. - Amazon.com 1997 Letter to Shareholders (the original "Type 1 / Type 2" framing of decision reversibility).
+2. Bezos, J. - Amazon.com 2015 and 2016 Letters to Shareholders ("one-way door / two-way door"; the argument that growing orgs over-apply Type 1 process to Type 2 decisions).
+
+> **Verification status:** the Bezos shareholder-letter attribution (citations 1-2) is well-attested and the framing is widely reproduced, but the exact letter-by-letter wording was drawn from secondary synthesis in the discovery corpus and should be confirmed against the primary letters before any public-facing claim quotes them directly. There is, by design, no outcome-effectiveness citation: section 3 states plainly that none exists, which is the honest position for a P-tier practitioner method.

--- a/skills/tfs-one-way-vs-two-way-door/references/EXAMPLE.md
+++ b/skills/tfs-one-way-vs-two-way-door/references/EXAMPLE.md
@@ -1,0 +1,42 @@
+# Reversibility Classification - Worked Example
+
+A completed run of the `tfs-one-way-vs-two-way-door` skill on a real decision. This is the quality bar a generated classification should meet.
+
+> Uses the shared recurring scenario (Northwind, a B2B SaaS weighing a self-serve free-tier launch) so examples across skills read as one coherent product. This skill runs *first*: it triages how much process the decision deserves, before any option comparison or premortem.
+
+---
+
+## Decision being triaged
+
+- **Decision:** Launch a self-serve free tier of Northwind's B2B SaaS to accelerate top-of-funnel growth.
+
+## Summary (top of the artifact)
+
+One-way door. A public free tier is cheap to ship but expensive to retract - pulling it later damages trust and is path-dependent on pricing - so this gets full rigor and senior sign-off before committing, not a quick call. Route it next to an option comparison and a premortem.
+
+## Reversibility test
+
+| Dimension | Cost to walk it back | Reversible on this dimension? (Y / N / partial) |
+|---|---|---|
+| Money (spend / refunds / write-offs) | Build cost is sunk but modest; infra spend stops if the tier is killed | Y |
+| Time (how long to undo) | Turning the tier off is fast technically; communicating a withdrawal is slow | Partial |
+| Trust / reputation (customers, market, team) | Withdrawing a launched free tier reads as "they are struggling" and burns trust with users who adopted it; competitors cite it | N |
+| Legal / contractual (commitments, regulation) | Free users on month-to-month terms are low-risk; any data-retention or migration promises made at sign-up could bind | Partial |
+| Path-dependence (future options foreclosed, learning sunk) | A free tier reframes the market's price expectation and the sales motion; unwinding the freemium position is very hard once set | N |
+
+## Verdict
+
+- **Classification:** One-way door.
+- **For borderline cases - leans:** Not borderline. The money and time are reversible, but trust and path-dependence are not - and on this kind of decision the irreversible dimensions dominate. The "we can just turn it off" framing is exactly the convenient label this test exists to reject.
+
+## Matched deliberation level
+
+- **Who decides:** CEO + VP Sales + Head of Growth jointly, not the growth team alone.
+- **How much analysis:** Full. Compare the free-tier launch against alternatives (extended trial, sales-assisted PLG, no change) and stress-test the chosen path before committing budget.
+- **Sign-off:** Executive sign-off required before any external announcement; cross-functional alignment with Sales on comp and lead-routing first.
+- **Next tool (one-way doors only):** `tfs-decision-option-review` to compare free tier vs the alternatives against weighted criteria, then `tfs-premortem` to stress-test the chosen path before commit.
+- **Why this level:** Because the decision is hard to reverse on trust and pricing position, the cost of being wrong is high and durable. Speed here is a false economy; the rigor is warranted. (Contrast: the *pricing copy* on the free-tier page is a two-way door - let Growth A/B test it without sign-off.)
+
+---
+
+*Note: the value is the routing decision made before any work starts. A naive prompt would jump straight to analyzing or even recommending the free tier; this skill first establishes that the decision is irreversible on the dimensions that matter, so it earns full rigor - and just as importantly, it flags the reversible sub-decisions (the page copy) that should stay fast.*

--- a/skills/tfs-one-way-vs-two-way-door/references/TEMPLATE.md
+++ b/skills/tfs-one-way-vs-two-way-door/references/TEMPLATE.md
@@ -1,0 +1,40 @@
+# Reversibility Classification - Template
+
+Fill this in. The deliverable is the classification (verdict, dimensions, matched deliberation level) plus the one-line summary above it, not prose, and not a recommendation about which option to choose.
+
+---
+
+## Decision being triaged
+
+- **Decision:** [one line: the specific choice being made]
+
+## Summary (top of the artifact)
+
+[One line. The verdict and the matched level of process, e.g. "Two-way door: a reversible pricing-page test - let the growth PM ship it this week; do not route it through committee." A reader who stops here knows how much machinery this decision deserves.]
+
+## Reversibility test
+
+| Dimension | Cost to walk it back | Reversible on this dimension? (Y / N / partial) |
+|---|---|---|
+| Money (spend / refunds / write-offs) | | |
+| Time (how long to undo) | | |
+| Trust / reputation (customers, market, team) | | |
+| Legal / contractual (commitments, regulation) | | |
+| Path-dependence (future options foreclosed, learning sunk) | | |
+
+**Column notes:**
+- **Cost to walk it back:** what it would actually take to reverse the decision after committing, on this dimension. Be concrete; a vague "some cost" hides the one-way consequences the binary tends to bury.
+- Do not accept the convenient label. A decision that feels reversible (the money comes back) can still be a one-way door on trust or path-dependence.
+
+## Verdict
+
+- **Classification:** [one-way door / two-way door]
+- **For borderline cases - leans:** [which way, and the single dimension that decides it]
+
+## Matched deliberation level
+
+- **Who decides:** [the lowest level that can responsibly own this]
+- **How much analysis:** [light/none for two-way doors; named heavier work for one-way doors]
+- **Sign-off:** [what approval, if any, is warranted]
+- **Next tool (one-way doors only):** [the heavier tool the decision should now go to - e.g. `tfs-decision-option-review` to compare options, `tfs-premortem` to stress-test the commitment]
+- **Why this level:** [for a two-way door, why slowing it down is the real cost; for a one-way door, why the rigor is warranted]

--- a/skills/tfs-one-way-vs-two-way-door/skill.meta.yml
+++ b/skills/tfs-one-way-vs-two-way-door/skill.meta.yml
@@ -1,0 +1,82 @@
+# Rich sidecar for the tfs-one-way-vs-two-way-door skill.
+# DRAFT: shape is provisional and will be reconciled with agent-skills-toolkit
+# conventions once 2-3 skills exist. Evidence fields are a hand-authored summary
+# of evidence/dossier.md (the source of truth), not generated from it.
+#
+# Naming: id = <namespace>.<method> = thinking-framework-skills.one-way-vs-two-way-door;
+# slug = bare method = one-way-vs-two-way-door; installable name = prefix + slug =
+# tfs-one-way-vs-two-way-door (the tfs- prefix avoids cross-plugin name collisions;
+# see library.json "prefix").
+
+identity:
+  id: thinking-framework-skills.one-way-vs-two-way-door
+  slug: one-way-vs-two-way-door
+  name: tfs-one-way-vs-two-way-door   # installable name (matches the skill directory)
+  display_name: One-Way vs Two-Way Door
+  version: 0.1.0
+  status: draft        # draft | experimental | active | deprecated | archived
+  maturity: alpha
+
+classification:
+  primary_family: decision-and-option-evaluation
+  secondary_families: []
+  thinking_modes: [critical, consequential]
+  problem_contexts: [high-stakes, high-ambiguity]
+  use_cases:
+    - triage how much deliberation and sign-off a decision deserves before any analysis
+    - license fast decisions on reversible (two-way-door) calls
+    - force real rigor and senior sign-off on hard-to-reverse (one-way-door) calls
+    - give a chronically slow org a defensible reason to move fast or slow down
+  poor_fit_cases:
+    - the decision is already known high-stakes and under analysis (triage is done)
+    - actually comparing options against criteria (use decision-option-review)
+    - using a reversibility label as a license for speed while waving away one-way consequences
+    - a routine, obviously reversible call with no meaningful reversibility question
+
+interface:
+  required_inputs:
+    - a specific decision whose required level of process is unclear
+  optional_inputs:
+    - known constraints (cost, timeline, contractual or reputational exposure)
+  primary_artifact_type: reversibility-classification
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline                 # inline | forked
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.decision-option-review
+    - thinking-framework-skills.premortem
+
+relationships:
+  often_follows: []
+  often_precedes: [thinking-framework-skills.decision-option-review, thinking-framework-skills.premortem]
+  complements: [thinking-framework-skills.decision-option-review]
+  overlaps_with: [thinking-framework-skills.decision-option-review]
+  variants: []
+
+quality:
+  trigger_eval_status: not-run     # see eval/ (harness deferred to the Silver climb)
+  output_eval_status: not-run
+  known_failure_modes:
+    - misjudging reversibility by accepting the convenient label (under-classifying one-way doors)
+    - treating reversibility as a license for speed alone, ignoring trust/legal/path-dependence
+    - confusing the triage with the analysis (recommending an option instead of a level of process)
+    - over-processing a routine reversible call by classifying it at all
+
+evidence:
+  evidence_tier: "P"               # practitioner; thin controlled evidence; see dossier section 3
+  confidence: moderate on the calibration/forcing-function value; low on any outcome-quality claim
+  transferred_evidence: true       # human organizational practice only; not AI-validated
+  lineage:
+    derived_from: [bezos type-1/type-2 decisions, one-way-door/two-way-door management practice]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-one-way-vs-two-way-door/SKILL.md
+  references_path: skills/tfs-one-way-vs-two-way-door/references/
+  evidence_path: skills/tfs-one-way-vs-two-way-door/evidence/dossier.md
+  evals_path: skills/tfs-one-way-vs-two-way-door/eval/

--- a/skills/tfs-pyramid-principle/SKILL.md
+++ b/skills/tfs-pyramid-principle/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: tfs-pyramid-principle
+description: Produces a pyramid that structures a recommendation answer-first - a single governing thought on top, a small set of MECE, deliberately ordered key arguments beneath it, and supporting evidence under each (Minto), with an optional SCQA intro framing. Use when a conclusion or recommendation already exists and must be communicated clearly to a busy or senior reader, when findings need to be ordered into a tight top-down case, or when a write-up buries its point under context.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.pyramid-principle
+  family: synthesis
+  evidence-tier: "P"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Pyramid Principle
+
+Most recommendations are delivered in the order they were discovered - context, then analysis, then, eventually, the point - forcing the reader to hold a pile of facts in mind and guess where they lead. The pyramid principle inverts that: the conclusion (the **governing thought**, the one thing the reader should do or believe) goes first; beneath it sit a small set of **MECE key arguments** that together justify it; beneath each sits its **supporting evidence**. The reader descends only as far as their trust requires and can stop at the top with the recommendation in hand. The output is a structured **pyramid** (governing thought + ordered key lines + support), not a flowing essay. It composes a clear case; it does not check whether the case is sound.
+
+## When to Use
+
+- A conclusion or recommendation already exists and must be communicated to a busy or senior reader who needs the headline first.
+- Findings, analysis, or a memo need to be ordered into a tight top-down case instead of a chronological narrative.
+- A draft buries its point under context and reasons, and needs restructuring so the answer leads.
+- Preparing an executive summary, a decision memo, or the spine of a recommendation deck.
+
+## When NOT to Use
+
+- **Early exploratory thinking, before a conclusion exists.** Answer-first structure forces a premature headline; do the thinking first, then structure the answer.
+- **To test whether an argument holds.** Auditing reasons, co-premises, and objections for soundness is argument analysis (use **tfs-argument-mapping**). The pyramid composes a case; it does not check it.
+- **To decompose a question for analysis.** Breaking a problem into MECE sub-questions to investigate is an issue tree (use **tfs-issue-tree**), which structures the *question* for the analyst; the pyramid structures the *answer* for the reader.
+- **To make a thin case look authoritative.** Confident structure can lend false weight to weak evidence; a tidy pyramid is not a validated argument.
+
+## Instructions
+
+When asked to apply the pyramid principle, follow these steps:
+
+1. **State the governing thought.** Capture, in one sentence, the single conclusion or recommendation the reader should walk away with. If no conclusion exists yet (the thinking is still exploratory), say so and stop - this is the wrong tool.
+2. **Draft the key arguments.** List the small set of reasons (aim for three to five) that, taken together, justify the governing thought. Each must directly answer the question the governing thought provokes ("why do you say that?").
+3. **Make the set MECE.** Test the key arguments for overlap (mutually exclusive - merge or re-cut any that restate each other) and for gaps (collectively exhaustive - add anything material the set is missing). Keep it small; do not pad.
+4. **Order the key arguments deliberately.** Arrange them by one intelligible logic - importance, time sequence, or structure - not in the order they occurred to you. State which ordering you used.
+5. **Attach supporting evidence.** Under each key argument, list the facts, data, or sub-points that support it. This is where detail lives, so the top stays scannable.
+6. **Check the logic both ways.** Verify vertically (each level answers the one above) and horizontally (the key lines actually sum to the governing thought - no more, no less). Fix the structure if they do not hold.
+7. **Optionally frame the intro with SCQA.** If an opening hook helps, write a **S**ituation the reader accepts, the **C**omplication that disturbs it, the **Q**uestion it raises, and the **A**nswer (= the governing thought).
+8. **Emit the pyramid.** Produce the artifact in `references/TEMPLATE.md`: the governing thought, the ordered key lines, and the supporting evidence under each, as an explicit tree.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the filled pyramid (governing thought, ordered key lines, supporting evidence, optional SCQA intro), not a prose essay.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The governing thought is a single, concrete conclusion stated first - not a topic, a question, or a teaser.
+- [ ] There is a small set of key arguments (roughly three to five), each answering "why?" for the governing thought.
+- [ ] The key arguments are MECE: no two overlap, and nothing material to the claim is missing.
+- [ ] The key arguments are in a deliberate order (importance, time, or structure), and the ordering logic is stated.
+- [ ] The key lines actually sum to the governing thought - they justify it, no more and no less.
+- [ ] Supporting evidence sits under the right key line, keeping the top level scannable.
+- [ ] The output is the pyramid artifact, not prose.
+- [ ] No overclaiming: the skill makes the recommendation clearer to follow; it does not certify that the recommendation is correct (see `evidence/dossier.md`).
+
+## Evidence
+
+Tier **P** (practitioner). The pyramid principle is a widely and durably adopted convention for executive communication (Minto 1987); its core "state the answer first" move is consistent with general reading-comprehension findings on stating the main point up front. There is **no body of controlled studies on the named method**, and that comprehension research is adjacent (it tested thesis-first prose in general, not the pyramid, not business recommendations). The evidence is transferred from human practice, not validated for AI-augmented use. The honest value is mechanical: it makes the agent lead with the conclusion and surface an inspectable structure, rather than burying the point. It does not make the recommendation correct. Full grading, sources, and caveats: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed pyramid on a real recommendation.

--- a/skills/tfs-pyramid-principle/eval/cases.md
+++ b/skills/tfs-pyramid-principle/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-pyramid-principle
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (a harness is deferred to the Silver climb); these are the cases to check by hand, or to wire into evals later.
+
+## Should trigger
+
+- "I've decided we should consolidate onto one cloud provider. Help me write this up for the exec team so the recommendation leads, not the analysis."
+- "Here's my three-page memo - the actual recommendation is buried in the last paragraph. Restructure it so the point comes first and the support hangs under it."
+- "Turn these findings into a tight top-down case for the board: what we should do, then the few reasons, then the evidence."
+- "Structure my argument for killing the legacy SKU answer-first, with a small set of grouped reasons under the conclusion."
+- "I need an executive summary for the migration proposal. Lead with the call, then the key arguments, MECE, then the detail."
+- "Give me an SCQA intro and a pyramid for why we should raise prices next quarter."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "I'm not sure yet whether we should build, buy, or wait - help me think it through from scratch." (no conclusion yet; early exploratory thinking, wrong place for answer-first structure)
+- "Here's a vendor's case for switching to their platform. Pull it apart and tell me whether the reasoning actually holds and where the weak links are." (near-miss vs tfs-argument-mapping: analyze an argument for soundness, do not compose one)
+- "Break the question 'why is activation dropping?' into MECE sub-questions so I know what to investigate." (near-miss vs tfs-issue-tree: decompose the QUESTION for analysis, not structure an ANSWER for a reader)
+- "Run a premortem on the free-tier launch before we commit." (risk tool, not communication)
+- "Compare these three onboarding redesigns on the criteria that matter and recommend one." (decision-option-review: choose among options; the conclusion does not exist yet)
+- "Proofread this paragraph and fix the grammar." (copyedit, not restructuring around a conclusion)
+
+## Output checks (a good output must)
+
+- [ ] Lead with a single governing thought that is a concrete conclusion or recommendation, stated first - not a topic, a question, or a teaser.
+- [ ] Present a small set of key arguments (roughly three to five), each answering "why?" for the governing thought.
+- [ ] Make the key arguments MECE - no two overlap, and nothing material to the claim is missing - and show the support sitting under the right key line.
+- [ ] Put the key arguments in a deliberate, stated order (importance, time, or structure), not discovery order, and confirm the key lines sum to the governing thought.
+- [ ] Deliver the pyramid artifact (governing thought + ordered key lines + support, optional SCQA intro), not a flowing essay.
+- [ ] Not imply that a tidy pyramid certifies the recommendation is correct; limit the claim to clearer communication of a conclusion the author already holds.
+
+## Value vs unaided baseline
+
+Asked to write up a recommendation unaided, a strong model defaults to narrating its reasoning - context first, supports in the order they occurred to it, and the actual recommendation arriving late - and it tends to present the resulting tidy structure as if the structure itself proved the case. This skill forces the inversion: the governing thought leads, the supports are cut into a small MECE set and put in a deliberate, stated order, each key line is checked to actually sum to the conclusion, and the result is surfaced as an inspectable pyramid a reader can descend or stop at. It also holds the honest caveat that clear structure is not a sound argument, so the win is communication, not a claim of correctness.

--- a/skills/tfs-pyramid-principle/evidence/dossier.md
+++ b/skills/tfs-pyramid-principle/evidence/dossier.md
@@ -1,0 +1,83 @@
+# Evidence Dossier: Pyramid Principle
+
+> The single source of truth for the `pyramid-principle` skill. The `SKILL.md`, the
+> sidecar (`skill.meta.yml`), and the eval cases all derive from this file. If a claim
+> is not here, it does not belong in the skill.
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.pyramid-principle` (installable name `tfs-pyramid-principle`) |
+| **Family** | synthesis |
+| **Evidence tier** | **P** (practitioner; limited controlled evidence - see section 3) |
+| **Confidence** | High that the structure makes a recommendation easier to follow; low that any controlled study has measured it |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+---
+
+## 1. The mechanism (what actually does the work)
+
+Most recommendations are delivered the way they were discovered: context, then analysis, then (eventually) the conclusion, so the reader has to hold a pile of facts in working memory and wait to learn what they add up to. The pyramid principle inverts that. The single conclusion - the **governing thought**, the one thing the reader should do or believe - goes first. Beneath it sit a small set of **key arguments** (typically three to five) that, taken together, justify the governing thought. Beneath each key argument sits the **supporting evidence**. The result is a top-down tree the reader can descend exactly as far as their trust requires and stop.
+
+Three constraints do the actual work:
+
+1. **Answer first.** Leading with the conclusion lets the reader evaluate everything below it against a known claim, instead of reverse-engineering the point from the evidence. This is the load-bearing move.
+2. **A small, MECE set of key arguments.** The supports for the governing thought should be **M**utually **E**xclusive (no overlap, so the reader is not re-reading the same point) and **C**ollectively **E**xhaustive (nothing material to the claim is missing). MECE plus "small" is what keeps the case both complete and followable.
+3. **Vertical and horizontal logic.** Vertically, each level answers the question the level above provokes ("why do you say that?"). Horizontally, the key arguments are ordered by a single intelligible logic (importance, time, or structure), not dumped in the order they occurred to the author.
+
+An optional **SCQA** opening (**S**ituation the reader accepts, **C**omplication that disturbs it, **Q**uestion it raises, **A**nswer = the governing thought) gives the introduction a hook that lands on the conclusion rather than wandering toward it.
+
+The mechanism we implement is: state the answer, decompose it into a small MECE set of ordered arguments, attach evidence to each, and pressure-test the structure. The branded "Minto Pyramid Principle" is the packaging; the durable move is answer-first, grouped, ordered communication of a conclusion.
+
+## 2. Lineage
+
+- **The Pyramid Principle**: Minto, B. (1987). *The Pyramid Principle: Logic in Writing and Thinking.* Originated at McKinsey in the 1970s as house guidance for structuring consulting recommendations; it remains the dominant convention for executive communication in management consulting.
+- **MECE** (mutually exclusive, collectively exhaustive): a grouping discipline popularized alongside the pyramid in the same consulting lineage.
+- **SCQA** (situation-complication-question-answer): Minto's introduction pattern, widely taught as a standalone framing device.
+
+"Pyramid Principle" is a book title and a widely used generic phrase for the technique; "Minto" is a personal name and an informal label for the method. We name the skill descriptively (`pyramid-principle`) and cite Minto in the lineage rather than branding the skill. No attribution is required for the generic technique.
+
+## 3. What the evidence shows, and what it does NOT show
+
+This is the honest core of the dossier. The skill must not overclaim.
+
+**What is reasonably supported (the practitioner case):**
+- The method is **widely and durably adopted** in management consulting, corporate strategy, and executive communication - decades of practitioner use across firms, which is real signal that it is useful for its job (communicating a recommendation to a busy reader).
+- Its core move - **state the conclusion first** - is consistent with well-established reading-comprehension findings that an explicit topic/thesis stated up front (an "advance organizer") helps readers comprehend and recall structured expository text. The broad direction ("tell readers the point first") is supported by comprehension research even though that research did not test the pyramid method itself.
+
+**What is NOT shown (the caveats that keep the skill honest):**
+- There is **no body of controlled studies on the Pyramid Principle as a named method.** It is practitioner doctrine, not an experimentally validated intervention. We grade it **P**, not S or M, for exactly this reason.
+- The comprehension research that supports "answer first" is **adjacent, not direct**: it studied advance organizers and thesis-first prose in general, not Minto's pyramid, not business recommendations, and not AI-generated ones. Treat it as a plausibility anchor, not proof.
+- The method improves **communication of a conclusion the author already holds.** It does **not** test whether the conclusion is correct, and it can make a weak argument *sound* more authoritative by dressing it in confident structure. A clean pyramid is not a sound argument; that is a job for argument analysis, not for this skill.
+
+**Net grade: P.** Useful, heavily field-tested practitioner method with a comprehension-research direction behind its central move, but no controlled validation of the method as such. Claim the communication benefit; disclaim any claim that it makes the recommendation correct.
+
+## 4. Transferred-evidence flag (required honesty for this library)
+
+All of the support above comes from **human practice and human-subject comprehension research**, none of it from AI-augmented use. There is **no study** of a pyramid built by, or with, an AI agent, nor of whether an agent-produced pyramid improves a human reader's decision. The evidence is therefore **transferred from human contexts, not validated for AI-augmented use.** This skill must say so.
+
+The realistic AI value does not depend on the unproven claims: a model defaults to narrating its reasoning (context first, conclusion buried, supports in discovery order). This skill makes the agent **invert that default** - lead with the governing thought, force the supports into a small MECE set, order them deliberately, attach evidence, and surface the structure as an inspectable artifact a human can challenge. That is a reliable, mechanical improvement to how a recommendation is communicated, independent of whether anyone has measured the method in a lab.
+
+## 5. When it works / when it fails (drives the eval negative cases and "When NOT to Use")
+
+**Works best when:**
+- There is already a **conclusion or recommendation** to communicate (the thinking is done; this is the write-up).
+- The reader is busy or senior and needs the headline first, with the option to descend for detail.
+- The supports can be grouped into a small, non-overlapping set and put in a deliberate order.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- **There is no conclusion yet.** Early exploratory thinking, where the answer is genuinely unknown, is the wrong place for an answer-first structure - it forces a premature headline. (Anti-trigger.)
+- **The task is to test whether an argument holds**, not to communicate one. Auditing reasons, co-premises, and objections for soundness is argument analysis (use **tfs-argument-mapping**); the pyramid composes a clear case, it does not check it. (Near-miss anti-trigger.)
+- **The task is to decompose a question for analysis**, breaking a problem into MECE sub-questions to investigate. That is an issue tree (use **tfs-issue-tree**); it structures the *question* for the analyst, whereas the pyramid structures the *answer* for the reader. The two look similar (both are MECE trees) and are easily confused. (Near-miss anti-trigger.)
+- **Run as ritual** - slapping a one-line headline on top of unchanged, ungrouped prose, with supports that overlap or leave gaps, and key lines that do not actually sum to the governing thought. A pyramid whose levels do not hold together is cargo-cult structure. The skill must enforce MECE and the "do the key lines justify the top?" check.
+- **Used to make a thin case look strong.** Confident structure can lend false authority to weak evidence. The skill must not imply that a tidy pyramid is a validated argument.
+
+## 6. Output artifact
+
+The skill must emit a **pyramid**, not prose: a governing thought at the top, a small ordered set of key-argument lines beneath it, and the supporting evidence under each key line, plus (optionally) an SCQA intro framing. Represent it as an explicit outline/tree (indented levels or a small table), preceded by a one-line statement of the governing thought so a reader who stops at the top still has the recommendation. The structure is the deliverable; a flowing essay is not.
+
+## 7. Sources
+
+1. Minto, B. (1987). *The Pyramid Principle: Logic in Writing and Thinking.* - the method, MECE grouping, and SCQA introduction; originated as McKinsey house guidance.
+2. Reading-comprehension / advance-organizer literature (e.g. Ausubel's advance-organizer work and thesis-first expository-text studies) - the general finding that stating the main point up front aids comprehension and recall of structured text. Cited as an adjacent plausibility anchor for the "answer first" move, not as a test of the pyramid method.
+
+> **Verification status:** Minto (citation 1) is the well-attested primary source for the method and its components. The comprehension/advance-organizer link (citation 2) is drawn from secondary synthesis and is deliberately framed as adjacent support, not direct validation; confirm the specific studies against primary sources before any public-facing claim, and never upgrade this from a plausibility anchor to evidence that the pyramid method itself was tested. The "no controlled studies of the named method" statement in section 3 is the honest default and should stand unless a primary study is found.

--- a/skills/tfs-pyramid-principle/references/EXAMPLE.md
+++ b/skills/tfs-pyramid-principle/references/EXAMPLE.md
@@ -1,0 +1,56 @@
+# Pyramid - Worked Example
+
+A completed run of the `pyramid-principle` skill on a real recommendation. This is the quality bar a generated pyramid should meet.
+
+> Use the shared recurring scenario (Northwind, a B2B SaaS weighing a self-serve free-tier launch) so examples across skills read as one coherent product. See `docs/internal/AUTHORING.md`.
+
+---
+
+## Subject
+
+- **Recommendation being communicated:** Northwind has finished its analysis and decided to launch the self-serve free tier, but only behind explicit guardrails. The exec team now needs that recommendation written up as a decision memo. (The decision is made; this is the write-up, not the analysis.)
+- **Reader:** Northwind's exec team and the board sponsor for the Q3 growth target - busy readers who want the recommendation first and the option to descend for detail.
+- **Ordering logic for the key arguments:** Importance. The reader's first question is "should we do this at all?", so the arguments run growth case, then the conditions that make it safe, then the cost of waiting.
+
+## Governing thought (top of the pyramid)
+
+**Launch the self-serve free tier in Q3, but only behind three pre-committed guardrails (paid-feature gating, a usage cap with a cost tripwire, and a redesigned sales comp model); without them, hold.**
+
+## Optional SCQA intro
+
+- **Situation:** Northwind's growth is sales-led and predictable, and the Q3 board target assumes a step-change in top-of-funnel volume.
+- **Complication:** The sales-led motion cannot deliver that step-change on its own in one quarter, and competitors now offer a free entry point that is capturing the developers who later choose tooling.
+- **Question:** Should Northwind launch a self-serve free tier this quarter, and if so, on what terms?
+- **Answer:** Yes - launch in Q3, but only behind the three guardrails (= the governing thought).
+
+## The pyramid
+
+```
+GOVERNING THOUGHT: Launch the self-serve free tier in Q3, but only behind three pre-committed
+                   guardrails; without them, hold.
+
+  KEY ARGUMENT 1: The free tier is the only lever that can hit the Q3 top-of-funnel target.
+    - support: Sales-led sign-ups have grown ~12% per quarter; the board target needs ~3x volume, which the current motion cannot reach in one quarter.
+    - support: Two direct competitors launched free tiers in the last year and are now first to reach developers who later pick the team's tooling.
+    - support: A self-serve path removes the sales-touch bottleneck that currently caps how many small accounts can even enter the funnel.
+
+  KEY ARGUMENT 2: It is only safe if three risks are pre-committed against, so the launch must carry guardrails as conditions, not hopes.
+    - support: Cannibalization - without gating the top value features behind paid, existing customers can downgrade to free; guardrail = gate the top three features and instrument the free-to-paid funnel before launch.
+    - support: Cost runaway - unqualified free users can swamp support and infra; guardrail = a hard usage cap plus a cost-per-free-user tripwire set before launch.
+    - support: Sales conflict - reps will undercut the motion if comp and lead-routing are unchanged; guardrail = a redesigned comp model agreed with sales leadership before any announcement.
+
+  KEY ARGUMENT 3: Waiting a quarter costs more than a guarded launch risks.
+    - support: Each quarter of delay cedes the developer-entry point to the two competitors, who compound their lead.
+    - support: The guardrails make the downside bounded and reversible-on-signal (caps, tripwires, kill criteria), whereas a missed Q3 target is a fixed, public miss against the board.
+    - support: The build cost of the guarded thin-slice launch is small relative to the pipeline it is forecast to open.
+```
+
+## Structure check
+
+- **Vertical:** each key argument answers "why launch in Q3 behind guardrails?" - because it is the only lever that hits the target (1), because it is safe only if guarded (2), and because waiting costs more than guarding (3). Each support backs its own key line.
+- **Horizontal (MECE):** the three key lines do not overlap (the growth case, the safety conditions, and the cost of delay are distinct). Together they cover the reader's three real questions - is it worth doing, is it safe, and why now - leaving no material gap before a launch decision.
+- **Sum:** the three key arguments justify exactly the governing thought, including its "without them, hold" condition (argument 2 is what makes the guardrails non-negotiable). They do not over-claim a guaranteed outcome.
+
+---
+
+*Note how the value is in the inversion: the recommendation and its single hard condition ("only behind three guardrails; without them, hold") land in the first line, and the reader can stop there or descend exactly as far as their trust requires - whereas the same content told discovery-first would bury the decision under three paragraphs of market context. The pyramid makes the case clearer to follow; it does not, on its own, prove the decision is right.*

--- a/skills/tfs-pyramid-principle/references/TEMPLATE.md
+++ b/skills/tfs-pyramid-principle/references/TEMPLATE.md
@@ -1,0 +1,54 @@
+# Pyramid - Template
+
+Fill this in. The deliverable is the structured pyramid plus the governing thought above it, not prose.
+
+---
+
+## Subject
+
+- **Recommendation being communicated:** [the conclusion that already exists and now needs structuring]
+- **Reader:** [who this is for, e.g. "the exec team / the board"; the busier the reader, the harder the answer-first discipline matters]
+- **Ordering logic for the key arguments:** [importance / time / structure - state which, and why]
+
+## Governing thought (top of the pyramid)
+
+[One sentence. The single thing the reader should do or believe. A reader who stops here should have the recommendation. Not a topic, not a question, not a teaser.]
+
+## Optional SCQA intro
+
+- **Situation:** [the stable context the reader already accepts]
+- **Complication:** [what changed or went wrong that disturbs the situation]
+- **Question:** [the question the complication raises]
+- **Answer:** [= the governing thought above]
+
+> SCQA is optional. Use it when the recommendation needs a hook that lands on the conclusion; skip it when the reader already shares the context.
+
+## The pyramid
+
+Governing thought, then a small ordered set of MECE key arguments, each with its supporting evidence beneath it.
+
+```
+GOVERNING THOUGHT: [the conclusion]
+  KEY ARGUMENT 1: [reason that answers "why?"]
+    - support: [fact / data / sub-point]
+    - support: [fact / data / sub-point]
+  KEY ARGUMENT 2: [reason that answers "why?"]
+    - support: [...]
+    - support: [...]
+  KEY ARGUMENT 3: [reason that answers "why?"]
+    - support: [...]
+    - support: [...]
+```
+
+(Three to five key arguments; add or remove lines as the MECE set requires. Do not pad.)
+
+## Structure check
+
+- **Vertical:** does each key argument directly answer the question its governing thought provokes ("why do you say that?"), and does each support actually back its key line?
+- **Horizontal (MECE):** do any two key arguments overlap (not mutually exclusive)? Is anything material to the claim missing (not collectively exhaustive)?
+- **Sum:** taken together, do the key arguments justify the governing thought - no more, no less? If they over-claim or fall short, re-cut them.
+
+**Column / element notes:**
+- **Governing thought:** the answer first. Everything below exists to support exactly this and nothing else.
+- **Key argument:** a grouping of supports at one level up; it must be a claim in its own right, not a heading like "background."
+- **Support:** the evidence layer where detail lives, so the top stays scannable.

--- a/skills/tfs-pyramid-principle/skill.meta.yml
+++ b/skills/tfs-pyramid-principle/skill.meta.yml
@@ -1,0 +1,91 @@
+# Rich sidecar for the tfs-pyramid-principle skill.
+# DRAFT: shape is provisional and will be reconciled with agent-skills-toolkit
+# conventions once 2-3 skills exist. Evidence fields are a hand-authored summary
+# of evidence/dossier.md (the source of truth), not generated from it.
+#
+# Naming: id = <namespace>.<method> = thinking-framework-skills.pyramid-principle;
+# slug = bare method = pyramid-principle; installable name = prefix + slug =
+# tfs-pyramid-principle (the tfs- prefix avoids cross-plugin name collisions;
+# see library.json "prefix").
+
+identity:
+  id: thinking-framework-skills.pyramid-principle
+  slug: pyramid-principle
+  name: tfs-pyramid-principle      # installable name (matches the skill directory)
+  display_name: Pyramid Principle
+  version: 0.1.0
+  status: draft        # draft | experimental | active | deprecated | archived
+  maturity: alpha
+
+classification:
+  primary_family: synthesis
+  secondary_families: [reasoning-clarity]
+  thinking_modes: [convergent, structured-communication]
+  problem_contexts: [communication, decision-write-up]
+  use_cases:
+    - structure an existing recommendation answer-first for a busy or senior reader
+    - order findings into a tight top-down MECE case instead of a chronological narrative
+    - restructure a draft that buries its point under context
+    - build the spine of a decision memo or executive summary with an optional SCQA intro
+  poor_fit_cases:
+    - early exploratory thinking before a conclusion exists (forces a premature headline)
+    - testing whether an argument is sound (use argument-mapping)
+    - decomposing a question into sub-questions for analysis (use issue-tree)
+    - dressing a thin case in confident structure to make it look authoritative
+
+interface:
+  required_inputs:
+    - an existing conclusion or recommendation to communicate
+    - the supporting reasons and evidence behind it
+  optional_inputs:
+    - the intended reader (the busier the reader, the more the discipline matters)
+    - context for an SCQA intro framing
+  primary_artifact_type: pyramid     # governing thought + ordered key lines + support
+  output_formats: [markdown-outline, markdown-table]
+
+execution:
+  mode: inline                 # inline | forked
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.issue-tree
+    - thinking-framework-skills.argument-mapping
+    - thinking-framework-skills.decision-option-review
+
+relationships:
+  often_follows:
+    - thinking-framework-skills.decision-option-review   # decide, then communicate the recommendation
+    - thinking-framework-skills.issue-tree               # analyze via the tree, then present the answer
+  often_precedes: []
+  complements:
+    - thinking-framework-skills.argument-mapping         # compose the case here; check its soundness there
+  overlaps_with:
+    - thinking-framework-skills.issue-tree               # both are MECE trees; issue-tree structures the QUESTION, pyramid structures the ANSWER
+    - thinking-framework-skills.argument-mapping         # both touch claim+reasons; argument-mapping ANALYZES soundness, pyramid COMPOSES communication
+  variants: []
+
+quality:
+  trigger_eval_status: not-run     # see eval/cases.md (runner deferred to the Silver climb)
+  output_eval_status: not-run
+  known_failure_modes:
+    - ritual headline slapped on unchanged, ungrouped prose
+    - key arguments that overlap (not ME) or leave gaps (not CE)
+    - key lines that do not actually sum to the governing thought
+    - dumping arguments in discovery order instead of a deliberate one
+    - implying a tidy pyramid certifies the recommendation is correct
+
+evidence:
+  evidence_tier: "P"               # practitioner; no controlled studies of the named method (dossier section 3)
+  confidence: high on the communication benefit; low that the named method has been measured
+  transferred_evidence: true       # human practice + adjacent comprehension research; not AI-validated
+  lineage:
+    derived_from: [minto-pyramid-principle, mece-grouping, scqa-framing]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-pyramid-principle/SKILL.md
+  references_path: skills/tfs-pyramid-principle/references/
+  evidence_path: skills/tfs-pyramid-principle/evidence/dossier.md
+  evals_path: skills/tfs-pyramid-principle/eval/


### PR DESCRIPTION
## 8 coverage skills (-> 28 total)
Built by an 8-agent workflow against `AUTHORING.md` + the `tfs-premortem` exemplar, each with an explicit overlap-boundary. Fills the previously-empty **synthesis** and thin **systems/reflection** families.
- `tfs-issue-tree`, `tfs-affinity-mapping`, `tfs-pyramid-principle` (synthesis)
- `tfs-abstraction-laddering`, `tfs-one-way-vs-two-way-door`, `tfs-decision-journal`, `tfs-iceberg-model`, `tfs-backcasting`

**Cut for overlap/scope** (overlap ceiling doing its job): `stakeholder-lens-review` (-> parallel-perspectives mode), `steelmanning` (-> subsumed by red-team-light), `opportunity-solution-tree` (-> pm-skills domain).

Full 28-skill catalog validates `Tier universal, 0 errors / 0 warnings`.

## Master framework catalog
`docs/internal/research/framework-catalog.md` - the complete, simplified, prioritized framework universe synthesized from the discovery meta-analyses: 11 families, 7-tier evidence, a status per framework (`shipped`/`next`/`cand`/`fold`/`flag`/`pm`/`excl`), a priority-ordered "what to build next," an **expansion** section (fermi estimation, double-crux, theory of constraints, fishbone, scenario planning, mechanical/linear-model aggregation, and more), and deliberate exclusions with reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)