### PR TITLE
chore: pin LF line endings via .gitattributes (eol=lf)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Enforce LF line endings repo-wide, overriding core.autocrlf on Windows checkouts.
+#
+# Several artifacts are byte-exact drift-checked by scripts/*.mjs --check
+# (recommendable.{json,md}, manifest.generated.json, INDEX.md, both plugin.json,
+# the site route-manifest, and the SP3 generated catalog + why-not). If a Windows
+# checkout smudged any of them to CRLF, the local --check would fail while the
+# Linux CI --check passed - a confusing, platform-only break. Pinning LF everywhere
+# keeps the local and CI byte comparisons identical.
+* text=auto eol=lf
+
+# Binary files: never normalize line endings.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.webp binary
+*.ico  binary
+*.pdf  binary
+*.woff  binary
+*.woff2 binary


### PR DESCRIPTION
@
Pin LF line endings repo-wide via `.gitattributes` so the byte-exact drift guards (`scripts/*.mjs --check`) compare identically on Windows and on Linux CI.

`core.autocrlf` is `true` on Windows, which smudges checked-out files to CRLF; a CRLF-smudged working tree then fails the local `--check` while Linux CI passes - a confusing, platform-only break this prevents (`recommendable.{json,md}`, `manifest.generated.json`, `INDEX.md`, both `plugin.json`, the site route-manifest, and the new SP3 generated catalog + why-not are all byte-exact drift-checked).

The index was already all-LF, so `git add --renormalize .` produced **zero content churn** - this PR only adds the `.gitattributes` guarantee. Forward-fits the SP3 registry generators (in the stacked follow-up PR), whose generated views are also LF + drift-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@