### PR TITLE
feat(library): SP4 published Framework Library (infrastructure + first tranche)

### DIFF
--- a/frameworks/_template/dossier.md
+++ b/frameworks/_template/dossier.md
@@ -1,0 +1,28 @@
+---
+title: <Display Name>
+slug: <slug>
+generated_status: true
+---
+
+<!-- STATUS:GENERATED (gen-site.mjs from frameworks/registry.mjs) - do not edit between these markers -->
+<!-- /STATUS:GENERATED -->
+
+## What it is
+
+The mechanism in plain language: the durable cognitive move, named for what it does.
+
+## When it helps / when it misleads
+
+The situations it fits and the "when NOT to use" boundary. For shipped skills, the same hard-walls the skill enforces.
+
+## What the evidence says
+
+The honest grade and the actual research: what it supports, what it does NOT, the transferred-evidence flag. No laundered statistics. For shipped skills, summarize the skill's evidence dossier and link the framework page; do not restate grades that could drift.
+
+## Why it is / is not a skill here
+
+The vetting verdict and reasoning: Build (a distinct move), Fold into X (already covered), Recipe (no separable mechanism), or Reject (out of scope or under-evidenced). This is the learning value of the decision.
+
+## Lineage and who to read
+
+Origin, key people and companies, books and talks, and the named sources.

--- a/frameworks/premortem/dossier.md
+++ b/frameworks/premortem/dossier.md
@@ -1,0 +1,36 @@
+---
+title: Premortem
+slug: premortem
+generated_status: true
+---
+
+<!-- STATUS:GENERATED (gen-site.mjs from frameworks/registry.mjs) - do not edit between these markers -->
+<!-- /STATUS:GENERATED -->
+
+## What it is
+
+A premortem is prospective hindsight: you assume the plan has *already failed*, set a concrete horizon ("it is six months after launch and this failed badly"), and reason backward to explain why. The durable cognitive move is the grammatical shift from a conditional ("what might go wrong?") to a definite past ("it went wrong, here is why"). That shift does three things at once. It licenses dissent, because once failure is assumed, naming a reason is the assigned task rather than disloyalty. It recruits memory and imagination differently, because explaining a concrete past event is a richer retrieval cue than forecasting an abstract future, so people generate more and more specific causes. And it converts vague worry into pre-committed action by pairing each top cause with a leading signal (tripwire), a mitigation, an owner, and a kill criterion decided before sunk cost and momentum distort judgment. The branded ritual is the packaging; the move is prospective hindsight plus structured conversion to mitigations. The deliverable is a ranked risk register, not a discussion.
+
+## When it helps / when it misleads
+
+It helps most when the decision is real, consequential, and not yet committed - a launch, hire, investment, migration, or vendor selection where you can still change course - and the plan carries optimistic momentum that is quietly suppressing concerns. It earns its keep when causes can be turned into observable signals and pre-decided responses, and it is often best run last, after options have been compared and one chosen, as the final gate before committing.
+
+It misleads or wastes effort when:
+
+- The outcome is already known - that is a postmortem, a different tool. (This is the sharp when-NOT boundary.)
+- The decision is trivial or fully reversible. A two-way door does not need the ceremony.
+- It is run as ritual - "imagine it failed, list five risks, done" with no conversion to tripwires and kill criteria produces cargo-cult comfort, not better risk handling. The conversion step is mandatory.
+- It is used to launder a decision already made. If the mitigations are never acted on, the premortem is theater.
+- It is substituted for ideation or option comparison. It is a risk tool, not a way to generate or choose options.
+
+## What the evidence says
+
+The honest grade is **S/M (contested)**, and the dossier is deliberate about which half is which. The well-supported part: prospective hindsight reliably increases the number and specificity of causes people generate, and running a premortem reduces overconfidence and improves a planner's calibration. The not-supported part: there is no strong evidence that premortems improve final outcomes (success rates, ROI, fewer failures), and the famous "~30%" figure measures the number of reasons identified, not any gain in decision quality - quoting it as "30% better decisions" is a misreading the skill explicitly refuses. A required honesty flag applies: all of this evidence comes from human subjects in lab, workshop, and team settings; none of it studies a premortem run by or with an AI agent. The evidence is therefore transferred from human contexts, not validated for AI-augmented use, so the agent's value is framed narrowly - it makes the mechanism cheap to run, enforces the structure, and produces a durable artifact - none of which depends on the contested decision-quality claim. The full grading, the primary-source caveats, and the verification status of each effect-size phrasing live in the skill's evidence record: skills/think-premortem/evidence/dossier.md.
+
+## Why it is / is not a skill here
+
+Verdict: **Build / Shipped.** Premortem is a distinct, evidence-backed move, not a duplicate of anything else in the catalog, so it earned its own skill. The distinctness is in the mechanism: prospective hindsight (assume failure, explain backward) is not the same as forward risk listing, inversion, or option comparison, and the supported effects (more causes surfaced, better calibration) attach specifically to that framing. Shipping it also let it absorb two would-be siblings: Kill criteria / Tripwires folds into its register as the per-cause conversion step rather than standing alone, and FMEA-lite and Inversion remain candidates partly because they overlap what premortem already covers. The learning value of the decision is that "shipped" here did not mean "endorsed as outcome-improving" - it meant the move is real and the supported claims are worth packaging, with the overclaim (better decisions) and the AI-transfer gap disclaimed in the skill itself.
+
+## Lineage and who to read
+
+The underlying cognitive effect comes from Deborah Mitchell, J. Edward Russo, and Nancy Pennington, "Back to the future: Temporal perspective in the explanation of events" (Journal of Behavioral Decision Making, 1989) - the study behind the "more reasons under the has-happened framing" finding. The named technique is Gary Klein's, "Performing a Project Premortem" (Harvard Business Review, 2007); Klein is the attribution carried in the registry. The direct evaluation of plan calibration is Veinott, Klein & Wiggins, "Evaluating the Effectiveness of the PreMortem Technique on Plan Confidence" (ISCRAM 2010). Daniel Kahneman popularized it in Thinking, Fast and Slow (2011), tying it to overcoming optimism bias and groupthink. "Premortem" is a generic descriptive term in common use - no trademark, no attribution required - which is why the skill names it descriptively and cites the lineage rather than branding it. Read Klein for the practice and Mitchell et al. for why it works.

--- a/frameworks/registry.mjs
+++ b/frameworks/registry.mjs
@@ -93,6 +93,7 @@ export default {
       foldInto: 'red-team-light',
       oneLine: 'state the strongest version of an opposing view before responding',
       reasoning: 'Subsumed: it is the core move of red-team-light.',
+      dossierPath: 'frameworks/steelmanning/dossier.md',
     },
     {
       slug: 'six-thinking-hats',
@@ -107,6 +108,7 @@ export default {
       attribution: 'Edward de Bono, 1985',
       trademark: 'Six Thinking Hats (de Bono method; "Six Thinking Hats" is a trademark of the de Bono estate / IP holders)',
       aliases: ['6 Thinking Hats', 'de Bono hats'],
+      dossierPath: 'frameworks/six-thinking-hats/dossier.md',
     },
     {
       slug: 'role-storming',
@@ -521,6 +523,7 @@ export default {
       evalCases: 'skills/think-premortem/eval/cases.md',
       attribution: 'Gary Klein (premortem)',
       aliases: ['Pre-mortem', 'prospective hindsight'],
+      dossierPath: 'frameworks/premortem/dossier.md',
     },
     {
       slug: 'reference-class-forecasting',

--- a/frameworks/six-thinking-hats/dossier.md
+++ b/frameworks/six-thinking-hats/dossier.md
@@ -1,0 +1,47 @@
+I have everything I need. The registry entry confirms: slug `six-thinking-hats`, name "Six Thinking Hats", tier X, status flag, verdict reject, branded true, attribution "Edward de Bono, 1985", trademark string, and the reasoning that the mechanism already ships de-branded. The shipped sibling dossier lives at `skills/think-parallel-perspectives-review/evidence/dossier.md`. Now I'll author the dossier in the exact required shape.
+
+---
+
+title: Six Thinking Hats
+slug: six-thinking-hats
+generated_status: true
+---
+
+<!-- STATUS:GENERATED (gen-site.mjs from frameworks/registry.mjs) - do not edit between these markers -->
+<!-- /STATUS:GENERATED -->
+
+## What it is
+
+Six Thinking Hats is a branded parallel-thinking ritual: a structured discussion in which everyone deliberately adopts the same single mode of thought at the same moment, one mode at a time, instead of arguing across modes at once. The durable cognitive move underneath it is mode separation - examining a decision through one separated lens at a time (the facts and information; the upside and value; the cautions and risks; the intuition and feelings; the alternatives and creative angles; and the process or big-picture view), then synthesizing - so that no single mode (usually a loud risk-averse or optimistic voice) crowds out the rest and the quiet modes actually get airtime.
+
+The branded version assigns each mode a colored "hat" (white = facts, yellow = upside, black = caution, red = feelings, green = alternatives, blue = process) and runs the group through them in sequence. The colors are a memorization and facilitation device; the work is done by the separation itself, not by the hat metaphor.
+
+## When it helps / when it misleads
+
+It helps when a decision or idea needs a rounded, balanced look before committing; when risk-aversion or optimism is dominating the discussion and drowning out everything else; and when quieter considerations like intuition or alternatives keep getting skipped. "Parallel" (same lens at the same time) is what reduces adversarial cross-talk and forces the easily-skipped modes to get a real pass.
+
+It misleads, or is simply the wrong tool, when a single lens is obviously all that matters (just use it); when you need deep adversarial stress-testing of one thesis (use a red-team move) or want to surface failure causes (use a premortem); when the modes would be performed mechanically with only two or three carrying real weight (padding); or when the ritual becomes consensus theater rather than genuine separation of modes. The specific failure the method exists to prevent - the lenses blurring back together in the output - is also its most common failure in practice.
+
+## What the evidence says
+
+Honest grade: **X** for the branded ritual itself - that is, the evidence specific to the trademarked "Six Thinking Hats" product is poor, and that is why it is documented but not shipped as a branded skill.
+
+What the research actually supports is the underlying mechanism, not the brand. Deliberately separating modes of thinking is modestly supported: some practitioner and education studies (for example with nursing students and managers) report moderate positive effects on critical thinking and cognitive complexity. What it does NOT support is the branded framework's strong claims: a Cambridge-led review of thinking-skills frameworks (Moseley et al.) found the branded framework's evidence base sparse, and de Bono's widely-quoted "493% productivity improvement" figure is uncited and unsupported - it is not repeated here as fact, and is flagged precisely because it is the kind of laundered statistic to avoid. This is transferred evidence: it comes from human group and educational contexts, not AI-validated use, so it is transferred, not validated for an AI agent.
+
+For the graded, sourced version, see the dossier for the de-branded skill that ships this mechanism: `skills/think-parallel-perspectives-review/evidence/dossier.md`. Grades are kept there to avoid drift; this page does not restate a tier for the shipped skill.
+
+## Why it is / is not a skill here
+
+Vetting verdict: **Reject (as a branded skill); the generic mechanism ships, de-branded.**
+
+The IP gate is open, so the framework is documented here with full attribution rather than omitted. But documentation is not shipping. Two things keep the branded ritual from becoming a skill of its own. First, evidence: the brand-specific evidence is poor (X), and a thinking-framework-skills skill has to clear an evidence-and-distinctness bar that the branded ritual does not. Second, distinctness: the load-bearing cognitive move - separating modes and synthesizing - already ships descriptively as `think-parallel-perspectives-review` (registry slug `parallel-perspectives-review`), which absorbs the Six Thinking Hats move along with the stakeholder-lens move. Shipping a second, branded skill for the same mechanism would be redundant and would import the brand's marketing claims without adding a distinct capability.
+
+So the decision is: keep the framework documented with its trademark caveat and weak-evidence caveat, and let users reach the capability through the de-branded skill. The learning value is the separation of brand from mechanism - the durable move is worth shipping, the brand and its uncited numbers are not.
+
+## Lineage and who to read
+
+- Origin: **Edward de Bono, 1985**, in the book *Six Thinking Hats*. De Bono (1933-2021) was a physician and writer best known for coining "lateral thinking" and for a long catalogue of packaged thinking methods.
+- Trademark: "Six Thinking Hats" is a trademark of the de Bono method (the de Bono estate / IP holders). It is named and attributed here descriptively; the trademarked "hat" branding is not used as a product, and the brand's marketing claims are not relied on.
+- Primary source to read: de Bono, E. (1985). *Six Thinking Hats*.
+- For the critical read: Moseley, D. et al., the Cambridge-led review of thinking-skills frameworks, which found the branded framework's evidence base sparse. Pair the book with this review rather than taking the book's claims at face value, and treat the moderate-effect practitioner and education studies as context-specific rather than as a quantified product claim.
+- Where the mechanism lives in this repo: the de-branded skill `think-parallel-perspectives-review` and its evidence dossier at `skills/think-parallel-perspectives-review/evidence/dossier.md`.

--- a/frameworks/six-thinking-hats/dossier.md
+++ b/frameworks/six-thinking-hats/dossier.md
@@ -1,7 +1,4 @@
-I have everything I need. The registry entry confirms: slug `six-thinking-hats`, name "Six Thinking Hats", tier X, status flag, verdict reject, branded true, attribution "Edward de Bono, 1985", trademark string, and the reasoning that the mechanism already ships de-branded. The shipped sibling dossier lives at `skills/think-parallel-perspectives-review/evidence/dossier.md`. Now I'll author the dossier in the exact required shape.
-
 ---
-
 title: Six Thinking Hats
 slug: six-thinking-hats
 generated_status: true

--- a/frameworks/steelmanning/dossier.md
+++ b/frameworks/steelmanning/dossier.md
@@ -1,0 +1,34 @@
+---
+title: Steelmanning
+slug: steelmanning
+generated_status: true
+---
+
+<!-- STATUS:GENERATED (gen-site.mjs from frameworks/registry.mjs) - do not edit between these markers -->
+<!-- /STATUS:GENERATED -->
+
+## What it is
+
+Steelmanning is the discipline of stating the *strongest* version of a view you disagree with before you respond to it. Instead of attacking the weakest or most convenient form of an opposing position (a strawman), you reconstruct the best, most charitable, most defensible case the other side could make - often a case stronger than the one its actual proponents articulated - and only then engage. The durable cognitive move is charitable reconstruction of an opposing argument: you earn the right to disagree by first proving you can argue the other side better than its advocates.
+
+It is named for what it does: it builds an argument out of steel rather than straw, so that any rebuttal has to defeat the real thing.
+
+## When it helps / when it misleads
+
+It helps when you are about to dismiss, rebut, or decide against a position and want to be sure you are beating the actual argument and not a caricature of it: pressure-testing a confident conclusion, engaging a critic fairly, or stress-testing your own thesis by forcing yourself to articulate the best objection to it. For an AI that is biased toward agreeing with and completing the user's framing, deliberately constructing the strongest opposing case is a direct counter to that sycophancy.
+
+It misleads when it stops at construction without judgment - producing an eloquent opposing case but never weighing whether the objections actually land. The explicit when-NOT boundary: steelmanning is a *move*, not a complete decision procedure. On its own it does not rank objections by force, render a verdict, or tell you whether to seek a real dissenter rather than a role-played one. As a standalone ritual it can also become performative even-handedness that delays a decision the evidence already settles.
+
+## What the evidence says
+
+Steelmanning does not ship as its own skill, so it carries no independent grade here. The honest assessment travels with the skill it folds into. The supporting evidence is the same body that backs adversarial review: charitably reconstructing the strongest opposing case surfaces objections that cooperative, agreeable review misses, and it is a sound reasoning discipline.
+
+What the evidence does NOT show: that *constructed* or role-played opposition improves decisions as much as *authentic* dissent. Nemeth et al. (2001) found role-played devil's advocacy does not replicate the reasoning gains of a genuine minority that really disagrees - and a steelman written by the same agent that holds the original view is exactly such constructed dissent. So it is a blind-spot finder, not a substitute for a real dissenter. The evidence is transferred from human group-reasoning and security contexts, not AI-validated. For the full honest grading (tier P, with the constructed-dissent flag), see the skill it folds into: [`skills/think-red-team-light/evidence/dossier.md`](../../frameworks/think-red-team-light/).
+
+## Why it is / is not a skill here
+
+Verdict: Fold into Red Team / Blue Team (red-team-light). Tier P (practitioner). Steelmanning is a real, durable move, but it is the *core move* of red-team-light, not a separable capability. Red-team-light is built on steelmanning by design: it states the thesis fairly, then "builds the strongest objections - steelman, do not strawman," then adds what steelmanning alone lacks - ranking objections by force, testing whether each lands, rendering a verdict, and flagging when genuine rather than constructed dissent should be sought. Shipping steelmanning separately would create a near-twin skill that covers a strict subset of red-team-light's instructions, splitting the catalog and the evidence base across two routes to the same artifact. The learning value is the NO: a genuine, well-named technique can still be the wrong unit to ship when it is the heart of a skill that already exists. We document it honestly and fold it in, rather than laundering a useful idea into a redundant skill.
+
+## Lineage and who to read
+
+Steelmanning is internet-rationalist in origin: the term and its discipline were popularized in the early-2010s rationalist and effective-altruism communities (LessWrong, Slate Star Codex / Scott Alexander, and writers around the Center for Applied Rationality), framed as the constructive counterpart to the strawman fallacy. It is closely related to older norms of charitable interpretation - the principle of charity in philosophy of language (associated with Neil Wilson and Donald Davidson) and Daniel Dennett's "rapoport's rules" for fair criticism, drawn from game theorist Anatol Rapoport. As applied to challenging consensus, it shares lineage with devil's advocacy and red teaming (military, intelligence, and security practice), and inherits the central caveat from Charlan Nemeth's dissent research that role-played opposition underperforms authentic dissent.

--- a/scripts/gen-site.mjs
+++ b/scripts/gen-site.mjs
@@ -633,13 +633,22 @@ function spliceStatus(body, block) {
 const libAuthored = new Set();
 for (const e of registry.frameworks) {
   if (!e.dossierPath || e.dossierPath === 'pending' || !existsSync(join(ROOT, e.dossierPath))) continue;
-  const body = bodyOf(readFileSync(join(ROOT, e.dossierPath), 'utf8'));
+  const raw = readFileSync(join(ROOT, e.dossierPath), 'utf8');
+  // Fail loudly on a malformed dossier (e.g. leaked authoring preamble) rather than rendering
+  // garbage to a public page: bodyOf only strips frontmatter when the file STARTS with ---.
+  if (!/^---\r?\n/.test(raw)) throw new Error(`gen-site: ${e.dossierPath} must start with YAML frontmatter (--- on line 1).`);
+  const body = bodyOf(raw);
   const lines = [
     `> **Status:** ${LIB_STATUS(e.status)}  ·  **Evidence:** ${tierBadge(e.tier)}  ·  **Family:** ${libFamName.get(e.family) || e.family}  ·  **Verdict:** ${e.verdict} (${e.evalDate || registry.seededDate})`,
   ];
   if (e.status === 'shipped' && libShipped.has(e.slug)) lines.push('>', `> Run it: [\`think-${e.slug}\`](../../frameworks/think-${e.slug}/)`);
   if (e.foldInto && libShipped.has(e.foldInto)) lines.push('>', `> Use instead: [\`${libDisplayName(e.foldInto)}\`](../../frameworks/think-${e.foldInto}/)`);
-  if (e.branded && e.trademark) lines.push('>', `> ${e.name} is a trademark of ${e.trademark}.${e.attribution ? ` ${e.attribution}.` : ''}`);
+  if (e.branded && e.trademark) {
+    // Avoid a tautology when the trademark string already leads with the brand name
+    // (e.g. "Six Thinking Hats (a trademark of ...)"); otherwise use the "X is a trademark of Y" form.
+    const tm = e.trademark.startsWith(e.name) ? e.trademark : `${e.name} is a trademark of ${e.trademark}`;
+    lines.push('>', `> ${tm}.${e.attribution ? ` ${e.attribution}.` : ''}`);
+  }
   const page = `---
 title: ${yaml(e.name)}
 description: ${yaml(e.oneLine)}

--- a/scripts/gen-site.mjs
+++ b/scripts/gen-site.mjs
@@ -13,6 +13,7 @@
 import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
+import registry from '../frameworks/registry.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const DOCS = join(ROOT, 'site', 'src', 'content', 'docs');
@@ -21,6 +22,7 @@ const OUT = {
   families: join(DOCS, 'families'),
   recipes: join(DOCS, 'recipes'),
   evidence: join(DOCS, 'evidence'),
+  library: join(DOCS, 'library'), // SP4: Framework Library dossiers + index (registry-driven)
 };
 
 // --- helpers ----------------------------------------------------------------
@@ -607,4 +609,73 @@ writeFileSync(join(GENERATED, 'site-meta.json'), JSON.stringify({
   recipeCount: recipes.length,
 }, null, 2), 'utf8');
 
-console.log(`Generated ${count} framework pages, ${Object.keys(byFamily).length} domains, ${recipes.length} recipes, 4 lenses + map + chooser data, + indexes & bibliography -> ${DOCS}`);
+// --- SP4: Framework Library (per-method dossiers + index, registry-driven) ----
+// A library/<slug>/ page is emitted ONLY for an entry whose dossier source exists
+// (dossierPath set + on disk). pending/absent entries appear in the index as plain text.
+// The status block is generated from the registry and spliced between the dossier's
+// STATUS:GENERATED markers, so the committed dossier source never carries a status line.
+const libFamName = new Map(registry.families.map((f) => [f.slug, f.name]));
+const libBySlug = new Map(registry.frameworks.map((e) => [e.slug, e]));
+const libDisplayName = (slug) => libBySlug.get(slug)?.name ?? slug;
+const libShipped = new Set(registry.frameworks.filter((e) => e.status === 'shipped').map((e) => e.slug));
+const LIB_STATUS = (st) => ({
+  shipped: 'Shipped', fold: 'Folded', cand: 'Candidate', recipe: 'Candidate', next: 'Candidate',
+  flag: 'Documented, not shipped', excl: 'Documented, not shipped', pm: 'Documented, not shipped',
+}[st] || 'Documented, not shipped');
+const STATUS_BEGIN = '<!-- STATUS:GENERATED (gen-site.mjs from frameworks/registry.mjs) - do not edit between these markers -->';
+const STATUS_END = '<!-- /STATUS:GENERATED -->';
+function spliceStatus(body, block) {
+  const i = body.indexOf(STATUS_BEGIN);
+  const j = body.indexOf(STATUS_END);
+  if (i === -1 || j === -1 || j < i) throw new Error('gen-site: a Framework Library dossier is missing its STATUS:GENERATED markers');
+  return body.slice(0, i + STATUS_BEGIN.length) + '\n' + block + '\n' + body.slice(j);
+}
+const libAuthored = new Set();
+for (const e of registry.frameworks) {
+  if (!e.dossierPath || e.dossierPath === 'pending' || !existsSync(join(ROOT, e.dossierPath))) continue;
+  const body = bodyOf(readFileSync(join(ROOT, e.dossierPath), 'utf8'));
+  const lines = [
+    `> **Status:** ${LIB_STATUS(e.status)}  ·  **Evidence:** ${tierBadge(e.tier)}  ·  **Family:** ${libFamName.get(e.family) || e.family}  ·  **Verdict:** ${e.verdict} (${e.evalDate || registry.seededDate})`,
+  ];
+  if (e.status === 'shipped' && libShipped.has(e.slug)) lines.push('>', `> Run it: [\`think-${e.slug}\`](../../frameworks/think-${e.slug}/)`);
+  if (e.foldInto && libShipped.has(e.foldInto)) lines.push('>', `> Use instead: [\`${libDisplayName(e.foldInto)}\`](../../frameworks/think-${e.foldInto}/)`);
+  if (e.branded && e.trademark) lines.push('>', `> ${e.name} is a trademark of ${e.trademark}.${e.attribution ? ` ${e.attribution}.` : ''}`);
+  const page = `---
+title: ${yaml(e.name)}
+description: ${yaml(e.oneLine)}
+generated: true
+editUrl: ${JSON.stringify(EDIT_BASE ? `${EDIT_BASE}${e.dossierPath}` : false)}
+slug_id: ${yaml(e.slug)}
+status: ${yaml(e.status)}
+evidence_tier: ${yaml(e.tier)}
+---
+
+${BANNER('Framework Library dossier; status block from frameworks/registry.mjs, body from ' + e.dossierPath)}
+
+${spliceStatus(body, lines.join('\n')).trim()}
+`;
+  writeFileSync(join(OUT.library, `${e.slug}.md`), page, 'utf8');
+  libAuthored.add(e.slug);
+}
+const libRow = (e) => `| ${libAuthored.has(e.slug) ? `[${e.name}](./${e.slug}/)` : e.name} | ${tierBadge(e.tier)} | ${LIB_STATUS(e.status)}${libAuthored.has(e.slug) ? '' : ' _(dossier pending)_'} |`;
+const libGroups = registry.families.map((f) => {
+  const members = registry.frameworks.filter((e) => e.family === f.slug);
+  return members.length ? `## ${f.name}\n\n| Framework | Evidence | Status |\n|---|---|---|\n${members.map(libRow).join('\n')}` : '';
+}).filter(Boolean).join('\n\n');
+writeFileSync(join(OUT.library, 'index.md'), `---
+title: Framework Library
+description: ${yaml('Every thinking method this library has evaluated, with its honest evidence grade and a long-form dossier.')}
+generated: true
+editUrl: false
+sidebar:
+  order: 0
+---
+
+${BANNER('Framework Library index from frameworks/registry.mjs')}
+
+Every thinking method this library has evaluated, grouped by family, with its honest evidence grade and verdict. Entries marked _(dossier pending)_ are catalogued but their long-form dossier is not yet written. See [why some methods are documented but not shipped](../about/why-not/) and the full [evidence index](../evidence/).
+
+${libGroups}
+`, 'utf8');
+
+console.log(`Generated ${count} framework pages, ${Object.keys(byFamily).length} domains, ${recipes.length} recipes, ${libAuthored.size} library dossiers, 4 lenses + map + chooser data, + indexes & bibliography -> ${DOCS}`);

--- a/scripts/route-manifest.txt
+++ b/scripts/route-manifest.txt
@@ -71,6 +71,10 @@
 /learn/get-unstuck/index.html
 /learn/index.html
 /learn/think-better-in-30-minutes/index.html
+/library/index.html
+/library/premortem/index.html
+/library/six-thinking-hats/index.html
+/library/steelmanning/index.html
 /recipes/audit-reasoning/index.html
 /recipes/expand-options/index.html
 /recipes/first-principles/index.html

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -10,6 +10,7 @@ src/content/docs/frameworks/
 src/content/docs/families/
 src/content/docs/recipes/
 src/content/docs/evidence/
+src/content/docs/library/
 # explore/ is mixed: the lens + map pages are generated, chooser.mdx is hand-authored.
 src/content/docs/explore/*
 !src/content/docs/explore/chooser.mdx

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -86,6 +86,10 @@ export default defineConfig({
           items: [{ autogenerate: { directory: 'frameworks' } }],
         },
         {
+          label: 'Framework Library',
+          items: [{ autogenerate: { directory: 'library' } }],
+        },
+        {
           label: 'Domains',
           items: [{ autogenerate: { directory: 'families' } }],
         },


### PR DESCRIPTION
## What

The **Framework Library**: per-method long-form learning dossiers, rendered on the Astro site with a registry-generated status block, browsable by family. This first PR ships the **infrastructure + a 3-dossier tranche**; the rest of the registry stays `dossierPath: pending` and fills in over time (the SP5 `research-framework` engine drafts later tranches). Purely **additive** - no existing routes change.

## Pieces

- **Dossier format** (`frameworks/<slug>/dossier.md`): a do-not-edit `STATUS:GENERATED` block + a 5-section learning body (What it is / When it helps or misleads / What the evidence says / Why it is or is not a skill here / Lineage). Distinct from the shipped skill's `evidence/dossier.md` (the evidence record); the learning dossier summarizes + links it. `frameworks/_template/dossier.md` is the skeleton.
- **`gen-site.mjs`**: emits `library/<slug>/` pages + a by-family index. The status block (Status / Evidence / Family / Verdict + run-it / fold / branded lines) is generated from the registry and **spliced between the dossier's markers**, so the committed source never carries a status line that drifts. A page renders only for an entry whose `dossierPath` resolves; pending entries are plain text in the index. `editUrl` points at the committed dossier source.
- **Sidebar**: a "Framework Library" group. **gitignore**: generated `library/` content is ignored like the other generated docs.
- **First tranche** (one per status-block variant): `premortem` (shipped), `steelmanning` (fold → red-team-light), `six-thinking-hats` (branded, documented-not-shipped, de Bono trademark). `dossierPath` set on these 3 entries.

## Verification

- **Gate advanced 0/0** (102 / 34, eval-cases 38, engine in sync) - the registry referential check now validates the 3 `dossierPath`s resolve. **npm test 43/43.**
- Site: **87 pages, rendered-links + route-parity pass** (4 new library routes; baseline refreshed). The premortem dossier honestly grades S/M and refuses the "~30%" misreading; six-thinking-hats is X with proper trademark attribution.

## Flagged for the maintainer

- **Deferred (separate decision):** the meta-skills (advisor/research-framework/top3/random-frameworks) still render as `/frameworks/` pages. Moving them to a `/tools/` section is an outward-facing site-structure change to shipped content, so it's not bundled here.
- **Tier-string divergence:** the premortem status badge shows the registry governing tier (`S`) while the dossier body says the honest compound `S/M` - this is registry follow-up #1 (CI-verified consistent, displayed strings differ).
- Depends on SP3 (registry) and SP5 (the engine that drafts future dossiers), both on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)