### PR TITLE
Complete the empirical core: stocks-and-flows + linear-model aggregation (S)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,10 @@ Each skill is built around four commitments, not just a prompt:
 | [`tfs-decision-journal`](skills/tfs-decision-journal/SKILL.md) | meta-thinking-and-reflection | P | decision journal entry |
 | [`tfs-iceberg-model`](skills/tfs-iceberg-model/SKILL.md) | systems-and-consequences | P | iceberg (4 levels) |
 | [`tfs-backcasting`](skills/tfs-backcasting/SKILL.md) | risk-and-resilience | P | backcast path |
+| [`tfs-stocks-and-flows-reasoning`](skills/tfs-stocks-and-flows-reasoning/SKILL.md) | systems-and-consequences | **S** | stock-flow map |
+| [`tfs-linear-model-aggregation`](skills/tfs-linear-model-aggregation/SKILL.md) | decision-and-option-evaluation | **S** | scoring model |
 
-28 skills, 9 at **S**/S-M tier (the strong-evidence anchors). "(flag)" marks skills with a documented evidence or trademark caveat in their dossier. See `docs/internal/research/framework-catalog.md` for the full framework universe and roadmap.
+30 skills, 11 at **S**/S-M tier - the named empirical core is now fully shipped. "(flag)" marks skills with a documented evidence or trademark caveat in their dossier. See `docs/internal/research/framework-catalog.md` for the full framework universe and roadmap.
 
 ## Recipes
 

--- a/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
+++ b/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
@@ -4,7 +4,7 @@ The single source of "what to build next." WIP = 1: build the **Now** skill end 
 
 ## Now
 
-> **28 skills shipped (MVP 14 + empirical core 6 + coverage 8) + 4 recipes + eval cases for every skill, all validated (Tier universal, 0/0).** 9 are S/S-M tier; the empty families (synthesis, reflection) are now filled. The skill build-out is essentially complete for v0.x. Next: the Silver climb and the go-public flip (both gated on your go). See `docs/internal/research/framework-catalog.md` for the full framework universe and what remains as future candidates.
+> **30 skills shipped + 4 recipes + eval cases for every skill, all validated (Tier universal, 0/0).** 11 are S/S-M tier and **the named empirical core is now complete** (stocks-and-flows-reasoning + linear-model-aggregation added). Next: the **Silver climb** (recipes -> workflow+command components, Codex emission, eval runner, declare convergent), then the go-public flip. See `docs/internal/research/framework-catalog.md` (universe) and `documentation-and-site-plan.md` (docs/site).
 
 ## Build order
 

--- a/docs/internal/research/framework-catalog.md
+++ b/docs/internal/research/framework-catalog.md
@@ -21,12 +21,12 @@ The honest core (from the meta-analyses): the field is a small **empirical core*
 
 The skill build-out for v0.x is essentially complete (28 skills). If the catalog grows further, this is the recommended order:
 
-1. **Strong-evidence / consensus unbuilt `[next]`:** `stocks-and-flows-reasoning` (S, Sterman), `concept-mapping` (cross-LLM consensus first-class), `first-principles` (scope tightly), `causal-loop-diagrams` (M), `key-assumptions-check`, `fermi-estimation` (expansion), `double-crux` (expansion).
+1. **Strong-evidence / consensus unbuilt `[next]`:** `concept-mapping` (cross-LLM consensus first-class), `first-principles` (scope tightly), `causal-loop-diagrams` (M), `key-assumptions-check`, `fermi-estimation` (expansion), `double-crux` (expansion). (The two S-tier empirical-core stragglers - stocks-and-flows and mechanical/linear-model aggregation - are now shipped.)
 2. **Solo-plus-AI reflection `[next]`:** `belief-update-routine`, `idea-quality-audit` (uniquely fit the primary user mode).
 3. **P-tier coverage `[cand]`:** the remaining `[cand]` rows below, as demand warrants.
 4. **Never (this repo):** the `[fold]`, `[flag]`, `[pm]`, and `[excl]` rows - documented here so the exclusion is deliberate, not accidental.
 
-The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference-class-forecasting, argument-mapping, WOOP/MCII, authentic-dissent, after-action-review, natural-frequency-bayesian, far-analogy-ideation, plus stocks-and-flows-reasoning and mechanical/linear-model aggregation (the last two unbuilt). **9 of 11 are shipped.**
+The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference-class-forecasting, argument-mapping, WOOP/MCII, authentic-dissent, after-action-review, natural-frequency-bayesian, far-analogy-ideation, stocks-and-flows-reasoning, and mechanical/linear-model aggregation. **All 11 are now shipped - the empirical core is complete.**
 
 ---
 
@@ -106,7 +106,7 @@ The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference
 |---|---|---|---|
 | Futures Wheel | map first/second/third-order consequences outward | P | `[shipped]` |
 | Iceberg Model | events -> patterns -> structures -> mental models | P | `[shipped]` |
-| Stocks and Flows reasoning | reason about accumulations and rates | **S** | `[next]` (Sterman; people systematically misjudge these) |
+| Stocks and Flows reasoning | reason about accumulations and rates | **S** | `[shipped]` (Sterman) |
 | Causal Loop Diagrams | diagram reinforcing/balancing feedback loops | M/C | `[next]` (visual; markdown approximates) |
 | Second-Order Effects | lightweight "and then what?" prompt | P | `[fold]` -> mode of futures-wheel |
 | Systems map / Leverage points | sketch elements/relationships; find intervention points | P/C | `[cand]` |
@@ -209,9 +209,9 @@ Added here as genuinely additive (not folds of existing skills). Provisional tie
 | PEST(LE) | strategy | scan macro forces (political/economic/social/technological/legal/environmental) | P | macro complement; partly `[pm]` |
 | Kepner-Tregoe | decision | structured situation/problem/decision/potential-problem analysis | P | comprehensive but heavy |
 | PDCA / A3 | reflection | structured improvement loop / one-page problem-solving | P | overlaps AAR; consider as AAR variants |
-| Mechanical / linear-model aggregation | decision | combine cues with a simple fixed formula instead of holistic judgment | **S** | named empirical core (Meehl lineage); strong evidence, unbuilt - promote to `[next]` |
+| Mechanical / linear-model aggregation | decision | combine cues with a simple fixed formula instead of holistic judgment | **S** | `[shipped]` as `tfs-linear-model-aggregation` (Meehl/Dawes) |
 
-> Note: **mechanical/linear-model aggregation** is from the meta-analyses' named empirical core (it was in the landscape's core list), but no skill exists yet. Given its S-tier evidence (clinical-vs-actuarial judgment literature), it belongs in the `[next]` strong-evidence tier alongside stocks-and-flows.
+> Note: **mechanical/linear-model aggregation** and **stocks-and-flows reasoning** were the last two unbuilt members of the named empirical core; both are now shipped (`tfs-linear-model-aggregation`, `tfs-stocks-and-flows-reasoning`). **The empirical core is complete (11/11).**
 
 ---
 

--- a/library.json
+++ b/library.json
@@ -38,7 +38,9 @@
       { "name": "tfs-one-way-vs-two-way-door", "path": "skills/tfs-one-way-vs-two-way-door/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-decision-journal", "path": "skills/tfs-decision-journal/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
       { "name": "tfs-iceberg-model", "path": "skills/tfs-iceberg-model/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
-      { "name": "tfs-backcasting", "path": "skills/tfs-backcasting/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
+      { "name": "tfs-backcasting", "path": "skills/tfs-backcasting/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-stocks-and-flows-reasoning", "path": "skills/tfs-stocks-and-flows-reasoning/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" },
+      { "name": "tfs-linear-model-aggregation", "path": "skills/tfs-linear-model-aggregation/SKILL.md", "version": "0.1.0", "tier": "universal", "status": "active" }
     ]
   },
   "repository": "https://github.com/product-on-purpose/thinking-framework-skills",

--- a/skills/tfs-linear-model-aggregation/SKILL.md
+++ b/skills/tfs-linear-model-aggregation/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: tfs-linear-model-aggregation
+description: Builds a simple mechanical scoring model - a few weighted predictive cues combined by a fixed formula and applied consistently - for a repeated predictive judgment, because consistent simple rules reliably match or beat holistic expert intuition. Use when the same kind of evaluative judgment recurs (screening candidates, scoring leads, triaging) and gut calls are inconsistent or overconfident.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.linear-model-aggregation
+  family: decision-and-option-evaluation
+  evidence-tier: "S"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Linear-Model Aggregation
+
+For a judgment you make over and over - screening candidates, scoring leads, triaging tickets - holistic expert intuition is unreliable mainly because it is inconsistent: the same expert scores the same case differently on different days. A simple mechanical rule removes that: pick a few predictive cues, weight them (even equal weights work), score each case, combine by a fixed formula, and apply it identically every time. The robust, counterintuitive result is that such rules match or beat holistic judgment, because consistency beats brilliance applied erratically. The output is a **scoring model**. Two honest limits: it is for *repeated* judgments (not one-off strategic choices), and it is only as good as its cues.
+
+## When to Use
+
+- The same kind of evaluative/predictive judgment recurs (screening, lead/deal scoring, triage, prioritizing a queue).
+- Gut calls on these are inconsistent or overconfident.
+- A few cues with real predictive signal exist.
+
+## When NOT to Use
+
+- A genuinely one-off decision among a few options (use `decision-option-review`).
+- No real predictive cues or data exist - do not invent cues and weights (false precision).
+- High-stakes judgments about individuals (hiring, lending, justice) where mechanical scoring raises fairness/legal/ethical issues - flag these, do not silently automate.
+- When the point is a single strategic call, not a repeatable rule.
+
+## Instructions
+
+When asked to build a scoring model, follow these steps:
+
+1. **State the recurring judgment** and the outcome it predicts (and confirm the outcome is eventually measurable). If it is a one-off, stop and route to a decision review.
+2. **Choose a few predictive cues.** 3 to 6 cues that plausibly carry real signal; say why each. Resist adding cues that feel thorough but lack validity.
+3. **Assign weights.** Default to equal weights unless real data justifies otherwise - the evidence says simple/equal weights capture most of the benefit; do not fake precision.
+4. **Define the per-cue rubric.** How each cue is scored, so two people would score a case the same way.
+5. **Set the formula and threshold.** How the cue scores combine, and the decision rule (e.g. above X -> advance).
+6. **Mandate consistency, and flag the caveats.** State that the model must be applied the same way every time (overriding it on a hunch reintroduces the noise it removes), that it is only as good as its cues, and any fairness/ethical caveat for judgments about people.
+7. **Emit the scoring model** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the scoring model (cues, weights, rubric, formula, threshold, caveats), not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The judgment is genuinely repeated with a (measurable) outcome, not a one-off.
+- [ ] Cues are few and each has a stated reason to be predictive.
+- [ ] Weights default to equal/simple unless data justifies otherwise (no fake precision).
+- [ ] The per-cue rubric is concrete enough for consistent scoring.
+- [ ] The model includes the "apply consistently" mandate and the cue-validity caveat.
+- [ ] Fairness/legal/ethical caveats are flagged for judgments about individuals.
+- [ ] The output is the scoring-model artifact, not prose.
+
+## Evidence
+
+Tier **S**. Across decades and many domains, mechanical/actuarial combination of cues equals or beats holistic expert judgment in the large majority of studies (Meehl 1954; Grove et al. 2000 meta-analysis), and even equal-weight "improper" models capture most of the benefit (Dawes 1979); the driver is reduced inconsistency/noise (Kahneman, *Noise*, 2021). It applies to repeated judgments, is only as good as its cues, and raises fairness considerations for judgments about people. Evidence is from human expert-vs-model studies, transferred to AI use, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed scoring model.

--- a/skills/tfs-linear-model-aggregation/eval/cases.md
+++ b/skills/tfs-linear-model-aggregation/eval/cases.md
@@ -1,0 +1,35 @@
+# Eval cases: tfs-linear-model-aggregation
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "Our reps decide which inbound leads to chase by gut and it's all over the place. Give me a consistent way to score them."
+- "We screen hundreds of applicants. Build a simple scoring rule so it's not a different call every time."
+- "I want a repeatable rubric to triage incoming bug reports by priority."
+- "Help me replace 'I have a good feeling about this deal' with a consistent scoring model."
+- "Scoring candidates is noisy across interviewers - can we make it a fixed formula on a few signals?"
+- "Build a mechanical rule to prioritize our support queue."
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "We have three vendors and need to pick one this week." (near-miss: a one-off choice -> decision-option-review, not a repeated-judgment scoring model)
+- "Should we enter the European market?" (a unique strategic decision)
+- "We have no data on what predicts a good lead - just estimate the odds." (no real cues; the skill must refuse to fabricate)
+- "Score this one candidate for me." (a single instance, not a recurring rule)
+- "Brainstorm what makes a good lead." (ideation)
+- "Given a positive lead-score flag, what's the real chance it converts?" (natural-frequency-bayesian)
+
+## Output checks (a good output must)
+
+- [ ] Confirm the judgment is recurring with a measurable outcome (route one-offs to decision-option-review).
+- [ ] Use a few cues, each with a stated reason to be predictive.
+- [ ] Default to equal/simple weights unless data justifies otherwise (no fake precision).
+- [ ] Give a per-cue rubric concrete enough for consistent scoring, plus a formula and threshold.
+- [ ] Mandate consistent application and flag the cue-validity caveat.
+- [ ] Flag fairness/legal/ethical caveats for judgments about individuals.
+- [ ] Be the scoring-model artifact, not prose.
+
+## Value vs unaided baseline
+
+Asked to "help me evaluate leads," a strong model tends to produce either a holistic per-case opinion or an elaborate many-factor weighted rubric with false precision. This skill applies the Meehl/Dawes result: a few cues, simple/equal weights, a fixed formula, applied consistently - and it refuses to invent cues without predictive validity, mandates consistent application (the source of the benefit), and flags fairness limits. The win is consistency over cleverness, which an unaided model does not impose on itself.

--- a/skills/tfs-linear-model-aggregation/evidence/dossier.md
+++ b/skills/tfs-linear-model-aggregation/evidence/dossier.md
@@ -1,0 +1,62 @@
+# Evidence Dossier: Linear-Model Aggregation (Mechanical Combination)
+
+> Single source of truth for the `linear-model-aggregation` skill. The SKILL.md, sidecar, and evals derive from this. A strong-evidence anchor (named empirical core).
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.linear-model-aggregation` (installable name `tfs-linear-model-aggregation`) |
+| **Family** | decision-and-option-evaluation |
+| **Evidence tier** | **S** (one of the most replicated findings in judgment research) |
+| **Confidence** | High that simple consistent rules match or beat holistic judgment for repeated predictions |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+For a **repeated** predictive or evaluative judgment - screening candidates, scoring leads, triaging tickets, rating applications - holistic expert intuition is unreliable mainly because it is **inconsistent**: the same expert, given the same case on different days, reaches different conclusions (noise), and weights cues differently each time. A simple **mechanical rule** removes that inconsistency: pick a few predictive cues, assign weights (even equal weights work), score each case on each cue, combine by a fixed formula, and apply it the same way every time.
+
+The counterintuitive, robust result: such rules - including "improper" ones with equal or roughly-guessed weights - reliably **match or beat** holistic expert judgment, because consistency beats brilliance-applied-erratically. The skill's value is producing that rule and committing to applying it consistently.
+
+Two honest constraints are built in: (1) the model is only as good as its cues - garbage cues give a confident garbage model; (2) this is for *repeated* judgments of the same kind, not unique strategic one-offs.
+
+## 2. Lineage
+
+- Paul Meehl, *Clinical versus Statistical Prediction* (1954) - actuarial beats clinical. Robyn Dawes, "The robust beauty of improper linear models in decision making" (1979) - even equal-weight models beat experts. Grove & Meehl (1996) and Grove et al. (2000) meta-analysis. Kahneman, *Noise* (2021) - inconsistency (noise) as the mechanism.
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Strongly supported (the S):** across decades and many domains (clinical, hiring, lending, academic admission, parole), mechanical/actuarial combination of cues equals or outperforms holistic expert judgment in the large majority of studies (Grove et al. 2000 meta-analysis). Improper linear models (equal/unit weights) capture most of the benefit (Dawes 1979). The driver is reduced inconsistency.
+
+**What it does NOT show / boundaries (honest):**
+- It applies to **repeated** judgments where outcomes are (eventually) measurable, not to genuinely unique strategic one-offs. For a one-time choice among a few options, use a decision-option review, not a predictive model.
+- The model is only as good as its **cues**: cue selection requires real predictive validity; a tidy formula on bad cues is worse than honest uncertainty.
+- Mechanical scoring of individual people (hiring, lending, justice) carries fairness, legal, and ethical considerations the skill must flag, not ignore.
+
+## 4. Transferred-evidence flag
+
+The evidence is from human expert judgment vs statistical models. Transferred to AI use; an LLM is itself prone to inconsistent holistic gestalt across cases. The AI value: forcing an explicit, fixed, few-cue rule applied identically across cases removes that inconsistency and makes the judgment inspectable and auditable - the model produces and then *follows* the rule rather than re-deciding holistically each time.
+
+## 5. When it works / when it fails
+
+**Works best when:** the same kind of evaluative judgment recurs (screening candidates, scoring leads/deals, triaging, prioritizing a queue); gut calls are inconsistent or overconfident; a few cues with real predictive signal exist.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- A genuinely **one-off** decision (use decision-option-review).
+- **No predictive cues / data** - inventing cues and weights produces false precision (the central failure).
+- Over-engineering the weights (the evidence says equal/simple weights are fine; do not fake precision).
+- Applying the model inconsistently or overriding it case-by-case on a hunch (which reintroduces the noise it removes).
+- High-stakes judgments about individuals where mechanical scoring raises fairness/legal/ethical issues - flag these, do not silently automate.
+
+## 6. Output artifact
+
+A **scoring model**: the judgment it is for; the few predictive cues (with why each is plausibly predictive); the weights (equal-weight as the honest default unless data justifies otherwise); the per-cue scoring rubric; the combination formula; a threshold/decision rule; and an explicit "apply consistently" note plus the cue-validity and fairness caveats.
+
+## 7. Sources
+
+1. Meehl, P. (1954). *Clinical versus Statistical Prediction*.
+2. Dawes, R. (1979). "The robust beauty of improper linear models in decision making." *American Psychologist*.
+3. Grove, W. et al. (2000). Meta-analysis of clinical vs mechanical prediction.
+4. Kahneman, D., Sibony, O., & Sunstein, C. (2021). *Noise* - inconsistency as the mechanism.
+
+> **Verification status:** the Meehl/Dawes/Grove results are well-attested and frequently replicated; confirm the Grove 2000 meta-analytic specifics before a public quantified claim. The "only as good as its cues" and fairness caveats are mandatory honest framing.

--- a/skills/tfs-linear-model-aggregation/references/EXAMPLE.md
+++ b/skills/tfs-linear-model-aggregation/references/EXAMPLE.md
@@ -1,0 +1,38 @@
+# Scoring Model - Worked Example
+
+A completed run of `tfs-linear-model-aggregation`, on the shared Northwind scenario. This is the quality bar a generated model should meet.
+
+> Northwind is a B2B SaaS. Reps decide which inbound leads are "worth pursuing" by gut, inconsistently. (This is the recurring judgment behind the lead-scoring signal that natural-frequency-bayesian examined.) This skill replaces the gut call with a simple consistent rule.
+
+---
+
+## Judgment
+
+- **The recurring judgment:** is an inbound lead worth a rep's time to pursue?
+- **Outcome it predicts:** the lead becomes a closed-won opportunity within 90 days.
+
+## Cues (few, predictive)
+
+| Cue | Why it plausibly predicts the outcome | Weight | How it is scored (rubric) |
+|---|---|---|---|
+| ICP firmographic fit (size, segment) | Closed-won rate is far higher inside the ICP | 1 (equal) | 2 = strong fit, 1 = partial, 0 = outside ICP |
+| Engagement depth (key-action completed in trial) | Activated trials convert far more often | 1 | 2 = key action done, 1 = logged in, 0 = neither |
+| Budget/authority signal (named buyer, stated budget) | Deals without a buyer rarely close in 90 days | 1 | 2 = both, 1 = one, 0 = neither |
+| Inbound source quality (referral/demo-request vs cold list) | Higher-intent sources close more | 1 | 2 = referral/demo, 1 = content, 0 = cold |
+
+(Equal weights, per the evidence that simple weights capture most of the benefit. Revisit weights only if outcome data justifies it.)
+
+## Formula and decision rule
+
+- **Combine:** sum of the four cue scores (range 0-8).
+- **Threshold / rule:** score >= 5 -> rep pursues now; 3-4 -> nurture queue; <= 2 -> auto-decline.
+
+## Mandate and caveats
+
+- **Apply consistently:** every lead scored the same way; no overriding the score on a hunch ("I have a good feeling") - that gut override is exactly the inconsistency this removes.
+- **Only as good as its cues:** check quarterly whether high-scoring leads actually closed more than low-scoring ones; drop a cue that shows no predictive signal.
+- **Fairness / ethics:** this scores accounts, not protected individual attributes; keep it to firmographic/behavioral cues and review for proxy bias before any automation.
+
+---
+
+*Note: the value is consistency, not cleverness. The reps' holistic "good lead?" call varied day to day; a flat 4-cue rule, applied the same every time, will match or beat that gut judgment per Meehl/Dawes - and it is auditable. This is the right tool because the judgment recurs hundreds of times; a one-off "which of these 3 deals to chase" would instead use decision-option-review.*

--- a/skills/tfs-linear-model-aggregation/references/TEMPLATE.md
+++ b/skills/tfs-linear-model-aggregation/references/TEMPLATE.md
@@ -1,0 +1,31 @@
+# Scoring Model - Template
+
+Fill this in. The deliverable is the scoring model, not prose. Default to equal weights; do not invent cues. This is for repeated judgments, applied consistently.
+
+---
+
+## Judgment
+
+- **The recurring judgment:** [what is being scored, over and over]
+- **Outcome it predicts:** [the measurable result it is trying to forecast]
+
+## Cues (few, predictive)
+
+| Cue | Why it plausibly predicts the outcome | Weight | How it is scored (rubric) |
+|---|---|---|---|
+| | | | |
+| | | | |
+| | | | |
+
+(Default to equal weights unless real data justifies otherwise.)
+
+## Formula and decision rule
+
+- **Combine:** [e.g. sum of weighted cue scores]
+- **Threshold / rule:** [e.g. score >= X -> advance; otherwise pass]
+
+## Mandate and caveats
+
+- **Apply consistently:** the same rule for every case; overriding it on a hunch reintroduces the inconsistency it removes.
+- **Only as good as its cues:** [note the cue-validity limit; how to check it against outcomes over time].
+- **Fairness / ethics:** [for judgments about individuals, the fairness/legal caveat].

--- a/skills/tfs-linear-model-aggregation/skill.meta.yml
+++ b/skills/tfs-linear-model-aggregation/skill.meta.yml
@@ -1,0 +1,76 @@
+# Rich sidecar for the tfs-linear-model-aggregation skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.linear-model-aggregation
+  slug: linear-model-aggregation
+  name: tfs-linear-model-aggregation
+  display_name: Linear-Model Aggregation
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: decision-and-option-evaluation
+  secondary_families: [reasoning-clarity]
+  thinking_modes: [analytical, critical]
+  problem_contexts: [high-stakes, high-complexity]
+  use_cases:
+    - replace inconsistent gut calls on a repeated judgment with a simple consistent rule
+    - score candidates, leads, or tickets predictively and auditably
+    - reduce noise/inconsistency in recurring evaluations
+  poor_fit_cases:
+    - one-off decisions among a few options (use decision-option-review)
+    - no real predictive cues/data (do not invent them)
+    - over-engineering weights (equal weights are usually fine)
+    - high-stakes individual judgments with unaddressed fairness/legal issues
+
+interface:
+  required_inputs:
+    - a recurring predictive/evaluative judgment with a measurable outcome
+  optional_inputs:
+    - candidate cues, historical outcome data
+  primary_artifact_type: scoring-model
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.decision-option-review
+    - thinking-framework-skills.natural-frequency-bayesian
+
+relationships:
+  often_follows: []
+  often_precedes: []
+  complements:
+    - thinking-framework-skills.decision-option-review
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - using it for a genuine one-off decision
+    - inventing cues/weights with no predictive validity (false precision)
+    - applying the model inconsistently or overriding it on a hunch
+    - ignoring fairness/legal issues for judgments about individuals
+
+evidence:
+  evidence_tier: "S"
+  confidence: high; one of the most replicated findings in judgment research
+  transferred_evidence: true
+  lineage:
+    derived_from: [Meehl clinical vs statistical prediction, Dawes improper linear models, Kahneman Noise]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+  risk_flags: [fairness-when-scoring-individuals]
+
+implementation:
+  skill_path: skills/tfs-linear-model-aggregation/SKILL.md
+  references_path: skills/tfs-linear-model-aggregation/references/
+  evidence_path: skills/tfs-linear-model-aggregation/evidence/dossier.md
+  evals_path: skills/tfs-linear-model-aggregation/eval/

--- a/skills/tfs-stocks-and-flows-reasoning/SKILL.md
+++ b/skills/tfs-stocks-and-flows-reasoning/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tfs-stocks-and-flows-reasoning
+description: Produces a stock-flow map by separating a quantity that accumulates from the inflows and outflows that change it, then reasoning about the stock's trajectory from the net flow rather than the direction of any single flow. Use when a problem involves an accumulation (cash, debt, backlog, headcount, customer base, technical debt, emissions) and intuition about whether it is rising or falling may be wrong.
+license: Apache-2.0
+metadata:
+  id: thinking-framework-skills.stocks-and-flows-reasoning
+  family: systems-and-consequences
+  evidence-tier: "S"
+  version: 0.1.0
+  standard: "0.8"
+---
+<!-- thinking-framework-skills | https://github.com/product-on-purpose/thinking-framework-skills | Apache-2.0 -->
+# Stocks and Flows Reasoning
+
+People systematically misjudge accumulations. They confuse a stock (a quantity that builds up: cash, debt, a customer base, a backlog, technical debt) with the flows that change it, and infer the stock's direction from a flow's direction. The classic error: "the inflow is falling, so the stock is falling." It is not - the stock keeps rising while inflow exceeds outflow. This skill makes the structure explicit: name the stock, name its inflows and outflows separately, and reason about its trajectory from the net flow. The output is a **stock-flow map**. It corrects a specific, well-evidenced accumulation error; it does not claim to teach systems thinking wholesale.
+
+## When to Use
+
+- A quantity accumulates over time (runway, debt, backlog, headcount, customer base, reserves, technical debt) and the question is whether it is rising or falling.
+- A trend in a flow is being used to infer the stock ("churn dropped, so the base is growing").
+- Before acting on an "it's getting better/worse" intuition about an accumulation.
+
+## When NOT to Use
+
+- The quantity does not accumulate (a one-off event, a ratio with no stock).
+- A simple direct relationship with no accumulation is all that is at play.
+- Mapping forward consequences (use futures-wheel) or systemic causes (use iceberg-model); this is specifically about accumulation dynamics.
+
+## Instructions
+
+When asked to reason about an accumulating quantity, follow these steps:
+
+1. **Name the stock.** The quantity that accumulates, and its current level if known. Make sure it is a stock (a level), not a flow (a rate).
+2. **List the inflows.** What adds to the stock, and at what rate / trend.
+3. **List the outflows.** What drains the stock, and at what rate / trend. Do not skip the outflow - ignoring it is a common error.
+4. **Compute the net flow.** Inflow minus outflow: is the stock currently gaining or losing, and is the net flow itself trending up or down?
+5. **State the corrected trajectory.** What the stock actually does (rises / falls / plateaus and when), derived from the net flow, not from any single flow's direction.
+6. **Name the naive intuition it corrects.** What someone would wrongly conclude from the flow alone, and why it is wrong.
+7. **Emit the stock-flow map** per `references/TEMPLATE.md`.
+
+## Output Format
+
+Use the template in `references/TEMPLATE.md`. The deliverable is the stock-flow map with the corrected trajectory, not prose.
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- [ ] The stock is genuinely a level (accumulation), not a flow/rate.
+- [ ] Both inflows and outflows are listed; the outflow is not ignored.
+- [ ] The trajectory is derived from the net flow, not from one flow's direction.
+- [ ] The naive intuition being corrected is named.
+- [ ] No overclaim: it corrects an accumulation error, it does not teach systems thinking wholesale (see `evidence/dossier.md`).
+- [ ] The output is the stock-flow map artifact, not prose.
+
+## Evidence
+
+Tier **S**. The underlying failure is robustly demonstrated: across repeated experiments, including with highly educated subjects, people misread stock/flow relationships and infer stock direction from flow direction (Sterman's accumulation experiments; Cronin, Gonzalez & Sterman 2009; Meadows, *Thinking in Systems*). The strong evidence is that the error is real and that making the structure explicit removes it on a given problem; it is not a claim of broad systems-thinking transfer. Evidence is from human reasoners, transferred to AI use, not AI-validated. Full grading: `evidence/dossier.md`.
+
+## Examples
+
+See `references/EXAMPLE.md` for a completed stock-flow map.

--- a/skills/tfs-stocks-and-flows-reasoning/eval/cases.md
+++ b/skills/tfs-stocks-and-flows-reasoning/eval/cases.md
@@ -1,0 +1,34 @@
+# Eval cases: tfs-stocks-and-flows-reasoning
+
+> Trigger and output evaluation, derived from `SKILL.md` and `evidence/dossier.md`. No runner yet (deferred to the Silver climb); check by hand or wire in later.
+
+## Should trigger
+
+- "We cut churn in half - does that mean our customer base is finally growing?"
+- "Emissions growth is slowing. Is the CO2 in the atmosphere going down?"
+- "Hiring is up but attrition is also up - is headcount actually rising, and when do we hit 200?"
+- "Our backlog feels endless even though we're closing more tickets than ever. What's going on?"
+- "We reduced new debt this quarter. Is our total debt shrinking?"
+- "Map the runway: cash in vs cash out - when do we actually run out?"
+
+## Should NOT trigger (wrong tool / near-miss)
+
+- "What are the second- and third-order effects of launching a free tier?" (near-miss: futures-wheel, forward consequences, not accumulation dynamics)
+- "Why does our conversion keep dropping? Map the systemic causes." (iceberg-model)
+- "What's our gross margin this quarter?" (a ratio/snapshot, no accumulation)
+- "Should we launch the free tier or fix the funnel?" (decision)
+- "Forecast next year's revenue with a range." (reference-class-forecasting)
+- "Summarize our financials for the board." (summarization)
+
+## Output checks (a good output must)
+
+- [ ] Name the stock as a level (accumulation), not a flow/rate.
+- [ ] List both inflows and outflows separately; not ignore the outflow.
+- [ ] Derive the stock's trajectory from the net flow (inflow minus outflow), not from one flow's direction.
+- [ ] State when the stock actually rises/falls/plateaus.
+- [ ] Name the naive intuition it corrects.
+- [ ] Be the stock-flow map artifact, not prose; not claim to teach systems thinking wholesale.
+
+## Value vs unaided baseline
+
+Asked "we cut churn, are we growing?", a strong model often mirrors the user's framing and confirms the flow-direction intuition ("yes, lower churn means growth"), the exact stock-flow error the evidence documents even in expert subjects. This skill forces the explicit stock/inflow/outflow separation and the net-flow logic, surfacing that a base can keep shrinking while churn falls - and names the wrong intuition it corrects.

--- a/skills/tfs-stocks-and-flows-reasoning/evidence/dossier.md
+++ b/skills/tfs-stocks-and-flows-reasoning/evidence/dossier.md
@@ -1,0 +1,56 @@
+# Evidence Dossier: Stocks and Flows Reasoning
+
+> Single source of truth for the `stocks-and-flows-reasoning` skill. The SKILL.md, sidecar, and evals derive from this. A strong-evidence anchor (named empirical core).
+
+| | |
+|---|---|
+| **Skill** | `thinking-framework-skills.stocks-and-flows-reasoning` (installable name `tfs-stocks-and-flows-reasoning`) |
+| **Family** | systems-and-consequences |
+| **Evidence tier** | **S** (a robustly demonstrated reasoning *failure* the skill corrects) |
+| **Confidence** | High that people systematically misjudge accumulation; the correction is mechanical |
+| **Status** | draft (authored 2026-05-31 from the discovery corpus) |
+
+## 1. The mechanism (what actually does the work)
+
+People reason badly about **accumulations**. They confuse a **stock** (a quantity that accumulates: cash, debt, headcount, a customer base, a backlog, technical debt, CO2, trust) with the **flows** that change it (the inflow that adds to it, the outflow that drains it). The classic error: assuming that because an *inflow is falling*, the *stock is falling*. It is not - the stock keeps rising as long as inflow exceeds outflow. (Emissions can slow while atmospheric CO2 still rises; churn can drop while the customer base still shrinks if new-customer inflow is lower.)
+
+The skill makes the structure explicit: name the stock, name its inflows and outflows separately, and reason about the stock's trajectory from the **net flow** (inflow minus outflow), not from the direction of any single flow. The work is done by forcing the stock/flow distinction that intuition collapses.
+
+## 2. Lineage
+
+- System dynamics: Jay Forrester (origin); John Sterman, *Business Dynamics* (2000); Donella Meadows, *Thinking in Systems* (2008). The accumulation-misjudgment experiments are Sterman's (and Cronin, Gonzalez & Sterman, "Why don't well-educated adults understand accumulation?", 2009).
+
+No trademark. Named descriptively.
+
+## 3. What the evidence shows, and what it does NOT show
+
+**Strongly supported (the S):** the *failure* is robust. Across repeated experiments - including with highly educated subjects (MIT graduate students) - people systematically misread stock/flow relationships (the "bathtub" tasks), inferring stock direction from flow direction. This is one of the better-documented systematic reasoning errors.
+
+**What that means for the skill (honest framing):** the strong evidence is that the *error is real and widespread*, and that making the stock/flow structure explicit removes it on a given problem. There is no claim that running this skill improves general systems-thinking transfer (the broader systems-thinking-pedagogy evidence is mixed). So: claim that it corrects a specific, well-evidenced accumulation error; do not claim it teaches systems thinking wholesale.
+
+## 4. Transferred-evidence flag
+
+The evidence is from human reasoners. Transferred to AI use; a model can also slip into flow-direction-equals-stock-direction reasoning when narrating a trend. The AI value: forcing the explicit stock/inflow/outflow separation and the net-flow logic is a direct counter, and the stock-flow map is inspectable.
+
+## 5. When it works / when it fails
+
+**Works best when:** a problem involves a quantity that accumulates over time, and the question is whether it is rising or falling (runway, debt, backlog, headcount, customer base, technical debt, reserves, emissions); when a trend in a *flow* is being used to infer the *stock*.
+
+**Fails or misleads when (poor-fit / anti-patterns):**
+- The quantity does not accumulate (a one-off event, a ratio with no stock structure).
+- **Confusing the stock with a flow** (the very error - e.g., treating "revenue this month", a flow, as "cash", a stock).
+- Assuming a falling inflow means a falling stock, or ignoring the outflow entirely.
+- Treating a *flattening* flow as a *falling* stock.
+- When a simple direct relationship (no accumulation) is all that is at play.
+
+## 6. Output artifact
+
+A **stock-flow map**: the stock named explicitly; its inflows and outflows listed separately; the net-flow logic (is inflow above or below outflow, and trending which way); the corrected trajectory of the stock; and the naive intuition it corrects (what someone would wrongly conclude from the flow alone).
+
+## 7. Sources
+
+1. Sterman, J. (2000). *Business Dynamics*; and Sterman's accumulation experiments.
+2. Cronin, M., Gonzalez, C., & Sterman, J. (2009). "Why don't well-educated adults understand accumulation?" *Organizational Behavior and Human Decision Processes*.
+3. Meadows, D. (2008). *Thinking in Systems*.
+
+> **Verification status:** the Sterman accumulation-failure finding is well-attested; confirm the Cronin/Gonzalez/Sterman citation specifics before a public quantified claim. The honest scope - "corrects a specific accumulation error," not "teaches systems thinking" - is the core caveat.

--- a/skills/tfs-stocks-and-flows-reasoning/references/EXAMPLE.md
+++ b/skills/tfs-stocks-and-flows-reasoning/references/EXAMPLE.md
@@ -1,0 +1,38 @@
+# Stock-Flow Map - Worked Example
+
+A completed run of `tfs-stocks-and-flows-reasoning`, on the shared Northwind scenario. This is the quality bar a generated map should meet.
+
+> Northwind is a B2B SaaS. The team just cut churn and concluded "we're growing again." This skill checks whether the customer base is actually rising.
+
+---
+
+## Stock
+
+- **The accumulating quantity:** active paying customers - **current level:** 1,000.
+
+## Flows
+
+| Inflows (add to the stock) | Rate / trend |
+|---|---|
+| New customers won per month | ~30/month, flat (and slightly declining as the funnel weakens) |
+
+| Outflows (drain the stock) | Rate / trend |
+|---|---|
+| Customers churned per month | was ~50/month; the retention fix cut it to ~35/month |
+
+## Net flow
+
+- Inflow vs outflow right now: 30 in, 35 out = **net -5/month** (still losing customers), even after the churn cut.
+- Net-flow trend: improving (the gap closed from -20 to -5), but still negative; and inflow is drifting down, which could re-widen it.
+
+## Corrected trajectory
+
+- The customer base is **still shrinking**, just more slowly (~5/month), not growing. It only starts growing once new-customer inflow (30) exceeds churn outflow (35) - i.e. either win >35/month or cut churn below 30/month.
+
+## Naive intuition it corrects
+
+- "We halved churn, so we're growing." Wrong: churn is a flow; the customer base is the stock. A lower outflow slows the decline but does not reverse it while inflow is still below outflow. The team would have celebrated growth while the base kept eroding.
+
+---
+
+*Note: the value is refusing to read the stock (customer base) off the direction of one flow (churn). The fix reframes the goal correctly: to actually grow, raise inflow above 35 or cut churn below 30 - which sends the team back to the acquisition work (the free-tier / funnel decisions), now with the right target.*

--- a/skills/tfs-stocks-and-flows-reasoning/references/TEMPLATE.md
+++ b/skills/tfs-stocks-and-flows-reasoning/references/TEMPLATE.md
@@ -1,0 +1,32 @@
+# Stock-Flow Map - Template
+
+Fill this in. The deliverable is the map with the corrected trajectory, not prose. Make sure the "stock" is a level, not a rate.
+
+---
+
+## Stock
+
+- **The accumulating quantity:** [what builds up] - **current level:** [if known]
+
+## Flows
+
+| Inflows (add to the stock) | Rate / trend |
+|---|---|
+| | |
+
+| Outflows (drain the stock) | Rate / trend |
+|---|---|
+| | |
+
+## Net flow
+
+- Inflow vs outflow right now: [gaining / losing], by roughly [amount].
+- Is the net flow itself trending up or down? [...]
+
+## Corrected trajectory
+
+- What the stock actually does: [rises / falls / plateaus, and when], because [net-flow logic].
+
+## Naive intuition it corrects
+
+- What someone would wrongly conclude from a single flow's direction: [...] - wrong because [...].

--- a/skills/tfs-stocks-and-flows-reasoning/skill.meta.yml
+++ b/skills/tfs-stocks-and-flows-reasoning/skill.meta.yml
@@ -1,0 +1,73 @@
+# Rich sidecar for the tfs-stocks-and-flows-reasoning skill. DRAFT shape.
+# A hand-authored summary of evidence/dossier.md (the source of truth).
+
+identity:
+  id: thinking-framework-skills.stocks-and-flows-reasoning
+  slug: stocks-and-flows-reasoning
+  name: tfs-stocks-and-flows-reasoning
+  display_name: Stocks and Flows Reasoning
+  version: 0.1.0
+  status: draft
+  maturity: alpha
+
+classification:
+  primary_family: systems-and-consequences
+  secondary_families: [reasoning-clarity]
+  thinking_modes: [systems, analytical, critical]
+  problem_contexts: [high-complexity]
+  use_cases:
+    - judge whether an accumulating quantity is actually rising or falling
+    - separate a stock from the inflows and outflows that change it
+    - correct a "the flow is falling so the stock is falling" intuition
+  poor_fit_cases:
+    - quantities that do not accumulate (one-off events, ratios without a stock)
+    - simple direct relationships with no accumulation
+    - forward consequences (futures-wheel) or systemic causes (iceberg-model)
+
+interface:
+  required_inputs:
+    - an accumulating quantity and a question about its trajectory
+  optional_inputs:
+    - the inflow and outflow rates/trends
+  primary_artifact_type: stock-flow-map
+  output_formats: [markdown-table]
+
+execution:
+  mode: inline
+  subagent_suitable: false
+  recipe_suitable: true
+  likely_companions:
+    - thinking-framework-skills.iceberg-model
+    - thinking-framework-skills.reference-class-forecasting
+
+relationships:
+  often_follows: []
+  often_precedes: []
+  complements:
+    - thinking-framework-skills.iceberg-model
+  overlaps_with: []
+  variants: []
+
+quality:
+  trigger_eval_status: not-run
+  output_eval_status: not-run
+  known_failure_modes:
+    - confusing the stock with a flow
+    - assuming a falling inflow means a falling stock; ignoring the outflow
+    - treating a flattening flow as a falling stock
+
+evidence:
+  evidence_tier: "S"
+  confidence: high that the accumulation error is real and widespread; the correction is mechanical
+  transferred_evidence: true
+  lineage:
+    derived_from: [system dynamics, Sterman accumulation experiments, Meadows Thinking in Systems]
+  source_dossier: evidence/dossier.md
+  attribution_required: false
+  trademark: none
+
+implementation:
+  skill_path: skills/tfs-stocks-and-flows-reasoning/SKILL.md
+  references_path: skills/tfs-stocks-and-flows-reasoning/references/
+  evidence_path: skills/tfs-stocks-and-flows-reasoning/evidence/dossier.md
+  evals_path: skills/tfs-stocks-and-flows-reasoning/eval/


### PR DESCRIPTION
The two unbuilt S-tier named-empirical-core methods, completing the evidence anchor (11/11).

- **`tfs-stocks-and-flows-reasoning`** (S; Sterman, Meadows) - stock-flow map; corrects the robustly-documented accumulation error (inferring stock direction from a single flow), honestly scoped to that, not a claim to teach systems thinking.
- **`tfs-linear-model-aggregation`** (S; Meehl, Dawes, Grove, Kahneman *Noise*) - scoring model; consistent simple rules match/beat holistic expert judgment for repeated predictions; honest cue-validity + fairness caveats; bounded vs `decision-option-review` (repeated rule vs one-off choice).

Catalog now **30 skills, 11 at S/S-M tier**. Full catalog validates `Tier universal, 0/0`. Catalog + AGENTS + backlog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)