### PR TITLE
docs: v0.3.0 Framework Library platform specs + catalog/why-not truth-up

### DIFF
--- a/docs/internal/release-plans/plan_v0.3.0/spec-sp3-registry.md
+++ b/docs/internal/release-plans/plan_v0.3.0/spec-sp3-registry.md
@@ -1,0 +1,140 @@
+# SP3 spec: the framework registry (`registry.yaml`) + strong CI
+
+> **STATUS: SPEC, pending maintainer review.** Part of [`PLAN.md`](./PLAN.md). The data foundation
+> for the Framework Library. Pairs with [`spec-sp9-ip-policy.md`](./spec-sp9-ip-policy.md) (attribution
+> fields) and feeds [`spec-sp4-framework-library.md`](./spec-sp4-framework-library.md) (dossiers) and
+> [`spec-sp5-research-framework.md`](./spec-sp5-research-framework.md) (the engine that proposes entries).
+
+## Why
+
+Today the catalog of evaluated frameworks lives in **two hand-maintained markdown files** that drift:
+`docs/internal/research/framework-catalog.md` (the universe, with `[shipped]/[next]/[cand]/[fold]/...`
+tags) and `site/src/content/docs/about/why-not.md` (the public exclusion list). The 2026-06-03 vetting
+run proved the drift is real: the catalog still tagged three v0.2.0-shipped skills as `[next]` and one
+`[cand]` (leverage-points) that is actually a fold. A hand-list cannot enforce that every shipped
+framework has a skill, every fold points at a real target, or every branded entry carries attribution.
+
+The maintainer's decision (locked 2026-06-03): make a **registry the single source of truth**, with
+**strong CI** around it, and generate every view. A framework's identity, grade, status, and reasoning
+live once; the catalog, the advisor's recommendable feed, and the site Framework Library index are all
+**generated and drift-checked**. "Resilient docs" is exactly this: the documents cannot rot because a
+required check regenerates and byte-compares them on every PR.
+
+## Design overview
+
+```
+frameworks/registry.yaml            <- single source of truth (hand/agent-authored entries)
+  |-- registry.schema.json          <- committed JSON Schema (validates every entry)
+  |-- gen -> docs/internal/research/framework-catalog.md   (master list, generated)
+  |-- gen -> skills/think-framework-advisor/references/recommendable.{json,md}  (advisor + chooser feed)
+  |-- gen -> site/src/content/docs/frameworks/ index + per-entry status   (Framework Library, SP4)
+scripts/gen-registry.mjs            <- the generator (one source, many views; --check for CI)
+scripts/check-registry.mjs          <- the integrity checks (schema, referential, completeness, IP)
+```
+
+The registry is **YAML** (decided): comfortable for long `reasoning` prose and multi-line attribution,
+diff-friendly, and comment-tolerant. The generated views stay in their existing formats so nothing
+downstream (the advisor, the site generator) changes shape; they simply stop being hand-authored.
+
+### The entry schema
+
+Each `frameworks[]` entry (one per evaluated method, shipped or not):
+
+| Field | Req | Notes |
+|---|---|---|
+| `slug` | yes | kebab method name, no `think-` prefix (e.g. `belief-update-routine`); unique; the dossier dir + skill dir key |
+| `name` | yes | display name (e.g. "Belief-Update Routine") |
+| `family` | yes | enum: the 11 families (problem-framing ... meta-thinking-and-reflection) |
+| `tier` | yes | enum `S/M/P/V/A/C/X` (honest evidence grade; X never ships) |
+| `status` | yes | enum `shipped / next / cand / fold / flag / pm / excl` |
+| `verdict` | yes | enum `build / fold / recipe / reject / shipped` (the vetting decision) |
+| `evalDate` | yes | ISO date the verdict was set/confirmed |
+| `reasoning` | yes | why this status/verdict (the decisive rationale; multi-line) |
+| `foldInto` | cond | required when `status: fold` / `verdict: fold`; a `slug` that MUST resolve to a `shipped` entry |
+| `dossierPath` | cond | `frameworks/<slug>/dossier.md` or the literal `pending`; required once SP4 lands |
+| `evalCases` | cond | `skills/think-<slug>/eval/cases.md`; required when `status: shipped` (couples to SP1) |
+| `attribution` | cond | author/origin (e.g. "Donella Meadows, 1999"); **required when `branded: true`** |
+| `trademark` | cond | TM/owner/license string; **required when `branded: true`** (the IP lint, SP9) |
+| `branded` | no | bool; true for IP/branded frameworks (Six Thinking Hats, Cynefin, ...) |
+| `sources` | no | list of `{title, url, kind}` for the dossier bibliography seed |
+| `aliases` | no | other names (so search/dedupe catches "MECE" == "mutually exclusive ...") |
+
+The `anti_triggers` + `not_use` fields SP1 adds to `recommendable.json` are **registry-shaped**: once
+SP3 lands, the registry owns them (or they stay derived from each shipped skill's `eval/cases.md` +
+`SKILL.md`, with the registry referencing the source). SP1 forward-fits this on purpose; SP3 does not
+rebuild SP1.
+
+### The generated views (drift-checked)
+
+1. **`framework-catalog.md`** - the master list, grouped by family, each row `name | one-line | tier |
+   [status] -> note`. Replaces the hand-authored catalog (SP3 open decision: fully generated, or a
+   generated table with a hand-authored narrative preamble - recommendation: fully generated table,
+   optional hand preamble above a `<!-- generated below -->` marker).
+2. **`recommendable.{json,md}`** - unchanged shape (SP1's enriched fields), now sourced from the
+   registry's `shipped` entries rather than re-derived independently. The existing
+   `gen-recommendable.mjs --check` drift guard subsumes into the registry drift guard.
+3. **The site Framework Library index** (SP4) - the list of every framework with its status badge,
+   linking to each dossier.
+
+## Components
+
+### C1. `frameworks/registry.yaml` + `frameworks/registry.schema.json`
+The authored source + its JSON Schema. Seed `registry.yaml` from the current `framework-catalog.md`
+(a one-time migration: parse the existing rows into entries, carry the tags as `status`, the notes as
+`reasoning`). The migration is a throwaway script or a careful hand-pass; the registry is hand-owned
+thereafter (entries proposed by SP5's `research-framework`).
+
+### C2. `scripts/gen-registry.mjs` (generator, `--check` mode)
+Reads `registry.yaml`, writes the three generated views. `--check` regenerates to memory and
+byte-compares against the committed files; exits 1 on any drift (the `gen-recommendable` pattern,
+generalized). Zero-dependency Node, UTF-8 explicit (the Windows cp1252 trap).
+
+### C3. `scripts/check-registry.mjs` (integrity, `--check`)
+The strong CI, run in the required `check` gate:
+
+1. **Schema validation** - every entry validates against `registry.schema.json` (enums for tier,
+   status, family; required-field conditionals; `branded -> attribution + trademark`).
+2. **Drift guard** - delegates to `gen-registry.mjs --check` (all three views byte-match).
+3. **Referential integrity** - `status: shipped` <-> `skills/think-<slug>/` exists (both directions:
+   no shipped entry without a skill dir; no skill dir without a shipped entry). Every `foldInto`
+   resolves to a `shipped` slug. Every `dossierPath != pending` resolves to a real file. Every source
+   `url` is well-formed.
+4. **Completeness** - every entry has a `dossierPath` (or `pending`); no `frameworks/<slug>/dossier.md`
+   exists without a registry entry (no orphan dossier).
+5. **IP / attribution lint** - `branded: true` requires non-empty `attribution` + `trademark`.
+6. **Eval coupling** (ties to SP1) - every `shipped` entry's `evalCases` path exists and SP1's static
+   validator passes for it.
+
+### C4. Gate wiring
+`scripts/check.mjs` invokes `check-registry.mjs` after the toolkit evaluator and the SP1 validator;
+`ci.yml`'s required `check` job covers it; `check-registry` is made a **required** status check on
+`main` (same posture as `check`). `npm run check` runs the full chain. Worktree-portable toolkit
+resolution (SP1's fix) is a prerequisite so the registry checks run from any workspace.
+
+## Acceptance criteria
+
+- **AC1** `frameworks/registry.yaml` holds one entry per framework currently in `framework-catalog.md`,
+  validating against `registry.schema.json`; `node scripts/check-registry.mjs --check` exits 0.
+- **AC2** `framework-catalog.md`, `recommendable.{json,md}`, and the site index are **generated**;
+  hand-editing any of them and running `--check` exits 1 (drift caught).
+- **AC3** Referential integrity holds: every `shipped` <-> a skill dir; every `foldInto` -> a real
+  shipped slug; every non-`pending` `dossierPath` -> a real file. A fixture that breaks each (orphan
+  shipped, dangling fold, missing dossier) makes `--check` exit 1.
+- **AC4** A `branded: true` entry missing `attribution` or `trademark` fails the IP lint.
+- **AC5** `check-registry` runs inside the required `check` gate on every PR; `npm run check` green
+  (advanced, 0/0) from a worktree.
+
+## Out of scope
+
+The dossier *content* and the site Framework Library *rendering* (SP4); the `research-framework`
+engine that proposes entries (SP5); the IP re-tag pass and the `why-not.md` rewrite (SP9, which rides
+on the `attribution`/`branded` fields this spec defines). SP3 builds the data spine and its guards only.
+
+## Open decisions for review
+
+1. **`framework-catalog.md`: fully generated, or generated-table-under-a-hand-preamble?** Recommendation:
+   fully generated table; an optional hand-authored narrative may sit above a `<!-- generated -->` marker
+   that the generator preserves.
+2. **Registry field ownership of `anti_triggers`/`not_use`:** registry-owned, or registry-references the
+   shipped skill's derived values (SP1's source)? Recommendation: keep them derived from the skill's
+   authored files (one source), registry references; avoids a second copy of the same prose.

--- a/docs/internal/release-plans/plan_v0.3.0/spec-sp4-framework-library.md
+++ b/docs/internal/release-plans/plan_v0.3.0/spec-sp4-framework-library.md
@@ -1,0 +1,139 @@
+# SP4 spec: the published Framework Library (per-framework dossiers, resilient docs + Astro)
+
+> **STATUS: SPEC, pending maintainer review.** Part of [`PLAN.md`](./PLAN.md). Depends on
+> [`spec-sp3-registry.md`](./spec-sp3-registry.md) (the registry that supplies each dossier's status
+> header) and [`spec-sp5-research-framework.md`](./spec-sp5-research-framework.md) (the engine that
+> drafts dossiers). This is the "resilient docs and astro dossiers for all frameworks" deliverable.
+
+## Why
+
+The library's identity is **honest grading, not breadth** - but the maintainer wants the *learning*
+value of documenting every framework that was evaluated, including the rejected ones with their
+reasoning, without diluting the shippable skill catalog (the open-IP / keep-evidence policy, SP9).
+Today that knowledge is trapped: a one-line row in `framework-catalog.md` and, for exclusions, a
+paragraph in `why-not.md`. There is no place a reader can go to learn what Cynefin *is*, why it was
+not shipped as a skill, what the evidence actually says, and who to read next.
+
+SP4 builds that place: a **long-form dossier per framework**, published on the Astro site as a browsable
+**Framework Library** and committed in-repo as markdown, with a **status header generated from the
+registry** so the verdict can never drift from the dossier. "Resilient" = the dossier set is guarded by
+the same registry CI (every entry has a dossier or `pending`; no orphan dossiers; the status badge is
+generated, not typed).
+
+## Design overview
+
+```
+frameworks/<slug>/dossier.md          <- long-form, hand/agent-authored body + a generated status block
+  (frameworks/ is the registry + dossier home; skills/ stays the shippable-skill home)
+gen-site.mjs (extended)               -> site/src/content/docs/library/<slug>/   (Astro Framework Library)
+                                      -> site/src/content/docs/library/index      (the browsable index)
+registry.yaml (SP3)                   -> the status block injected at the top of each rendered dossier
+```
+
+A **shipped** framework has BOTH a `skills/think-<slug>/` (the agent-executable skill, source of truth
+for the SKILL.md) AND a `frameworks/<slug>/dossier.md` (the human learning doc). They are different
+audiences: `SKILL.md` is the terse activation contract an agent reads; the dossier is the essay a person
+reads. The shipped skill's own `evidence/dossier.md` is the *evidence* record; the Framework Library
+dossier is the *learning* record (lineage, when-to-use, who-to-read, and for shipped skills a pointer to
+the skill). Open decision below: whether to unify a shipped skill's two dossiers or keep them distinct.
+
+### The dossier format (`frameworks/<slug>/dossier.md`)
+
+A generated status block (do-not-edit, from the registry) + a hand/agent-authored body:
+
+```markdown
+---
+title: <name>
+slug: <slug>
+generated_status: true   # the block below is generated from registry.yaml; edit the registry, not this
+---
+
+<!-- STATUS (generated from frameworks/registry.yaml by gen-site.mjs - do not edit) -->
+> **Status:** <Shipped | Documented, not shipped | Folded | Candidate>  ·  **Evidence:** <tier badge>
+> ·  **Family:** <family>  ·  **Verdict:** <verdict> (<evalDate>)
+> <if shipped> Run it: [`think-<slug>`](../../frameworks/think-<slug>/)
+> <if fold>   Use instead: [`<foldInto>`](...)
+> <if branded> <name> is a trademark of <trademark>. <attribution>.
+<!-- /STATUS -->
+
+## What it is
+The mechanism, in plain language. The durable cognitive move, named for what it does.
+
+## When it helps / when it misleads
+The situations it fits, and the "when NOT to use" boundary (for shipped skills, the same hard-walls).
+
+## What the evidence says
+Honest grade with the actual research: what it supports, what it does NOT, transferred-evidence flag.
+No laundered statistics. (For shipped skills, this can transclude or summarize the skill's dossier.)
+
+## Why it is / is not a skill here
+The vetting verdict and reasoning: distinct move (Build), already-covered (Fold -> X), no separable
+mechanism (Recipe), or out-of-scope/under-evidenced (Reject). This is the "rejected with reasoning"
+content the maintainer asked for - the learning value of a no.
+
+## Lineage and who to read
+Origin, key people/companies, books/talks, and the graded sources (seeded from registry `sources`).
+```
+
+### The Astro Framework Library
+
+`gen-site.mjs` gains a `library/` output: one page per `frameworks/<slug>/dossier.md`, plus an index
+page listing every framework grouped by family with its status badge and evidence tier (the same
+generated-view discipline as the rest of the site - gitignored, rebuilt each build). It joins the
+sidebar as a top-level "Framework Library" group alongside "Frameworks (by name)" (the shipped skills).
+Generated-page Edit links point at `frameworks/<slug>/dossier.md` (its true source) per the
+"Generated-page Edit links" rule; the status block is `editUrl: false`-equivalent (it is registry-derived).
+
+## Components
+
+### C1. Dossier scaffold + the first tranche
+A `frameworks/_template/dossier.md` skeleton (the format above). Author dossiers for the highest-value
+set first: the 34 shipped skills (transclude/summarize their evidence dossiers), then the notable
+rejections that carry learning (the 2026-06-03 folds/rejects: steelmanning, stakeholder-lens, leverage-
+points, mece, opportunity-solution-tree), then the branded set SP9 opens (Six Thinking Hats, Cynefin,
+Wardley, Blue Ocean). Most dossiers are drafted by `research-framework` (SP5) and finalized by a human.
+
+### C2. `gen-site.mjs` Framework Library output
+The new `library/` generated pages + index, the status block injected from the registry, the sidebar
+group, the Edit-link handling. Reuses the existing generator's patterns (no new dependency).
+
+### C3. Registry CI extension (delegates to SP3)
+The "every entry has a dossier or `pending`; no orphan dossier" completeness check is SP3's C3.4. SP4
+flips entries from `dossier: pending` to a real path as dossiers land; the check enforces no shipped
+framework is left without one indefinitely (open decision: a deadline/quota, or just the `pending`
+visibility).
+
+### C4. Link/route resilience
+Every dossier is a rendered route, so the clause-14.11 rendered-link + route-parity guards (already in
+CI) cover the Framework Library automatically: a broken cross-dossier link or a dropped framework page
+fails the build. The route manifest is regenerated to include `library/` routes. This is the "resilient"
+guarantee made concrete - the docs cannot ship browser-broken.
+
+## Acceptance criteria
+
+- **AC1** `frameworks/<slug>/dossier.md` exists for every shipped skill and every 2026-06-03 verdict;
+  each renders at `library/<slug>/` on the site with a registry-generated status block.
+- **AC2** The Framework Library index lists every registry entry grouped by family with status + tier
+  badges; it is generated (hand-editing it and rebuilding restores it).
+- **AC3** The registry completeness check (SP3) is green: no shipped/notable entry without a dossier;
+  no orphan dossier without an entry.
+- **AC4** The rendered-link + route-parity guards pass over the new `library/` routes (no broken
+  cross-links; route manifest updated).
+- **AC5** A dossier's status badge changes when its registry `status` changes and the site is rebuilt
+  (proof the badge is generated, not typed).
+
+## Out of scope
+
+The registry + schema + most CI (SP3); the engine that drafts dossiers (SP5); the IP re-tag + why-not
+rewrite (SP9). SP4 is the dossier *format*, the *rendering*, and the *resilience guarantees* only.
+
+## Open decisions for review
+
+1. **Shipped skills: one dossier or two?** A shipped skill has `skills/think-<slug>/evidence/dossier.md`
+   (evidence) and would gain `frameworks/<slug>/dossier.md` (learning). Recommendation: keep both but
+   have the learning dossier *transclude/summarize* the evidence one (single source for the graded
+   evidence), so they cannot contradict.
+2. **Dossier review gate before publish** (shared with SP5): how much `research-framework` drafts vs. a
+   human finalizes, and whether a dossier publishes at `draft` status or only after sign-off.
+3. **`frameworks/` vs `docs/library/` as the in-repo home.** Recommendation: `frameworks/` at repo root
+   (co-located with `registry.yaml`, parallel to `skills/`), rendered into the site's `library/`.

--- a/docs/internal/release-plans/plan_v0.3.0/spec-sp5-research-framework.md
+++ b/docs/internal/release-plans/plan_v0.3.0/spec-sp5-research-framework.md
@@ -1,0 +1,144 @@
+# SP5 spec: the `research-framework` engine (subagent + command) + its prompts
+
+> **STATUS: SPEC, pending maintainer review.** Part of [`PLAN.md`](./PLAN.md). The engine that
+> populates [`spec-sp4-framework-library.md`](./spec-sp4-framework-library.md) (dossiers) and proposes
+> entries for [`spec-sp3-registry.md`](./spec-sp3-registry.md) (the registry). Codifies the 2026-06-03
+> multi-agent vetting workflow (evidence + overlap + judge) into a reusable, repeatable engine.
+
+## Why
+
+The 2026-06-03 vetting run worked but was a one-off ad-hoc workflow. The maintainer wants documenting
+and evaluating frameworks to be a **repeatable engine**, not a bespoke fan-out each time. `research-
+framework` is that engine: given a framework name (or a discovery brief), it researches the method,
+grades the evidence honestly, assesses overlap against the shipped catalog, drafts the SP4 dossier, and
+proposes an SP3 registry entry - leaving the ship/no-ship call to the human (or the vetting judge for
+borderline cases). It is the same evidence + overlap discipline the vetting used, made a tool.
+
+## Form: subagent fronted by a thin command (recommended)
+
+A **subagent** (`agents/research-framework.md`) holds the role, the bar, and the honesty discipline in
+its system prompt; a **thin command** (`commands/research-framework.md`) is the user-facing entry that
+gathers the input (a framework name, or "discover N candidates in family X") and dispatches the subagent.
+This matches the family pattern (heavy logic in the agent, thin command) and keeps the prompt versioned
+as a file. The subagent has read access to the repo (INDEX.md, the catalog/registry, shipped skills),
+web search, and write access only to `frameworks/<slug>/` (the dossier) and a proposed-entry block it
+prints for human paste into `registry.yaml` (it does NOT silently mutate the registry - a human or the
+registry CI is the gate).
+
+## What it produces (per framework)
+
+1. **A dossier** `frameworks/<slug>/dossier.md` in the SP4 format (body sections filled; the status
+   block left for the registry to generate).
+2. **A proposed registry entry** (YAML) with `slug, name, family, tier, status, verdict, evalDate,
+   reasoning, foldInto?, sources, attribution?, trademark?, branded?` - validated against
+   `registry.schema.json` before it is emitted.
+3. **A one-screen verdict summary** (the evidence grade, the overlap call, the recommended status).
+
+For **discovery mode** ("find candidates in family X"), it returns a ranked shortlist of method names
+with a one-line distinctness hypothesis each, for the human to greenlight before full dossiers are run.
+
+## The prompts
+
+### System prompt (`agents/research-framework.md` body)
+
+```
+You are research-framework, the framework-documentation engine for the thinking-framework-skills
+library. The library's identity is HONEST EVIDENCE GRADING, not breadth. Your job is to research a
+thinking method, grade its evidence truthfully, assess whether it adds a distinct move the library does
+not already have, draft its long-form learning dossier, and propose a registry entry. You document
+everything; you do NOT decide what ships - you give the human an honest, sourced basis to decide.
+
+Non-negotiables:
+- HONEST GRADE. Use the seven-tier model: S strong research, M moderate, P practitioner, V vendor, A
+  anecdotal, C conceptually-plausible-but-undertested, X poor/contradictory. Most practitioner methods
+  are P. Reserve S/M for genuine research backing on the ACTUAL move (not a related one). If the
+  evidence is borrowed from an adjacent method or from human studies not validated on AI agents, say so
+  explicitly and set transferred_evidence true. Laundering a P into an M by citing a cousin's robustness
+  is the single failure this library exists to prevent. A truthful "P, useful anyway, here is when not
+  to use it" beats an inflated "S".
+- REAL SOURCES. Cite findings you can name (authors, year, what was measured). Do not invent citations
+  or effect sizes. If a widely-quoted statistic has no traceable primary source, say so and refuse it.
+- OVERLAP HONESTY. Read INDEX.md (the shipped skills) and framework-catalog.md / registry.yaml. A method
+  earns "distinct" only if it adds a durable cognitive move not already covered (the ~20% overlap
+  ceiling). If it is a mode of a shipped skill, recommend FOLD (name the target). If it has no separable
+  mechanism (a chain of existing moves), recommend RECIPE. If it belongs in the sibling pm-skills library
+  by domain, recommend out-of-scope. Default to fold/reject; near-twins dilute the catalog.
+- IP / ATTRIBUTION. The IP gate is open: branded/trademarked frameworks are DOCUMENTED (with proper TM,
+  owner, attribution) and ship as a skill only if evidence + distinctness independently clear. For any
+  branded method, fill attribution + trademark and set branded true.
+- ARTIFACT-FIRST for shippable candidates. If you recommend Build, name the concrete structured artifact
+  the skill would emit (a register, matrix, ledger, map - not "think harder") and the explicit
+  "when NOT to use" hard-wall vs the nearest shipped skill.
+
+You write the dossier body (What it is / When it helps-misleads / What the evidence says / Why it is or
+is not a skill here / Lineage and who to read) and emit a schema-valid proposed registry entry plus a
+one-screen verdict. You never edit registry.yaml directly and never claim a grade the sources do not earn.
+```
+
+### Task prompt (dispatched by the command, per framework)
+
+```
+Research the thinking method: "<name>" (<one-line gloss if known>).
+Repo root: <REPO>. Read INDEX.md (shipped skills), docs/internal/research/framework-catalog.md (and
+frameworks/registry.yaml once it exists), docs/contributing.md (the selection bar). Use web search for
+the actual literature; do not invent citations.
+
+Produce, in order:
+1. EVIDENCE: the real mechanism (not the brand); the honest tier (S..X) with what the research does and
+   does NOT support; transferred_evidence flag; 3-6 named sources with what each shows and its grade.
+2. OVERLAP: the closest shipped skills (high/medium/low) and why; distinct / fold(->target) / recipe /
+   reject / out-of-scope; the hard-wall vs the nearest skill, or "near-twin".
+3. VERDICT: Build / Fold / Recipe / Reject, with the decisive reason, the proposed evidence tier, and
+   (if Build) the named artifact + the when-NOT-to-use wall. Honor the catalog's prior tag unless you
+   have a concrete reason to overturn it (state it if you do).
+4. DOSSIER: write frameworks/<slug>/dossier.md in the SP4 format (body only; leave the status block for
+   the registry generator).
+5. REGISTRY ENTRY: emit a schema-valid YAML entry for registry.yaml (do not write the file; print it).
+Be adversarial about Build: the rejections are the product.
+```
+
+### Discovery-mode prompt (optional, for catalog expansion / SP6)
+
+```
+Propose <N> candidate thinking methods in family "<family>" that the library does NOT already cover
+(check INDEX.md + the registry). For each: the method name, a one-line mechanism, a distinctness
+hypothesis (what move it adds that no shipped skill has), and a rough evidence-tier guess. Rank by
+(distinctness x evidence strength). Do not write dossiers yet - this is a shortlist for the human to
+greenlight before full research runs.
+```
+
+## Components
+
+- **C1** `agents/research-framework.md` (the subagent: system prompt above + frontmatter: name,
+  description, tools = read/grep/glob/websearch + write scoped to `frameworks/`).
+- **C2** `commands/research-framework.md` (the thin command: takes a framework name or a discovery brief;
+  dispatches the subagent with the task/discovery prompt; both Claude + Codex per the agent-targets).
+- **C3** A `--check`-friendly proposed-entry validator: the emitted YAML entry is validated against
+  `registry.schema.json` (SP3) before it is shown, so a malformed proposal cannot reach the registry.
+- **C4** Wiring into the Standard's manifest pipeline (a new subagent + command are Silver/Gold
+  components; `gen-manifest` + the per-target presence checks must stay 0/0).
+
+## Acceptance criteria
+
+- **AC1** `research-framework "<name>"` produces a schema-valid proposed registry entry + a
+  `frameworks/<slug>/dossier.md` body in the SP4 format + a one-screen verdict, with named sources.
+- **AC2** On a method already covered (e.g. steelmanning), it returns Fold -> the correct shipped skill,
+  matching the 2026-06-03 verdict (a regression check that the engine reproduces the vetting).
+- **AC3** On a branded method (e.g. Six Thinking Hats), it fills attribution + trademark + branded.
+- **AC4** It refuses an untraceable statistic rather than laundering a grade (proven on a known case,
+  e.g. the "Fermi 99-vs-3 / 42%" effect the catalog already flags as untraceable).
+- **AC5** Adding the subagent + command keeps the conformance gate green (advanced, 0/0); per-target
+  manifests regenerate.
+
+## Out of scope
+
+The registry + its CI (SP3); the dossier rendering on the site (SP4); the IP re-tag pass (SP9); the
+applicator skills that USE the corpus (SP7/SP8). SP5 is the producer engine + its prompts only.
+
+## Open decisions for review
+
+1. **Subagent vs in-skill** (recommendation: subagent + thin command, above).
+2. **Auto-write the dossier vs print-for-review.** Recommendation: write the dossier file (cheap to
+   revert, under `frameworks/`), but print-only the registry entry (the registry is the gated source of
+   truth; a human or CI admits it).
+3. **Where discovery mode runs** (the command, or a separate `discover-frameworks` thin command).

--- a/docs/internal/release-plans/plan_v0.3.0/spec-sp9-ip-policy.md
+++ b/docs/internal/release-plans/plan_v0.3.0/spec-sp9-ip-policy.md
@@ -1,0 +1,79 @@
+# SP9 spec: IP policy application (open the IP gate, keep the evidence gate)
+
+> **STATUS: SPEC, pending maintainer review.** Part of [`PLAN.md`](./PLAN.md). A small policy pass that
+> rides on [`spec-sp3-registry.md`](./spec-sp3-registry.md)'s `attribution`/`trademark`/`branded` fields.
+> The 2026-06-03 catalog + why-not truth-up (this session) is the **down-payment**; SP9 is the full pass.
+
+## Why
+
+The maintainer reversed the blanket IP/trademark exclusion (2026-06-03): **document every framework
+(shipped, candidate, rejected) with proper trademark/attribution; ship as a skill only if it
+independently clears the evidence + distinctness bar.** Branded status is no longer an automatic veto;
+weak evidence still is. The catalog's identity stays honest grading, not breadth - the win is the
+learning value of documenting everything (including why a thing was rejected) without diluting the
+shippable skill set. SP9 applies that policy mechanically and rewrites the one artifact built on the old
+rule: `why-not.md`.
+
+## What changes
+
+### A. Registry attribution fields (defined in SP3, populated here)
+`attribution` (author/origin), `trademark` (TM/owner/license), `branded` (bool). The SP3 IP lint already
+**requires** `attribution` + `trademark` when `branded: true`, so the policy is enforced by CI, not by
+vigilance.
+
+### B. The IP-only re-tag pass
+Frameworks whose **only** exclusion reason was IP/branding are re-evaluated on evidence + distinctness
+alone, tags updated, with the change reasoned in the registry `reasoning` field:
+- **Six Thinking Hats** -> becomes shippable IF it clears evidence + distinctness (properly attributed to
+  Edward de Bono). Note: the library already ships `think-parallel-perspectives-review` as the
+  descriptive, mechanism-named version of separated-lens review, so Six Thinking Hats most likely lands
+  as a **branded alias / documented-not-shipped** entry pointing at it - the re-tag does not presume a
+  Build, it removes the IP veto and re-runs the evidence/overlap test (via `research-framework`, SP5).
+- **Cynefin, Wardley Mapping, Blue Ocean** -> become **documented** (full Framework Library dossiers with
+  attribution) and ship as skills only if their evidence supports it (likely C/P with distinctness
+  questions - documented, not shipped).
+The X/V/C evidence grading and the ~20% overlap ceiling are **untouched**: opening the IP gate does not
+lower the evidence bar.
+
+### C. `why-not.md` -> an index into the Framework Library
+The live `site/src/content/docs/about/why-not.md` is rewritten from a **hard exclusion list** into an
+**index into the published Framework Library**: each "not shipped" framework becomes a short entry that
+links to its full dossier (`library/<slug>/`) and states the one-line reason (folded / under-evidenced /
+out-of-scope / branded-and-documented). The page stops being a dead-end "no" and becomes a doorway to the
+learning content. It is generated from the registry (the `status != shipped` entries) so it cannot drift
+from the verdicts - the same generated-view discipline as everything else.
+
+## Relationship to the 2026-06-03 down-payment (item 1, this session)
+
+Before SP3/SP9 exist, this session makes the **cheap, durable** version of the same move so the vetting
+verdicts do not evaporate:
+- `framework-catalog.md` is truthed-up by hand (re-tag leverage-points `[cand] -> [fold]`; fix the stale
+  `[next]` rows; mark belief-update Build + idea-quality-audit Recipe).
+- `why-not.md` gains the four folds + the reject as honest documented entries (forward-compatible with
+  the index role: each carries its reason and its fold-target, so the SP9 rewrite only has to add the
+  dossier links).
+When SP3 lands, these hand-edits are migrated into `registry.yaml` and both files become generated; the
+down-payment is structured so that migration is a lift, not a rewrite.
+
+## Components
+
+- **C1** Populate `attribution`/`trademark`/`branded` on affected registry entries (rides on SP3).
+- **C2** The IP-only re-tag pass (run `research-framework` on the formerly-IP-excluded set; update tags +
+  reasoning; most become documented-not-shipped).
+- **C3** `why-not.md` becomes a generated view of the registry's `status != shipped` entries, each
+  linking to its dossier. Folded into `gen-registry.mjs` (SP3) + its drift guard.
+- **C4** The IP lint (SP3 C3.5) is the enforcement; no separate mechanism.
+
+## Acceptance criteria
+
+- **AC1** Every `branded: true` registry entry carries `attribution` + `trademark`; the IP lint is green
+  and fails on a branded entry missing either.
+- **AC2** The formerly-IP-excluded set (Six Thinking Hats, Cynefin, Wardley, Blue Ocean, ...) is re-tagged
+  on evidence + distinctness, each with `reasoning`; none is excluded *solely* for being branded.
+- **AC3** `why-not.md` is generated from the registry, links each not-shipped framework to its dossier,
+  and `--check` catches drift; the X/V/C grading and the overlap ceiling are unchanged from before.
+
+## Out of scope
+
+The registry + schema + IP lint mechanism (SP3 defines them; SP9 populates + applies). The dossiers the
+re-tagged frameworks now need (SP4 + SP5). SP9 is the policy application + the `why-not` rewrite only.

--- a/docs/internal/research/framework-catalog.md
+++ b/docs/internal/research/framework-catalog.md
@@ -5,8 +5,9 @@ A single, simplified, complete, and prioritized list of every thinking framework
 - **Taxonomy:** the 11 cognitive-operation families (Claude Opus's landscape, the recommended foundation).
 - **Evidence tiers (7-tier model):** **S** strong research · **M** moderate · **P** practitioner · **V** vendor/commercial · **A** anecdotal · **C** conceptually plausible, under-tested · **X** poor/contradictory.
 - **Status legend:**
-  - `[shipped]` - built and validated (28 skills, Tier universal 0/0).
+  - `[shipped]` - built and validated (34 skills, Tier advanced 0/0).
   - `[next]` - strongest unbuilt candidates (build these first; S/M evidence or cross-LLM consensus, and distinct).
+  - `[recipe]` - ships as a workflow chaining existing skills, not a standalone skill (no separable mechanism).
   - `[cand]` - candidate (clears the bar but lower priority / P-tier coverage).
   - `[fold]` - subsumed: ship as a mode/sub-skill of an existing skill, not standalone.
   - `[flag]` - include only with explicit "when not to use" / trademark / false-precision caveats.
@@ -19,12 +20,15 @@ The honest core (from the meta-analyses): the field is a small **empirical core*
 
 ## Priority summary (what to build next, in order)
 
-The skill build-out for v0.x is essentially complete (28 skills). If the catalog grows further, this is the recommended order:
+The skill build-out is at 34 skills + 5 recipes. **2026-06-03 truth-up** (multi-agent vetting + v0.2.0 reconciliation) resolved the old `[next]` list:
 
-1. **Strong-evidence / consensus unbuilt `[next]`:** `concept-mapping` (cross-LLM consensus first-class), `first-principles` (scope tightly), `causal-loop-diagrams` (M), `key-assumptions-check`, `fermi-estimation` (expansion), `double-crux` (expansion). (The two S-tier empirical-core stragglers - stocks-and-flows and mechanical/linear-model aggregation - are now shipped.)
-2. **Solo-plus-AI reflection `[next]`:** `belief-update-routine`, `idea-quality-audit` (uniquely fit the primary user mode).
-3. **P-tier coverage `[cand]`:** the remaining `[cand]` rows below, as demand warrants.
-4. **Never (this repo):** the `[fold]`, `[flag]`, `[pm]`, and `[excl]` rows - documented here so the exclusion is deliberate, not accidental.
+1. **Shipped since (v0.2.0):** `concept-mapping`, `causal-loop-diagrams`, `fermi-estimation` are built; `first-principles` shipped as a **recipe**. The two S-tier empirical-core stragglers (stocks-and-flows, linear-model-aggregation) are shipped - the empirical core is complete (11/11).
+2. **Vetted-closed:** `key-assumptions-check` and `double-crux` were **rejected** (both reduce to `what-would-have-to-be-true`); `idea-quality-audit` is a **`[recipe]`** (decision-option-review + red-team-light over a shortlist); `leverage-points` re-vetted `[cand]` -> **`[fold]`** (owned by `iceberg-model`, which already cites its Meadows source).
+3. **Building now:** `belief-update-routine` cleared the bar (**Build**, P) - the one new skill from the round; it completes the meta-thinking-and-reflection family's over-time-belief corner.
+4. **P-tier coverage `[cand]`:** the remaining `[cand]` rows below, as demand warrants.
+5. **Never (this repo):** the `[fold]`, `[flag]`, `[pm]`, and `[excl]` rows - documented so each exclusion is deliberate.
+
+> This catalog becomes a generated view of `frameworks/registry.yaml` (SP3); the above is the interim hand truth-up. Row tags below updated to match.
 
 The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference-class-forecasting, argument-mapping, WOOP/MCII, authentic-dissent, after-action-review, natural-frequency-bayesian, far-analogy-ideation, stocks-and-flows-reasoning, and mechanical/linear-model aggregation. **All 11 are now shipped - the empirical core is complete.**
 
@@ -65,7 +69,7 @@ The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference
 |---|---|---|---|
 | Problem Restatement | rewrite the problem several ways, pick a better frame | M/P | `[shipped]` |
 | Abstraction Laddering | move up (why) and down (how) to the right altitude | P | `[shipped]` |
-| First Principles Thinking | decompose to fundamental truths, reason up | P/C | `[next]` (scope tightly to avoid "think harder") |
+| First Principles Thinking | decompose to fundamental truths, reason up | P/C | `[shipped]` as the `first-principles` recipe (v0.2.0; abstraction-laddering + assumption-reversal) |
 | How Might We | turn an insight into an opportunity question | P | `[fold]` -> output of problem-restatement |
 | Is / Is Not analysis | sharpen scope by what the problem is and is not | P | `[fold]` -> a problem-restatement move |
 | Frame storming | brainstorm the framing, not the solution | P | `[fold]` -> problem-restatement |
@@ -81,7 +85,7 @@ The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference
 | Evidence vs Inference Sort | label claims evidence / inference / assumption | P | `[shipped]` |
 | Ladder of Inference Check | reconstruct the climb from data to conclusion | P | `[shipped]` |
 | What Would Have to Be True | turn a claim into testable conditions | P | `[shipped]` (also family 5/7) |
-| Key Assumptions Check / Assumption Mapping | inventory and rank a plan's assumptions | P | `[next]` (intelligence-analysis staple; watch overlap with WWHTBT) |
+| Key Assumptions Check / Assumption Mapping | inventory and rank a plan's assumptions | P | `[excl]` rejected 2026-06-03: same assumption-ledger as what-would-have-to-be-true |
 | Cognitive bias checklist | run a decision against relevant biases | P | `[cand]` |
 | Inversion | ask how to guarantee failure, then avoid it | P | `[cand]` (overlaps assumption-reversal + premortem) |
 | Counterfactual reasoning | examine "what if X had been different" | P | `[cand]` |
@@ -107,9 +111,9 @@ The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference
 | Futures Wheel | map first/second/third-order consequences outward | P | `[shipped]` |
 | Iceberg Model | events -> patterns -> structures -> mental models | P | `[shipped]` |
 | Stocks and Flows reasoning | reason about accumulations and rates | **S** | `[shipped]` (Sterman) |
-| Causal Loop Diagrams | diagram reinforcing/balancing feedback loops | M/C | `[next]` (visual; markdown approximates) |
+| Causal Loop Diagrams | diagram reinforcing/balancing feedback loops | M/C | `[shipped]` (v0.2.0) |
 | Second-Order Effects | lightweight "and then what?" prompt | P | `[fold]` -> mode of futures-wheel |
-| Systems map / Leverage points | sketch elements/relationships; find intervention points | P/C | `[cand]` |
+| Systems map / Leverage points | sketch elements/relationships; find intervention points | P/C | `[fold]` -> iceberg-model (Meadows leverage-ladder mode; re-vetted 2026-06-03) |
 | Three Horizons | present / transition / emerging future | C | `[cand]` (foresight) |
 | Causal Layered Analysis | litany / system / worldview / myth layers | C | `[cand]` (foresight) |
 | Theory of Constraints | find and exploit the system bottleneck | P | `[cand]` (expansion) |
@@ -127,7 +131,7 @@ The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference
 | Pairwise comparison | compare two at a time to rank fuzzy criteria | P | `[cand]` |
 | Expected-value / decision-tree | weigh outcomes by probability x magnitude | M | `[cand]` (expansion: formal EV/decision trees) |
 | Minimax regret | minimize worst-case regret | P | `[cand]` |
-| Fermi estimation | structured order-of-magnitude estimate from decomposition | P/M | `[next]` (expansion; high utility, no current coverage) |
+| Fermi estimation | structured order-of-magnitude estimate from decomposition | P/M | `[shipped]` (v0.2.0) |
 | Eisenhower / MoSCoW / Pareto | urgent-important triage; vital-few focus | P | `[cand]` (expansion; prioritization) |
 | Kepner-Tregoe | structured problem + decision analysis | P | `[cand]` (expansion) |
 | Cynefin | sort clear/complicated/complex/chaotic | C | `[flag]` cargo-cult risk; trademark |
@@ -160,7 +164,7 @@ The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference
 | Affinity Mapping | cluster many notes into emergent themes (bottom-up) | P | `[shipped]` |
 | Pyramid Principle | answer-first governing thought + grouped support | P | `[shipped]` |
 | MECE decomposition | mutually-exclusive, collectively-exhaustive split | P | `[fold]` -> principle inside issue-tree |
-| Concept Mapping | diagram concepts and labeled relationships | M/P | `[next]` (cross-LLM consensus first-class) |
+| Concept Mapping | diagram concepts and labeled relationships | M/P | `[shipped]` (v0.2.0) |
 | Dialectical synthesis | hold thesis/antithesis to a stronger synthesis | C | `[cand]` |
 | Contradiction / tension mapping | surface central tensions rather than smoothing | C | `[cand]` |
 | Insight statement generation | turn observations into sharp transferable insights | P | `[cand]` |
@@ -183,8 +187,8 @@ The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference
 |---|---|---|---|
 | After Action Review | expected vs actual -> why -> sustain/change | S/M | `[shipped]` |
 | Decision Journal | record now for honest later calibration | P | `[shipped]` |
-| Belief-update routine | periodically revisit and update key beliefs vs new evidence | P | `[next]` (solo-plus-AI fit) |
-| Idea-quality audit | score and pressure-test a batch of ideas (solo + AI) | P | `[next]` (solo-plus-AI fit) |
+| Belief-update routine | periodically revisit and update key beliefs vs new evidence | P | `[next]` Build approved (2026-06-03 vetting); authoring as `think-belief-update-routine` |
+| Idea-quality audit | score and pressure-test a batch of ideas (solo + AI) | P | `[recipe]` decision-option-review + red-team-light over a shortlist (vetted 2026-06-03; no separable mechanism) |
 | What / So What / Now What | observation -> meaning -> action | P | `[cand]` |
 | PDCA / A3 | plan-do-check-act improvement loop | P | `[cand]` (expansion; overlaps AAR) |
 | Socratic self-questioning | disciplined self-interrogation of a belief | P | `[cand]` (expansion) |
@@ -198,8 +202,8 @@ Added here as genuinely additive (not folds of existing skills). Provisional tie
 
 | Framework | Family | Mechanism | Tier | Note |
 |---|---|---|---|---|
-| Fermi estimation | decision | decompose an unknown into estimable factors for an order-of-magnitude answer | P/M | high utility for AI; no current coverage; `[next]` |
-| Double-crux | assumption-challenge | find the single belief whose change would flip each side of a disagreement | C/P | modern (CFAR); resolves disagreements; distinct from red-team/dissent |
+| Fermi estimation | decision | decompose an unknown into estimable factors for an order-of-magnitude answer | P/M | `[shipped]` as `think-fermi-estimation` (v0.2.0) |
+| Double-crux | assumption-challenge | find the single belief whose change would flip each side of a disagreement | C/P | `[excl]` rejected 2026-06-03: solo-reduces to what-would-have-to-be-true's killer conditions |
 | Theory of Constraints | systems | find the binding bottleneck and exploit/elevate it | P | distinct systems-intervention lens |
 | Fishbone / Ishikawa | systems | structured multi-cause diagram (the meta-analysis's recommended Five-Whys upgrade) | P | fills the multi-cause gap Five-Whys leaves |
 | Scenario planning | strategy/foresight | construct 2-4 plausible distinct futures and stress strategy across them | C/M | distinct from futures-wheel (consequences) and backcasting (path); evidence thin |

--- a/site/src/content/docs/about/why-not.md
+++ b/site/src/content/docs/about/why-not.md
@@ -15,7 +15,7 @@ We implement the durable cognitive move, named descriptively, not the brand wrap
 
 ## The overlap ceiling
 
-A candidate that mostly duplicates a shipped skill does not earn a second slot. **FMEA-lite**, **Inversion**, and **Crazy 8s** each overlap an existing skill enough to fold in rather than stand alone. Folding keeps the catalog small enough to choose from, which is the point: more cards is not more capability.
+A candidate that mostly duplicates a shipped skill does not earn a second slot. **FMEA-lite**, **Inversion**, and **Crazy 8s** each overlap an existing skill enough to fold in rather than stand alone. **Leverage Points** (Meadows' intervention ladder) folds into [Iceberg Model](../../frameworks/think-iceberg-model/), which already calls out the highest-leverage intervention and draws on the same source; **MECE decomposition** is the load-bearing discipline inside [Issue Tree](../../frameworks/think-issue-tree/), not a separate skill. Folding keeps the catalog small enough to choose from, which is the point: more cards is not more capability.
 
 ## X-tier: poor or contradictory evidence
 


### PR DESCRIPTION
## Summary

Two docs deliverables toward v0.3.0, no code changes.

### 1. Framework Library platform specs (`plan_v0.3.0/spec-sp{3,4,5,9}-*.md`)

The "resilient docs and astro dossiers for all frameworks" design, each as its own spec co-located with the in-flight SP1 spec (does not touch `PLAN.md` or `spec-sp1`):

- **SP3** - `frameworks/registry.yaml` as single source of truth + strong CI (JSON-Schema, drift guard on every generated view, referential integrity, completeness, IP/attribution lint, eval coupling).
- **SP4** - per-framework dossiers (`frameworks/<slug>/dossier.md`) published as an Astro **Framework Library**, status generated from the registry, covered by the clause-14.11 link/route guards.
- **SP5** - the `research-framework` engine (subagent + thin command) **with its prompts**: research -> honest grade -> overlap -> dossier -> proposed registry entry. Codifies the 2026-06-03 vetting into a repeatable tool.
- **SP9** - the open-IP / keep-evidence policy application + the `why-not.md` -> Framework Library index rewrite.

### 2. The 2026-06-03 catalog + why-not truth-up (the SP9 down-payment)

Locks in the multi-agent vetting verdicts so they do not evaporate:

- `leverage-points` re-tagged `[cand]` -> `[fold]` (Meadows ladder owned by iceberg-model); `idea-quality-audit` -> `[recipe]`; `belief-update-routine` marked Build-approved.
- Stale `[next]` rows fixed: `concept-mapping` / `causal-loop-diagrams` / `fermi-estimation` -> `[shipped]` (v0.2.0); `first-principles` -> shipped recipe; `key-assumptions-check` + `double-crux` -> `[excl]` (both reduce to `what-would-have-to-be-true`). Skill count 28 -> 34.
- `why-not.md` gains the two new folds (leverage-points -> iceberg-model; MECE -> issue-tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
