### PR TITLE
docs: comprehensive README pass, conformance doc, and release-plan truth-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,23 @@
 <a id="readme-top"></a>
 
-<div align="center">
-
 # Thinking Framework Skills
 
 **An evidence-graded library of agent-executable thinking-method skills.**
 
 Every method is reduced to its working mechanism, graded honestly on how strong its evidence actually is, and shipped as a skill that produces a concrete artifact, not prose.
 
-<p>
-  <a href="#-what-this-is"><strong>What it is</strong></a>
-  &nbsp;·&nbsp;
-  <a href="#-quick-start"><strong>Install</strong></a>
-  &nbsp;·&nbsp;
-  <a href="#-the-catalog"><strong>Frameworks</strong></a>
-  &nbsp;·&nbsp;
-  <a href="#-the-evidence-model"><strong>Evidence</strong></a>
-  &nbsp;·&nbsp;
-  <a href="#-recipes"><strong>Recipes</strong></a>
-  &nbsp;·&nbsp;
-  <a href="https://product-on-purpose.github.io/thinking-framework-skills/"><strong>Live site</strong></a>
-</p>
+[**What it is**](#-what-this-is) &nbsp;·&nbsp; [**Install**](#-quick-start) &nbsp;·&nbsp; [**Frameworks**](#-the-catalog) &nbsp;·&nbsp; [**Evidence**](#-the-evidence-model) &nbsp;·&nbsp; [**Recipes**](#-recipes) &nbsp;·&nbsp; [**Live site**](https://product-on-purpose.github.io/thinking-framework-skills/)
 
 <p>
   <img src="https://img.shields.io/badge/status-active-success?style=flat-square" alt="Status: Active">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square" alt="License: Apache-2.0"></a>
-  <img src="https://img.shields.io/badge/version-0.1.0-blue?style=flat-square" alt="Version 0.1.0">
+  <img src="https://img.shields.io/badge/version-0.2.0-blue?style=flat-square" alt="Version 0.2.0">
+  <a href="#-conformance-what-advanced-gold-tier-means"><img src="https://img.shields.io/badge/tier-advanced%20(Gold)-B8860B?style=flat-square" alt="Conformance tier: advanced (Gold)"></a>
   <a href="#-the-catalog"><img src="https://img.shields.io/badge/skills-34-brightgreen?style=flat-square" alt="Skills: 34"></a>
   <a href="#-recipes"><img src="https://img.shields.io/badge/recipes-5-brightgreen?style=flat-square" alt="Recipes: 5"></a>
   <a href="https://agentskills.io/specification"><img src="https://img.shields.io/badge/spec-agentskills.io-orange?style=flat-square" alt="Agent Skills Spec"></a>
   <img src="https://img.shields.io/badge/evidence-graded-purple?style=flat-square" alt="Evidence-graded">
 </p>
-
-</div>
 
 ---
 
@@ -43,16 +28,18 @@ Every method is reduced to its working mechanism, graded honestly on how strong 
 - [Quick start](#-quick-start)
 - [What makes it different](#-what-makes-it-different)
 - [The library at a glance](#-the-library-at-a-glance)
-- [The catalog](#-the-catalog)
 - [The evidence model](#-the-evidence-model)
+- [The catalog](#-the-catalog)
 - [How a skill works](#-how-a-skill-works)
 - [Recipes](#-recipes)
 - [Find your way in](#-find-your-way-in)
 - [Documentation](#-documentation)
+- [Conformance: what advanced (Gold) tier means](#-conformance-what-advanced-gold-tier-means)
 - [Project status](#-project-status)
+  - [At a glance](#at-a-glance) · [Repo structure](#repo-structure) · [Changelog](#changelog)
 - [Contributing](#-contributing)
-- [License and attribution](#-license-and-attribution)
-- [Maintainer](#-maintainer)
+- [License](#-license)
+- [About the maintainer](#-about-the-maintainer)
 
 </details>
 
@@ -167,103 +154,9 @@ flowchart TB
 
 ---
 
-## 📚 The catalog
-
-All 34 skills, by family. The tier is the evidence grade (see [the evidence model](#-the-evidence-model)). Each links to its full page (mechanism, procedure, worked example, graded sources) on the live site.
-
-### Problem Framing - frame the real problem (2)
-
-| Skill | Tier | What it does |
-|---|---|---|
-| **Problem Restatement** | `M/P` | Rewrite the problem several ways to expose hidden framing, then pick a more useful one |
-| **Abstraction Laddering** | `P` | Move up ("why") and down ("how") the ladder to find the altitude where the problem is workable |
-
-### Divergent Ideation - generate options (5)
-
-| Skill | Tier | What it does |
-|---|---|---|
-| **Brainwriting** | `S` | Silent, parallel, written idea generation that reliably outperforms verbal brainstorming |
-| **Far-Analogy Ideation** | `S` | Transfer solutions from distant domains, which produce more original ideas than near ones |
-| **SCAMPER** | `P` | Run an idea through seven transformation prompts to force structured variation |
-| **Question Burst** | `P` | Generate a rapid burst of questions, rank them, and pursue the most catalytic one |
-| **Assumption Reversal** | `P` | Surface the assumptions baked into a problem, negate them, and generate non-obvious reframes |
-
-### Perspective & Multi-Lens - see it from other angles (1)
-
-| Skill | Tier | What it does |
-|---|---|---|
-| **Parallel Perspectives Review** | `P` | Examine a decision through several separated lenses in turn, then synthesize a balanced read |
-
-### Systems & Consequences - trace consequences (4)
-
-| Skill | Tier | What it does |
-|---|---|---|
-| **Stocks and Flows Reasoning** | `S` | Reason explicitly about accumulations and rates, which people systematically misjudge |
-| **Causal Loop Diagrams** | `M/P` | Close and sign the feedback loops (reinforcing or balancing) to read why a system spirals, settles, or oscillates |
-| **Futures Wheel** | `P` | Map first-, second-, and third-order consequences radiating from a change |
-| **Iceberg Model** | `P` | Move from events down to the patterns, structures, and mental models that produce them |
-
-### Assumption & Belief Challenge - challenge assumptions (3)
-
-| Skill | Tier | What it does |
-|---|---|---|
-| **Authentic Dissent** | `S` | Cultivate genuine minority disagreement, which improves reasoning where role-played dissent does not |
-| **Ladder of Inference Check** | `P` | Trace how you climbed from raw data to conclusion to catch where interpretation crept in |
-| **Red Team Light** | `P` | A lightweight adversarial pass that attacks a plan to surface its weak points |
-
-### Reasoning Clarity - clarify the reasoning (4)
-
-| Skill | Tier | What it does |
-|---|---|---|
-| **Argument Mapping** | `S` | Diagram the structure of claims, reasons, and objections to expose where it is weak |
-| **Natural-Frequency Bayesian Framing** | `S` | Express probabilities as natural frequencies (3 in 1,000) to make conditional reasoning tractable |
-| **Evidence vs Inference Sort** | `P` | Separate what is actually known from what is being inferred, and label each |
-| **Issue Tree** | `P` | Decompose a question into a logical tree of sub-questions to make analysis tractable |
-
-### Decision & Option Evaluation - decide between options (5)
-
-| Skill | Tier | What it does |
-|---|---|---|
-| **Linear-Model Aggregation** | `S` | Score options on a simple weighted model that tends to beat holistic judgment |
-| **Fermi Estimation** | `M/P` | Estimate an unknown by decomposing it into order-of-magnitude factors, then multiplying back to a number with a low/high band |
-| **What Would Have to Be True** | `P` | Turn a claim into the specific conditions that must hold, then test them |
-| **Decision Option Review** | `P` | Compare options against weighted criteria with explicit tradeoffs |
-| **One-Way vs Two-Way Door** | `P` | Classify a decision by reversibility and match the deliberation cost to it |
-
-### Risk & Resilience - anticipate what could go wrong (4)
-
-| Skill | Tier | What it does |
-|---|---|---|
-| **Premortem** | `S/M` | Imagine the plan has already failed and work backward to causes, tripwires, and kill criteria |
-| **Reference Class Forecasting** | `S` | Estimate from the track record of similar past projects, not inside-view optimism |
-| **WOOP** | `S` | Wish, Outcome, Obstacle, Plan: mental contrasting plus implementation intentions |
-| **Backcasting** | `P` | Start from a desired future state and work backward to the steps to reach it |
-
-### Synthesis - turn inputs into a message (3)
-
-| Skill | Tier | What it does |
-|---|---|---|
-| **Concept Mapping** | `M/P` | Build a labeled-relationship concept network so each link reads as an explicit proposition, surfacing gaps and missing links |
-| **Affinity Mapping** | `P` | Cluster many raw notes into emergent themes from the bottom up |
-| **Pyramid Principle** | `P` | Structure communication as a governing claim over grouped, ordered support |
-
-### Meta-Thinking & Reflection - learn and route (3)
-
-| Skill | Tier | What it does |
-|---|---|---|
-| **After Action Review** | `S` | Structured review of expected vs actual, and what to change, to improve the next loop |
-| **Decision Journal** | `P` | Record the decision, rationale, and prediction now to calibrate your judgment later |
-| **Framework Advisor** | `M/C` | The front door: describe a situation, get a prioritized Thinking Plan of which skills to run |
-
-> Browse them five other ways - by job, by evidence, by artifact, by situation, or on the map - in the site's [Explore](https://product-on-purpose.github.io/thinking-framework-skills/explore/) section. The skills themselves live in [`skills/`](skills/).
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
----
-
 ## 🔬 The evidence model
 
-Honest grading is the differentiator. Every skill and every claim is labeled with one of seven tiers:
+Honest grading is the differentiator, so the key comes **before** the catalog: every skill and every claim is labeled with one of seven tiers, from strongest to weakest.
 
 | Tier | Meaning |
 |---|---|
@@ -275,7 +168,103 @@ Honest grading is the differentiator. Every skill and every claim is labeled wit
 | `C` | **Conceptual** - reasonable, not yet demonstrated |
 | `X` | **Poor/contradictory** - the evidence cuts against it (excluded, documented) |
 
-A strong-evidence core anchors the library; the rest is honestly labeled around it. The [bibliography](https://product-on-purpose.github.io/thinking-framework-skills/evidence/bibliography/) aggregates the graded sources so a skeptic can trace any claim to its grounding. See [`docs/concepts.md`](docs/concepts.md) for the short version.
+A few skills carry a **split grade** (for example `M/P` or `S/M`): the mechanism rests on one tier while a specific claim about it rests on another. Where a grade leans on **human-subject** research that has not been tested on an AI agent, the skill's dossier flags that transfer explicitly rather than overclaiming.
+
+A strong-evidence core anchors the library; everything else is honestly labeled around it. The [bibliography](https://product-on-purpose.github.io/thinking-framework-skills/evidence/bibliography/) aggregates the graded sources so a skeptic can trace any claim to its grounding. See [`docs/concepts.md`](docs/concepts.md) for the short version.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+---
+
+## 📚 The catalog
+
+All 34 skills, by family. The `Tier` column is the [evidence grade](#-the-evidence-model) defined just above. **Each skill name links to its full page** - mechanism, numbered procedure, worked example, and graded sources - on the live site.
+
+### Problem Framing - frame the real problem (2)
+
+| Skill | Tier | What it does |
+|---|---|---|
+| [**Problem Restatement**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-problem-restatement/) | `M/P` | Rewrite the problem several ways to expose hidden framing, then pick a more useful one |
+| [**Abstraction Laddering**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-abstraction-laddering/) | `P` | Move up ("why") and down ("how") the ladder to find the altitude where the problem is workable |
+
+### Divergent Ideation - generate options (5)
+
+| Skill | Tier | What it does |
+|---|---|---|
+| [**Brainwriting**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-brainwriting/) | `S` | Silent, parallel, written idea generation that reliably outperforms verbal brainstorming |
+| [**Far-Analogy Ideation**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-far-analogy-ideation/) | `S` | Transfer solutions from distant domains, which produce more original ideas than near ones |
+| [**SCAMPER**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-scamper/) | `P` | Run an idea through seven transformation prompts to force structured variation |
+| [**Question Burst**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-question-burst/) | `P` | Generate a rapid burst of questions, rank them, and pursue the most catalytic one |
+| [**Assumption Reversal**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-assumption-reversal/) | `P` | Surface the assumptions baked into a problem, negate them, and generate non-obvious reframes |
+
+### Perspective & Multi-Lens - see it from other angles (1)
+
+| Skill | Tier | What it does |
+|---|---|---|
+| [**Parallel Perspectives Review**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-parallel-perspectives-review/) | `P` | Examine a decision through several separated lenses in turn, then synthesize a balanced read |
+
+### Systems & Consequences - trace consequences (4)
+
+| Skill | Tier | What it does |
+|---|---|---|
+| [**Stocks and Flows Reasoning**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-stocks-and-flows-reasoning/) | `S` | Reason explicitly about accumulations and rates, which people systematically misjudge |
+| [**Causal Loop Diagrams**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-causal-loop-diagrams/) | `M/P` | Close and sign the feedback loops (reinforcing or balancing) to read why a system spirals, settles, or oscillates |
+| [**Futures Wheel**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-futures-wheel/) | `P` | Map first-, second-, and third-order consequences radiating from a change |
+| [**Iceberg Model**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-iceberg-model/) | `P` | Move from events down to the patterns, structures, and mental models that produce them |
+
+### Assumption & Belief Challenge - challenge assumptions (3)
+
+| Skill | Tier | What it does |
+|---|---|---|
+| [**Authentic Dissent**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-authentic-dissent/) | `S` | Cultivate genuine minority disagreement, which improves reasoning where role-played dissent does not |
+| [**Ladder of Inference Check**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-ladder-of-inference-check/) | `P` | Trace how you climbed from raw data to conclusion to catch where interpretation crept in |
+| [**Red Team Light**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-red-team-light/) | `P` | A lightweight adversarial pass that attacks a plan to surface its weak points |
+
+### Reasoning Clarity - clarify the reasoning (4)
+
+| Skill | Tier | What it does |
+|---|---|---|
+| [**Argument Mapping**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-argument-mapping/) | `S` | Diagram the structure of claims, reasons, and objections to expose where it is weak |
+| [**Natural-Frequency Bayesian Framing**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-natural-frequency-bayesian/) | `S` | Express probabilities as natural frequencies (3 in 1,000) to make conditional reasoning tractable |
+| [**Evidence vs Inference Sort**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-evidence-vs-inference-sort/) | `P` | Separate what is actually known from what is being inferred, and label each |
+| [**Issue Tree**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-issue-tree/) | `P` | Decompose a question into a logical tree of sub-questions to make analysis tractable |
+
+### Decision & Option Evaluation - decide between options (5)
+
+| Skill | Tier | What it does |
+|---|---|---|
+| [**Linear-Model Aggregation**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-linear-model-aggregation/) | `S` | Score options on a simple weighted model that tends to beat holistic judgment |
+| [**Fermi Estimation**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-fermi-estimation/) | `M/P` | Estimate an unknown by decomposing it into order-of-magnitude factors, then multiplying back to a number with a low/high band |
+| [**What Would Have to Be True**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-what-would-have-to-be-true/) | `P` | Turn a claim into the specific conditions that must hold, then test them |
+| [**Decision Option Review**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-decision-option-review/) | `P` | Compare options against weighted criteria with explicit tradeoffs |
+| [**One-Way vs Two-Way Door**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-one-way-vs-two-way-door/) | `P` | Classify a decision by reversibility and match the deliberation cost to it |
+
+### Risk & Resilience - anticipate what could go wrong (4)
+
+| Skill | Tier | What it does |
+|---|---|---|
+| [**Premortem**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-premortem/) | `S/M` | Imagine the plan has already failed and work backward to causes, tripwires, and kill criteria |
+| [**Reference Class Forecasting**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-reference-class-forecasting/) | `S` | Estimate from the track record of similar past projects, not inside-view optimism |
+| [**WOOP**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-woop/) | `S` | Wish, Outcome, Obstacle, Plan: mental contrasting plus implementation intentions |
+| [**Backcasting**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-backcasting/) | `P` | Start from a desired future state and work backward to the steps to reach it |
+
+### Synthesis - turn inputs into a message (3)
+
+| Skill | Tier | What it does |
+|---|---|---|
+| [**Concept Mapping**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-concept-mapping/) | `M/P` | Build a labeled-relationship concept network so each link reads as an explicit proposition, surfacing gaps and missing links |
+| [**Affinity Mapping**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-affinity-mapping/) | `P` | Cluster many raw notes into emergent themes from the bottom up |
+| [**Pyramid Principle**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-pyramid-principle/) | `P` | Structure communication as a governing claim over grouped, ordered support |
+
+### Meta-Thinking & Reflection - learn and route (3)
+
+| Skill | Tier | What it does |
+|---|---|---|
+| [**After Action Review**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-after-action-review/) | `S` | Structured review of expected vs actual, and what to change, to improve the next loop |
+| [**Decision Journal**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-decision-journal/) | `P` | Record the decision, rationale, and prediction now to calibrate your judgment later |
+| [**Framework Advisor**](https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-framework-advisor/) | `M/C` | The front door: describe a situation, get a prioritized Thinking Plan of which skills to run |
+
+> Browse them five other ways - by job, by evidence, by artifact, by situation, or on the map - in the site's [Explore](https://product-on-purpose.github.io/thinking-framework-skills/explore/) section. The skills themselves live in [`skills/`](skills/).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -342,8 +331,33 @@ Browse them on the [live site](https://product-on-purpose.github.io/thinking-fra
 ## 📖 Documentation
 
 - **[Live site](https://product-on-purpose.github.io/thinking-framework-skills/)** - the full, searchable, interactive experience (per-framework pages, learning tracks, explorers, the bibliography). This is the home for *using* the library.
-- **[`docs/`](docs/)** - the repo-browser and contributor layer: [getting started](docs/getting-started.md), [architecture](docs/architecture.md), [contributing](docs/contributing.md), [concepts](docs/concepts.md). Plus a `<file>.md` sidecar next to each code/config file.
+- **[`docs/`](docs/)** - the repo-browser and contributor layer: [getting started](docs/getting-started.md), [architecture](docs/architecture.md), [concepts](docs/concepts.md), [contributing](docs/contributing.md), [conformance](docs/conformance.md). Plus a `<file>.md` sidecar next to each code/config file.
 - **[`skills/`](skills/)** - the frameworks themselves (the source of truth the site renders).
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+---
+
+## 🥇 Conformance: what advanced (Gold) tier means
+
+This plugin is built to the [agent-skills-toolkit](https://github.com/product-on-purpose/agent-skills-toolkit) **Advanced Skill Library Standard**, which grades a skill library on three tiers. Each tier includes everything below it:
+
+| Tier | Name | What it certifies |
+|---|---|---|
+| 🥉 | **Universal (Bronze)** | The skills are portable - valid frontmatter, an `AGENTS.md`, a manifest, references one level deep - so the identical files run on any agentskills.io-compatible agent. |
+| 🥈 | **Convergent (Silver)** | The plugin declares its agent targets and emits each higher-order component (commands, workflows, chain contracts) correctly for both Claude Code and Codex, with a manifest that matches what is on disk. |
+| 🥇 | **Advanced (Gold)** | The plugin proves itself - it ships CI that runs the Standard's own validators against it and passes (self-hosting), generates its `INDEX.md` and native manifests from a single authored source, and maintains release notes and a deprecation policy. |
+
+`thinking-framework-skills` validates at **advanced (Gold) with 0 errors and 0 warnings** against the pinned toolkit. Concretely, it earns Gold through:
+
+- **G2 - self-hosting CI that passes.** Every pull request runs [`scripts/check.mjs`](scripts/check.mjs) (the Standard's validators) via [`.github/workflows/ci.yml`](.github/workflows/ci.yml), and `check` is a required status check on `main`. The same one command reproduces the result locally.
+- **G4 - generated INDEX + manifests.** [`INDEX.md`](INDEX.md), `.claude-plugin/plugin.json`, the Codex manifest, and `manifest.generated.json` are all generated from the authored [`library.json`](library.json) and drift-checked; a hand-edit is a CI error.
+- **G5 - release notes.** Curated [`RELEASE-NOTES.md`](RELEASE-NOTES.md), distinct from the technical [`CHANGELOG.md`](CHANGELOG.md).
+- **G6 - deprecation policy** and **G7 - all Bronze + Silver requirements**, by inclusion.
+
+Two Gold checks are **not applicable** here, and the library says so rather than papering over it: **G1 (hook documentation)** and **G3 (eval coverage for chains and hooks)** apply only to plugins that ship hooks or chained components. This library ships neither - its recipes are workflow chains of independent skills, not runtime chain contracts - so those checks pass vacuously. Every skill still carries its own `eval/cases.md`.
+
+> Full breakdown, check by check: [`docs/conformance.md`](docs/conformance.md). The Standard itself: [agent-skills-toolkit / STANDARD.md](https://github.com/product-on-purpose/agent-skills-toolkit/blob/main/STANDARD.md).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -351,7 +365,63 @@ Browse them on the [live site](https://product-on-purpose.github.io/thinking-fra
 
 ## 📊 Project status
 
-`v0.2.0` - public and growing. 34 skills + 5 recipes, validating at the toolkit's **advanced (Gold)** tier with zero errors or warnings, with a self-hosting conformance gate in CI. The docs site builds clean and is published to GitHub Pages. The library grows additively, and the evidence grades are refreshed as the research does. See [`RELEASE-NOTES.md`](RELEASE-NOTES.md) and [`CHANGELOG.md`](CHANGELOG.md).
+`v0.2.0` - **public and growing.** The library grows additively, and evidence grades are refreshed as the research does. User-facing highlights live in [`RELEASE-NOTES.md`](RELEASE-NOTES.md); the full technical history is in [`CHANGELOG.md`](CHANGELOG.md).
+
+### At a glance
+
+|  |  |
+|---|---|
+| **Current version** | [v0.2.0](https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.2.0) |
+| **Skills** | 34, across 10 cognitive-operation families |
+| **Recipes** | 5 (skill chains shipped as workflow components) |
+| **Conformance** | [advanced (Gold)](#-conformance-what-advanced-gold-tier-means) - 0 errors / 0 warnings, self-hosting CI |
+| **Evidence** | 11 skills at `S` / `S-M` tier; every skill graded and sourced |
+| **Spec** | [agentskills.io](https://agentskills.io/specification) |
+| **License** | [Apache-2.0](LICENSE) |
+| **Docs site** | [product-on-purpose.github.io/thinking-framework-skills](https://product-on-purpose.github.io/thinking-framework-skills/) |
+| **Install** | `/plugin install thinking-framework-skills@product-on-purpose` |
+
+### Repo structure
+
+```
+thinking-framework-skills/
+├── skills/                  # 34 thinking-method skills (the source of truth)
+│   └── think-<method>/      #   SKILL.md, evidence/dossier.md, references/, eval/cases.md, skill.meta.yml
+├── _workflows/              # Recipe definitions (multi-skill chains) as workflow components
+├── recipes/                 # Human-readable recipe write-ups
+├── scripts/                 # gen-site, gen-manifest, gen-recommendable, and the check.mjs gate
+├── site/                    # Astro Starlight docs site (a generated view of skills/)
+├── docs/                    # Contributor and build docs
+│   └── internal/            #   AUTHORING.md, specs/, release-plans/, research/
+├── .github/workflows/       # CI: the self-hosting conformance gate + Pages deploy
+├── library.json             # Authored manifest (the canonical component index)
+├── INDEX.md                 # Generated catalog index (drift-checked)
+├── CHANGELOG.md             # Technical version history
+├── RELEASE-NOTES.md         # Curated, user-facing release highlights
+└── AGENTS.md                # Universal agent-discovery file
+```
+
+| Path | What's in it |
+|---|---|
+| [`skills/`](skills/) | All 34 skills, each a self-contained 5-file unit (the site renders from these) |
+| [`_workflows/`](_workflows/) | The 5 recipes as workflow components - ordered skill chains with handoffs |
+| [`scripts/`](scripts/) | Generators (site, manifests, name-safety set) and [`check.mjs`](scripts/check.mjs), the conformance gate |
+| [`docs/`](docs/) | [Getting started](docs/getting-started.md), [architecture](docs/architecture.md), [concepts](docs/concepts.md), [contributing](docs/contributing.md), [conformance](docs/conformance.md) |
+| [`docs/internal/`](docs/internal/) | The [authoring loop](docs/internal/AUTHORING.md), specs, [release plans](docs/internal/release-plans/), and research |
+
+### Changelog
+
+Full detail in [`CHANGELOG.md`](CHANGELOG.md); curated highlights in [`RELEASE-NOTES.md`](RELEASE-NOTES.md).
+
+<details>
+<summary><strong>Release history</strong></summary>
+
+| Version | Highlights |
+|---|---|
+| [**0.2.0**](https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.2.0) | Catalog grows 31 to 34 (Concept Mapping, Causal Loop Diagrams, Fermi Estimation, each vetted against the catalog before authoring) plus a first-principles recipe (4 to 5). A more visual docs site: legible diagrams and beginner concept diagrams on six pages. Gold-tier hardening - a self-hosting conformance gate in CI, a generated `INDEX.md`, and `RELEASE-NOTES.md`. Tier declared `advanced`. |
+| [**0.1.0**](https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.1.0) | First public release: 31 evidence-graded, agent-executable skills + 4 composable recipes, validating at convergent (Silver). The `think-framework-advisor` front-door router. A full Astro Starlight docs site (per-framework pages, learning tracks, exploration lenses, interactive chooser, graded bibliography). Listed in the Product on Purpose marketplace. |
+
+</details>
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -359,22 +429,49 @@ Browse them on the [live site](https://product-on-purpose.github.io/thinking-fra
 
 ## 🤝 Contributing
 
-A new framework has to clear the selection bar: it must add a **distinct, durable cognitive move** (not duplicate one already shipped), carry an **honest evidence grade** with a dossier of graded sources, produce a **concrete artifact**, and state **when not to use it**. The full authoring loop and the bar are in [`docs/contributing.md`](docs/contributing.md) and [`docs/internal/AUTHORING.md`](docs/internal/AUTHORING.md). Diagrams follow the pm-skills `utility-mermaid-diagrams` house style.
+Contributions, ideas, and framework proposals are welcome. The bar is deliberately high - it is what keeps the library trustworthy.
 
-Issues, ideas, and framework proposals are welcome in the repo's GitHub issues.
+**A new framework must clear the selection bar.** It has to:
+
+1. Add a **distinct, durable cognitive move** - not duplicate one already shipped. The overlap ceiling is real: candidates that reduce to an existing skill are rejected or become recipes.
+2. Carry an **honest evidence grade** with a dossier of graded sources, including what the research does *not* show.
+3. Produce a **concrete artifact**, not prose.
+4. State **when *not* to use it.**
+
+**To propose or build one:**
+
+1. Open an issue describing the move and its evidence - the fastest way to get feedback before you build.
+2. Read [`docs/contributing.md`](docs/contributing.md) and the per-skill authoring loop in [`docs/internal/AUTHORING.md`](docs/internal/AUTHORING.md).
+3. Mirror an existing skill's 5-file structure (`SKILL.md`, `evidence/dossier.md`, `references/`, `eval/cases.md`, `skill.meta.yml`).
+4. Run the conformance gate locally (`node scripts/check.mjs`) before opening a PR; CI runs the same gate.
+
+Diagrams follow the pm-skills `utility-mermaid-diagrams` house style. Commit with [Conventional Commits](https://www.conventionalcommits.org/).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ---
 
-## 📄 License and attribution
+## 📄 License
 
-**[Apache-2.0](LICENSE).** Method names that are trademarks or carry specific licenses remain the property of their owners; this library implements the underlying cognitive mechanisms, names them descriptively, and notes lineage and attribution in each skill's references rather than claiming the brands.
+Distributed under the **[Apache License 2.0](LICENSE)**. In short: you may use this library commercially, modify and redistribute it, use it privately, and include it in proprietary software. The only requirements are attribution and including the license notice.
+
+**On method names and trademarks.** Names that are trademarks or carry specific licenses remain the property of their owners. This library implements the underlying cognitive *mechanisms*, names them descriptively, and notes lineage and attribution in each skill's references rather than claiming the brands.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ---
 
-## Maintainer
+## 👋 About the maintainer
 
-**Jeremy Prisant** ([@jprisant](https://github.com/jprisant)) · Part of the [Product on Purpose](https://github.com/product-on-purpose) portfolio.
+<a href="https://github.com/jprisant"><img src="https://img.shields.io/badge/Maintained_by-Jonathan_Prisant-blue?style=for-the-badge&logo=github" alt="Maintained by Jonathan Prisant"></a>
+
+Built and maintained by **Jonathan Prisant** ([@jprisant](https://github.com/jprisant)), a product leader who thinks in systems and gets unreasonably excited about understanding and solving problems. `thinking-framework-skills` is the reasoning sibling to [`pm-skills`](https://github.com/product-on-purpose/pm-skills): one helps you decide *what* to work on and *why* it is sound, the other helps you execute *how*.
+
+*If this library has sharpened a decision, or saved you from a bad one, consider starring the repo and sharing it with your team.*
+
+<p align="center">
+  <strong>Built with purpose by <a href="https://github.com/product-on-purpose">Product on Purpose</a></strong><br>
+  <sub>Evidence-graded thinking, packaged as skills your agent can actually run</sub>
+</p>
 
 <div align="right"><a href="#readme-top">Back to top ↑</a></div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ It is not the learning experience. The rendered guide for end users (quick-facts
 - [architecture.md](./architecture.md) - how a skill is laid out, how `library.json` and the `_workflows` recipes feed `scripts/gen-site.mjs`, and why the skills (not the site) are canonical.
 - [contributing.md](./contributing.md) - how to propose or change a skill, plus the evals and checks a change has to pass.
 - [concepts.md](./concepts.md) - the vocabulary: cognitive-operation families, recipes, IDs (`thinking-framework-skills.<method>`), and the evidence tiers (S/M/P/V/A/C/X).
+- [conformance.md](./conformance.md) - what advanced (Gold) tier means, the G1-G7 checks, and how this plugin meets (or vacuously passes) each.
 - [internal/](./internal/) - **internal** specs, plans, research, and the authoring guide ([internal/AUTHORING.md](./internal/AUTHORING.md)). Working notes, not polished docs; expect churn.
 
 ## Per-file sidecars
@@ -18,6 +19,6 @@ Many code and config files have a `<name>.md` sidecar next to them (for example 
 
 ## Pointers off this folder
 
-- The frameworks: [`../skills/`](../skills/) - 31 skills across 10 families, plus 4 composable recipes.
+- The frameworks: [`../skills/`](../skills/) - 34 skills across 10 families, plus 5 composable recipes.
 - The live docs site: <https://product-on-purpose.github.io/thinking-framework-skills/> - the reading experience, generated from the skills.
 - The advisor (front door): pick a framework by describing your situation at <https://product-on-purpose.github.io/thinking-framework-skills/frameworks/think-framework-advisor/>.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,60 @@
+# Conformance: how this plugin reaches advanced (Gold) tier
+
+`thinking-framework-skills` is built to the [agent-skills-toolkit](https://github.com/product-on-purpose/agent-skills-toolkit) **Advanced Skill Library Standard** ([`STANDARD.md`](https://github.com/product-on-purpose/agent-skills-toolkit/blob/main/STANDARD.md)). This page is the check-by-check breakdown behind the one-line claim in the README: *validates at advanced (Gold), 0 errors / 0 warnings.*
+
+If you only want to verify it yourself, skip to [Reproduce it locally](#reproduce-it-locally).
+
+## The three tiers
+
+The Standard grades a plugin (a "skill library") on three tiers. The tiers are cumulative: each one includes every requirement below it.
+
+| Tier | Toolkit name | What it certifies | Audience |
+|---|---|---|---|
+| 🥉 Bronze | `universal` | The skills are **portable**: valid frontmatter, `name` equals the directory, descriptions meet the quality bar, references one level deep, an `AGENTS.md` at the root, and a minimal `library.json`. The identical files run on any agentskills.io-compatible agent (around 50 of them). | beginner on-ramp |
+| 🥈 Silver | `convergent` | The plugin declares its **agent targets** and emits each higher-order component (slash commands, workflows, subagents, chain contracts) in the correct format for both Claude Code and Codex. Chain contracts are valid (no orphans or phantoms), the manifest matches what is on disk, and versions follow semver. | intermediate |
+| 🥇 Gold | `advanced` | The plugin **proves itself**: it ships CI that runs the Standard's own validators against it and passes (self-hosting), generates its `INDEX.md` and native manifests from one authored source, and maintains release notes plus a deprecation policy. A Gold plugin is, by construction, a self-proving example of the Standard. | advanced |
+
+A plugin declares its tier in [`library.json`](../library.json) (`"tier": "advanced"`) and the toolkit's evaluator verifies the highest tier it actually satisfies, reporting any requirement that blocks the next tier up.
+
+## The Gold checks (G1-G7), and how this plugin meets each
+
+The Standard freezes the Gold requirements as G1 through G7. Here is each one and how `thinking-framework-skills` satisfies it.
+
+| # | Gold requirement | Status here | How |
+|---|---|---|---|
+| **G1** | Every hook documents its event, trigger, matcher, scope, and failure behavior. | **N/A (vacuous)** | This plugin ships **no hooks**, so there is nothing to document. The check passes because there is nothing to fail. |
+| **G2** | Self-hosting CI that runs the full tier-applicable check suite and passes. | **Met** | [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) runs [`scripts/check.mjs`](../scripts/check.mjs) on every PR and push to `main`. `check.mjs` locates a toolkit checkout and runs the toolkit's `evaluate.mjs` against this repo - it holds **no validation logic of its own**, so the rules cannot drift from the Standard. `check` is a **required status check** on `main`. |
+| **G3** | Each chain contract and each hook has at least one eval/regression case, executed in CI. | **N/A (vacuous)** | This plugin ships **no hooks and no runtime chain contracts**. Its recipes are workflow components that chain *independent* skills (each runnable alone), not `chain:` contracts between coupled components, so the contract is empty (`agents/_chain-permitted.yaml` is `{}`). Nothing to cover. Note: every skill still ships its own `eval/cases.md` (triggers, anti-triggers, output checks) as a quality practice, even though the Standard does not require it here. |
+| **G4** | `INDEX.md`, the native plugin manifests, and `manifest.generated.json` are **generated** from the authored `library.json` + component frontmatter, and drift-checked. A hand-edited generated file is an error. | **Met** | [`INDEX.md`](../INDEX.md), [`.claude-plugin/plugin.json`](../.claude-plugin/plugin.json), the Codex manifest, and [`manifest.generated.json`](../manifest.generated.json) are produced by the toolkit's `gen-index` / `gen-manifest` from the authored [`library.json`](../library.json) and checked for drift in CI. |
+| **G5** | The plugin maintains `RELEASE-NOTES.md` (curated, user-facing), distinct from `CHANGELOG.md`. | **Met** | [`RELEASE-NOTES.md`](../RELEASE-NOTES.md) (curated highlights) and [`CHANGELOG.md`](../CHANGELOG.md) (Keep a Changelog, technical) are both maintained and kept distinct. |
+| **G6** | A deprecation policy: `status` / `deprecated-by` / `remove-in` handling, recognized by tooling. | **Met** | Component frontmatter carries `status` (every skill is `active`), and the manifest pipeline handles the deprecation fields. No component is deprecated today; the policy and handling are in place for when one is. |
+| **G7** | All Bronze + Silver requirements, by inclusion. | **Met** | Bronze (portable skills, `AGENTS.md`, manifest) and Silver (`agent-targets: [claude, codex]`, per-target manifests, a valid chain contract, manifest-matches-disk) all pass. |
+
+The honest part of this table is the two **N/A** rows. G1 and G3 are not "skipped" or waived - they have no surface to apply to, because the library deliberately ships no hooks and no coupled chains. The toolkit's evaluator treats them as satisfied, and a future version of this plugin that *did* add a hook or a chain contract would have to satisfy them for real.
+
+## Why "self-hosting" matters
+
+The defining move of Gold is **G2**: the plugin does not just claim conformance, it runs the conformance checker against itself in CI and blocks merges that fail. Two design choices make that trustworthy here:
+
+- **No second source of truth.** `scripts/check.mjs` is a thin locator that shells out to the toolkit's `evaluate.mjs`. The checks live in the toolkit, not vendored into this repo where they could quietly diverge.
+- **Reproducible by anyone.** CI clones the toolkit at a pinned commit and runs the same command a contributor runs locally, so a green check is something you can re-derive, not take on faith.
+
+## Reproduce it locally
+
+```bash
+# 1. Clone this repo and the toolkit side by side
+git clone https://github.com/product-on-purpose/thinking-framework-skills.git
+git clone https://github.com/product-on-purpose/agent-skills-toolkit.git
+
+# 2. From the plugin, run the gate (same command CI runs)
+cd thinking-framework-skills
+node scripts/check.mjs
+```
+
+Expected: `Tier: advanced` with `0 error(s), 0 warning(s)`. `check.mjs` finds the toolkit via `AGENT_SKILLS_TOOLKIT`, a sibling `../agent-skills-toolkit`, or a local `./.agent-skills-toolkit` checkout (the path CI uses).
+
+## See also
+
+- [`docs/architecture.md`](architecture.md) - how the skills become the generated docs site.
+- [`docs/contributing.md`](contributing.md) - the selection bar and authoring loop for new skills.
+- [agent-skills-toolkit / STANDARD.md](https://github.com/product-on-purpose/agent-skills-toolkit/blob/main/STANDARD.md) - the full Standard, including the frozen Gold criteria (Section 2.6).

--- a/docs/internal/release-plans/README.md
+++ b/docs/internal/release-plans/README.md
@@ -1,0 +1,21 @@
+# Release plans
+
+One folder per release line. These are **internal planning and build records** - what was scoped, the build order, and (after the fact) what actually shipped. They are not the canonical changelog.
+
+The canonical, user-facing records live at the repo root:
+
+- [`CHANGELOG.md`](../../../CHANGELOG.md) - technical history (Keep a Changelog).
+- [`RELEASE-NOTES.md`](../../../RELEASE-NOTES.md) - curated highlights.
+- GitHub releases: <https://github.com/product-on-purpose/thinking-framework-skills/releases>.
+
+## Releases
+
+| Plan | Release | Status | What it covered |
+|---|---|---|---|
+| [`plan_v0.1.0/`](./plan_v0.1.0/) | [v0.1.0](https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.1.0) | **Shipped** 2026-06-01 | The MVP build-out: the 14-skill canonical roster that grew into 31 skills + 4 recipes, the framework advisor, the docs site, and the go-public flip. `plan_v0.1.0/BACKLOG.md` is the historical build order. |
+| [`plan_v0.2.0/`](./plan_v0.2.0/) | [v0.2.0](https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.2.0) | **Shipped** 2026-06-01 | Catalog growth (+3 skills, +1 recipe, vetted before building), docs visual polish, and the advanced (Gold) tier hardening, then published and re-pinned in the marketplace. See [`plan_v0.2.0/PLAN.md`](./plan_v0.2.0/PLAN.md). |
+
+## Convention
+
+- A release line gets a folder when planning starts. While in flight it holds the live backlog / build order; once shipped it is annotated to a record of what landed.
+- Keep these honest. If a plan changed mid-flight (scope cut, candidate rejected, milestone renumbered), say so here rather than silently rewriting history - the value is the trail, not a tidy fiction.

--- a/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
+++ b/docs/internal/release-plans/plan_v0.1.0/BACKLOG.md
@@ -1,4 +1,6 @@
-# MVP backlog and build order
+# MVP backlog and build order (v0.1.0)
+
+> **STATUS: SHIPPED.** `v0.1.0` was released on 2026-06-01 (public repo + live docs site + marketplace listing). This file is the **historical build record** for the v0.1.0 MVP - the roster and order are preserved as authored. The "Now" snapshot below was true mid-build and is **intentionally not edited**; it describes the plan, not current state. For what actually shipped, see [`CHANGELOG.md`](../../../../CHANGELOG.md) and [`RELEASE-NOTES.md`](../../../../RELEASE-NOTES.md); for the next release, see [`../plan_v0.2.0/`](../plan_v0.2.0/); for the folder's purpose, see [`../README.md`](../README.md).
 
 The single source of "what to build next." WIP = 1: build the **Now** skill end to end (per [AUTHORING.md](../../AUTHORING.md)), ship it, then move the pointer. Roster is from the audit (Appendix B canonical roster); names use the `think-` prefix and `thinking-framework-skills.<method>` ids.
 

--- a/docs/internal/release-plans/plan_v0.2.0/PLAN.md
+++ b/docs/internal/release-plans/plan_v0.2.0/PLAN.md
@@ -1,0 +1,56 @@
+# v0.2.0 release record
+
+> **STATUS: SHIPPED** on 2026-06-01. Tag [`v0.2.0`](https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.2.0); marketplace re-pinned so installers get this build. This is the as-built record - what was scoped and what actually landed. Canonical history: [`CHANGELOG.md`](../../../../CHANGELOG.md) and [`RELEASE-NOTES.md`](../../../../RELEASE-NOTES.md).
+
+Unlike v0.1.0, v0.2.0 was not driven by a pre-committed backlog. It grew from three post-launch tracks the maintainer chose after the public launch settled: **grow the catalog**, **polish the docs**, and **harden to Gold**. This file records all three plus the publish step.
+
+## Goals
+
+1. Grow the catalog without diluting the moat - only frameworks that clear the selection bar and the overlap ceiling.
+2. Make the docs site easier to learn from (legible diagrams, beginner aids).
+3. Close the deferred Gold-tier gaps so the plugin is self-validating.
+4. Publish: cut the release and update the marketplace.
+
+## What shipped
+
+### 1. Catalog growth (+3 skills, +1 recipe): 31 to 34 skills, 4 to 5 recipes
+
+Vetted **before** building. A 12-agent evidence-and-overlap workflow assessed 6 candidate frameworks against the 31 shipped skills; only 3 cleared both the evidence bar and the ~20% overlap ceiling.
+
+| Candidate | Verdict | Reason |
+|---|---|---|
+| Concept Mapping | **Built** (`M/P`) | Distinct synthesis move; meta-analysis evidence is real but measures human retention, so graded `M/P` with a transferred-evidence flag (not `S`, despite a larger meta-analysis than `S`-tier Argument Mapping, because retention does not transfer to an agent the way reasoning quality does). |
+| Causal Loop Diagrams | **Built** (`M/P`) | Distinct systems move (signed feedback loops); evidence is feedback-misperception studies on humans, flagged. |
+| Fermi Estimation | **Built** (`M/P`) | Distinct decision move (order-of-magnitude decomposition); dossier deliberately **refuses** the floated "99 vs 3 / 42%" effect sizes as untraceable to a primary source. |
+| First Principles | **Recipe, not skill** | No separable mechanism of its own - it is decomposition + assumption-stripping, so it shipped as the `first-principles` recipe chaining `think-abstraction-laddering` + `think-assumption-reversal`. |
+| Key Assumptions Check | **Rejected** | Same artifact as `think-what-would-have-to-be-true`'s assumption ledger. |
+| Double Crux | **Rejected** | Solo-reduces to WWHTBT killer-conditions; overlaps authentic-dissent / red-team-light. |
+
+Each built skill follows the standard 5-file structure and hard-walls its overlaps in "When NOT to use." Registered in `library.json`; advisor name-safety set regenerated.
+
+### 2. Docs visual polish
+
+- README lifecycle diagram and the site all-frameworks map went from horizontal to **vertical** layouts so they are legible in a narrow column (the earlier horizontal-squish fix).
+- **Beginner concept diagrams** on six framework pages via an optional `references/CONCEPT.md` per skill, rendered after the quick-facts card: natural-frequency-bayesian (frequency tree), reference-class-forecasting (inside/outside view), causal-loop-diagrams (R/B loops), stocks-and-flows (bathtub), iceberg (4 levels), futures-wheel (consequence fan). Source-controlled, dark-mode-safe, not in the agent-facing `SKILL.md`.
+- `getting-started` and `how-to-read-a-page` converted to interactive `.mdx` (cards, steppers, callouts).
+
+### 3. Advanced (Gold) tier hardening
+
+Closed the three deferred Gold gaps so the plugin validates at `advanced`, 0 errors / 0 warnings:
+
+- **G2 - self-hosting CI.** `scripts/check.mjs` (a thin locator that runs the toolkit's validators, no logic of its own) + `.github/workflows/ci.yml` running it on every PR / push. `check` is a required status check on `main`. Root `package.json` exposes `npm run check`.
+- **G4 - generated INDEX + manifests.** `INDEX.md` generated and drift-checked alongside the native manifests.
+- **G5 - release notes.** `RELEASE-NOTES.md` (curated) added, distinct from `CHANGELOG.md`.
+- Tier declared `advanced` in `library.json`; version `0.1.0` to `0.2.0`.
+- G1 (hooks) and G3 (chain/hook evals) are N/A - this plugin ships no hooks and no chain contracts. See [`docs/conformance.md`](../../../conformance.md).
+
+### 4. Publish
+
+- Annotated tag `v0.2.0` + GitHub release (body from the RELEASE-NOTES v0.2.0 section).
+- Marketplace listing in `product-on-purpose/agent-plugins` re-pinned from the v0.1.0 commit to the v0.2.0 commit; marketplace metadata bumped. The pinned manifest carries `license` (the validate-registry gate).
+
+## Notes for next time
+
+- The vetting-before-building workflow did real work (rejected 3 of 6 candidates) and is the reusable pattern for catalog growth. Re-run it before adding skills; do not add a framework that reduces to a shipped one.
+- A fan-out build had concurrent agents racing on `library.json` (each registers itself per AUTHORING.md step 8); only one landed cleanly. Register the rest by hand, or serialize the registration step.
+- `release-plans/` should get its `plan_vX/` folder when planning starts, not after shipping - this v0.2.0 record was reconstructed after the fact, which is why it reads as a record rather than a backlog.


### PR DESCRIPTION
Addresses a 9-point docs/hygiene request.

**README (7 changes)**
1. The evidence-model tier key (S/M/P/V/A/C/X) now appears **before** the catalog, so grades have context first.
2. Every catalog skill name **links** to its live-site framework page.
3. Maintainer block signs pm-skills-style ("About the maintainer" + a maintainer badge + the "Built with purpose by Product on Purpose" footer; name Jonathan Prisant).
4. New **Conformance** section explaining what advanced (Gold) tier means, linking to a detailed breakdown.
5. Top summary/byline **left-aligned** (was centered); also fixes the stale version badge (0.1.0 -> 0.2.0) and adds a tier badge.
6. **All 9 mermaid diagrams verified** valid (2 in README + architecture + 6 concept diagrams).
7. Mirrors pm-skills' verbose sections: Project status (At a glance table, Repo structure, Changelog/release history), expanded Contributing and License.

**New:** `docs/conformance.md` - the G1-G7 check-by-check breakdown, honest that **G1 (hooks) and G3 (chain/hook evals) are N/A** here (the plugin ships no hooks and no chain contracts), not silently passed.

**Release-plans truth-up:** a folder `README.md` indexing the release lines; `plan_v0.1.0/BACKLOG.md` bannered SHIPPED/historical; new `plan_v0.2.0/PLAN.md` as the as-built record (catalog +3 via vet-before-build, docs polish, Gold hardening, publish + re-pin).

**Also (outside the diff):** set the repo description and 16 topics.

Verified by a 5-dimension adversarial pass: **43 checks pass, 0 fail** - counts consistent (34 skills / 5 recipes), every cited live URL resolves, all mermaid valid, internal anchors resolve, no en/em dashes. Docs-only; no change to `library.json` or skills, so the conformance gate stays 0/0.