### PR TITLE
fix(manifest): carry license into native plugin manifests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "thinking-framework-skills",
   "version": "0.1.0",
   "description": "An evidence-graded library of agent-executable thinking-method skills (premortem, problem restatement, and more). Each skill is reduced to its working mechanism, graded honestly on how strong its evidence actually is, and produces a concrete artifact rather than prose. Use to reframe a problem, challenge assumptions, generate options, stress-test a decision, or audit reasoning.",
+  "license": "Apache-2.0",
   "author": {
     "name": "product-on-purpose"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "thinking-framework-skills",
   "version": "0.1.0",
   "description": "An evidence-graded library of agent-executable thinking-method skills (premortem, problem restatement, and more). Each skill is reduced to its working mechanism, graded honestly on how strong its evidence actually is, and produces a concrete artifact rather than prose. Use to reframe a problem, challenge assumptions, generate options, stress-test a decision, or audit reasoning.",
+  "license": "Apache-2.0",
   "author": {
     "name": "product-on-purpose"
   },


### PR DESCRIPTION
The marketplace registry validator requires `license` in the pinned plugin.json; the toolkit nativeSpine dropped it. Regenerated so both native manifests declare Apache-2.0. Unblocks the marketplace listing for v0.1.0.