### PR TITLE
chore(release): v0.2.1 - docs-site conformance arc (14.11 guards, 43 link fixes)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "thinking-framework-skills",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An evidence-graded library of agent-executable thinking-method skills (premortem, problem restatement, and more). Each skill is reduced to its working mechanism, graded honestly on how strong its evidence actually is, and produces a concrete artifact rather than prose. Use to reframe a problem, challenge assumptions, generate options, stress-test a decision, or audit reasoning.",
   "license": "Apache-2.0",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "thinking-framework-skills",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An evidence-graded library of agent-executable thinking-method skills (premortem, problem restatement, and more). Each skill is reduced to its working mechanism, graded honestly on how strong its evidence actually is, and produces a concrete artifact rather than prose. Use to reframe a problem, challenge assumptions, generate options, stress-test a decision, or audit reasoning.",
   "license": "Apache-2.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. The format is based on 
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-03
+
 ### Added
 - `site/public/robots.txt` pointing at the generated sitemap.
 - Build-aware link and route integrity guards (family Astro site standard 14.11): `scripts/check-rendered-links.mjs` (browser-broken internal links + `#anchor` resolution, enforced with `STRICT_ANCHORS=1` in CI) and `scripts/check-route-parity.mjs` (guards against silently dropping a published route, against the committed `scripts/route-manifest.txt`). Both run after the build in the PR `site-build` job and the deploy build, gated on the build outcome. A `node --test` suite (`tests/check-rendered-links.test.mjs`, 10 cases) proves the rendered-link guard's robustness.
@@ -45,6 +47,7 @@ All notable changes to this project are documented here. The format is based on 
 - An Astro Starlight docs site (per-framework pages with 4-layer progressive disclosure, learning tracks, exploration lenses, an interactive chooser, an aggregated graded bibliography), deployed to GitHub Pages.
 - Listed in the Product on Purpose marketplace. Apache-2.0.
 
-[unreleased]: https://github.com/product-on-purpose/thinking-framework-skills/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/product-on-purpose/thinking-framework-skills/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.2.1
 [0.2.0]: https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.2.0
 [0.1.0]: https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.1.0

--- a/INDEX.md
+++ b/INDEX.md
@@ -4,7 +4,7 @@
 > drift-checked (G4). Edit the source, not this file. Overview and positioning are
 > in [`README.md`](README.md); agent guidance is in [`AGENTS.md`](AGENTS.md).
 
-**Tier:** Gold (advanced). Standard 0.8. Version 0.2.0. Self-validating: `node scripts/check.mjs`.
+**Tier:** Gold (advanced). Standard 0.8. Version 0.2.1. Self-validating: `node scripts/check.mjs`.
 
 ## Components
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,15 @@
 
 Curated, user-facing highlights per release. For the full technical history, see [`CHANGELOG.md`](CHANGELOG.md). For everything in the library, browse the [live docs site](https://product-on-purpose.github.io/thinking-framework-skills/).
 
+## v0.2.1
+
+**Docs-site link and route integrity, and the family site-standard convergence.** A maintenance release: no catalog changes, but the live site is now guarded and a batch of pre-existing broken links is fixed.
+
+- **43 broken links fixed.** A new build-aware link checker found 43 internal links that were silently 404ing on the live site (most from a single generator bug on the bibliography page) - all fixed, and now guarded so they cannot come back.
+- **The docs site is link- and route-guarded in CI.** Every pull request and every deploy runs a rendered-link check (including `#anchors`) and a route-parity check against a committed route manifest, so a browser-broken internal link or a silently dropped page fails the build (family Astro site standard, clause 14.11).
+- **"Edit" links on generated pages resolve.** Each generated page now points its Edit link at its true source (a framework page to its skill's `SKILL.md`) instead of a gitignored build path that 404s.
+- **Site-standard convergence.** The docs site CI/deploy aligned to the Product on Purpose family Astro standard: the GitHub Pages artifact flow, `.nvmrc`-pinned Node across every job, a single-sourced base path, and no per-file config sidecars.
+
 ## v0.2.0
 
 **Three new skills and a recipe, a more visual docs site, and a self-validating repo.**

--- a/docs/internal/release-plans/README.md
+++ b/docs/internal/release-plans/README.md
@@ -14,6 +14,7 @@ The canonical, user-facing records live at the repo root:
 |---|---|---|---|
 | [`plan_v0.1.0/`](./plan_v0.1.0/) | [v0.1.0](https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.1.0) | **Shipped** 2026-06-01 | The MVP build-out: the 14-skill canonical roster that grew into 31 skills + 4 recipes, the framework advisor, the docs site, and the go-public flip. `plan_v0.1.0/BACKLOG.md` is the historical build order. |
 | [`plan_v0.2.0/`](./plan_v0.2.0/) | [v0.2.0](https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.2.0) | **Shipped** 2026-06-01 | Catalog growth (+3 skills, +1 recipe, vetted before building), docs visual polish, and the advanced (Gold) tier hardening, then published and re-pinned in the marketplace. See [`plan_v0.2.0/PLAN.md`](./plan_v0.2.0/PLAN.md). |
+| [`plan_v0.2.1/`](./plan_v0.2.1/) | [v0.2.1](https://github.com/product-on-purpose/thinking-framework-skills/releases/tag/v0.2.1) | **Cutting** 2026-06-03 | Maintenance: tags the docs-site conformance arc merged after v0.2.0 (the family Astro site standard convergence + the local 14.11 link/route guards + 43 pre-existing broken-link fixes). No catalog changes. See [`plan_v0.2.1/PLAN.md`](./plan_v0.2.1/PLAN.md). |
 
 ## Convention
 

--- a/docs/internal/release-plans/plan_v0.2.1/PLAN.md
+++ b/docs/internal/release-plans/plan_v0.2.1/PLAN.md
@@ -1,0 +1,57 @@
+# v0.2.1 release plan
+
+> **STATUS: IN FLIGHT (cutting 2026-06-03).** A maintenance release that tags the docs-site
+> conformance work already merged to `main` since `v0.2.0`. No catalog changes. Canonical history:
+> [`CHANGELOG.md`](../../../../CHANGELOG.md) and [`RELEASE-NOTES.md`](../../../../RELEASE-NOTES.md);
+> folder purpose in [`../README.md`](../README.md).
+
+## Why a release, and why a patch
+
+Three site/CI conformance PRs landed on `main` after the `v0.2.0` tag and were never cut into a
+release - they sat in `CHANGELOG [Unreleased]`. They include real user-facing bug fixes (43 live
+broken links on the docs site), so they deserve a tagged line rather than only living on `main`.
+
+**Version: `0.2.1` (patch).** The change set is site/CI conformance plus bug fixes. There are **no
+new skills, no catalog changes, and no behavior change to any skill or to the plugin's API** - so
+under semver this is a patch, not a minor. (`library.json` is the version source of truth; the U9
+`version-match` check requires `package.json` to equal it.)
+
+## What it tags (the `[Unreleased]` arc since v0.2.0)
+
+| PR | Commit | What |
+|---|---|---|
+| #28 | `1148bc5` | Docs-site CI/deploy converged to the family Astro site standard (Pages artifact flow `@v5`, `.nvmrc` Node pin, `robots.txt`, advisor drift guard). |
+| #30 | `53992c9` | 14.10 closed (7 repo-level `.md` config sidecars deleted) + two P2s (`check` job to `.nvmrc`; `editLink` `/site/` segment). |
+| #31 | `53fd49e` | **14.11 reversal:** two local link/route guards (rendered-link + route-parity) ported from the hardened agent-skills-toolkit versions; single-sourced base (14.7); **43 pre-existing live broken links fixed**; generated-page `editUrl` fixed; guards wired in the PR + deploy builds + a `guard-tests` job. |
+
+## Cut steps
+
+1. **Version bump (done):** `library.json` + `package.json` `0.2.0 -> 0.2.1`; regenerate `INDEX.md`,
+   `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `manifest.generated.json` via the
+   toolkit `gen-index` / `gen-manifest`. Verified the regen diff is version-only, so it matches the
+   CI-pinned toolkit ref's drift check.
+2. **Notes (done):** `CHANGELOG` `[Unreleased] -> [0.2.1] - 2026-06-03` (+ fresh empty `[Unreleased]`,
+   compare links); `RELEASE-NOTES` gains a curated `v0.2.1` section.
+3. **PR + gate:** branch `chore/release-v0.2.1`; conformance gate green (`advanced`, 0/0, no drift);
+   open PR; all CI checks green; squash-merge.
+4. **Tag + release:** annotated tag `v0.2.1` on the merged commit; push; GitHub release with the body
+   from the `RELEASE-NOTES` `v0.2.1` section.
+5. **Marketplace:** in `product-on-purpose/agent-plugins`, re-pin the `thinking-framework-skills`
+   entry (`sha` + `version 0.2.0 -> 0.2.1`) to the tagged commit and bump `metadata.version`; PR + merge.
+
+## Acceptance (done = all true)
+
+- `library.json` = `package.json` = the three native manifests = `INDEX.md` all read `0.2.1`.
+- Conformance gate `advanced`, 0/0 (no manifest/index drift) locally and in CI.
+- `CHANGELOG` has a dated `[0.2.1]`; `RELEASE-NOTES` has a `v0.2.1` section; both links resolve.
+- Tag `v0.2.1` pushed; GitHub release published.
+- Marketplace `thinking-framework-skills` pinned to the `v0.2.1` commit at `version 0.2.1`.
+
+## Notes for next time
+
+- This is a record-style plan written at cut time (the work was already merged). Per `README.md`,
+  a release line ideally gets its `plan_vX/` folder when planning starts; this one is a tag-the-arc
+  release, so the folder and the work coincide.
+- The local 14.11 guards tagged here are the **bridge**, not the destination: the Astro standard
+  ROADMAP Phase 1.3 names this repo as the shared-workflow pilot, which will later swap the local
+  guards for the shared `workflow_call`. That is a future release, gated on infra in `agent-plugins`.

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "thinking-framework-skills",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An evidence-graded library of agent-executable thinking-method skills (premortem, problem restatement, and more). Each skill is reduced to its working mechanism, graded honestly on how strong its evidence actually is, and produces a concrete artifact rather than prose. Use to reframe a problem, challenge assumptions, generate options, stress-test a decision, or audit reasoning.",
   "standard": "0.8",
   "tier": "advanced",

--- a/manifest.generated.json
+++ b/manifest.generated.json
@@ -1,6 +1,6 @@
 {
   "name": "thinking-framework-skills",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "tier": "advanced",
   "standard": "0.8",
   "skills": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinking-framework-skills",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An evidence-graded library of agent-executable thinking-method skills.",
   "private": true,
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Maintenance release **v0.2.1** - tags the docs-site conformance arc that landed on `main` after `v0.2.0` and sat in `CHANGELOG [Unreleased]`. **No catalog changes**; this is site/CI conformance plus bug fixes, so it is a patch.

## What it tags

- **#28** (`1148bc5`) - docs-site CI/deploy converged to the family Astro site standard.
- **#30** (`53992c9`) - 14.10 (config sidecars) + two P2s (node pin, editLink `/site/`).
- **#31** (`53fd49e`) - the local 14.11 link/route guards + **43 pre-existing live broken-link fixes** + the generated-page `editUrl` fix.

## Release-prep changes

- `library.json` + `package.json` `0.2.0 -> 0.2.1`; `INDEX.md` + the three native manifests regenerated. The regen diff is **version-only**, so it matches the CI-pinned toolkit ref's drift check.
- `CHANGELOG` `[Unreleased] -> [0.2.1] - 2026-06-03` (+ fresh `[Unreleased]`, compare links); `RELEASE-NOTES` gains a `v0.2.1` section; `docs/internal/release-plans/plan_v0.2.1/PLAN.md` added.

Conformance gate is green locally (`advanced`, 0/0, no manifest/index drift). The annotated tag, GitHub release, and marketplace re-pin follow this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
