### PR TITLE
chore(infra): generate the AGENTS.md tables (end the recurring drift)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,62 +13,68 @@ Each skill is built around four commitments, not just a prompt:
 
 ## Skills
 
+<!-- BEGIN GENERATED SKILLS (scripts/gen-agents.mjs from frameworks/registry.mjs + skills/) - do not hand-edit below this line -->
 | Skill | Family | Evidence | Artifact |
 |---|---|---|---|
-| [`think-premortem`](skills/think-premortem/SKILL.md) | risk-and-resilience | S/M | risk register |
-| [`think-problem-restatement`](skills/think-problem-restatement/SKILL.md) | problem-framing | M/P | problem frame set |
-| [`think-evidence-vs-inference-sort`](skills/think-evidence-vs-inference-sort/SKILL.md) | reasoning-clarity | P | evidence/inference ledger |
+| [`think-authentic-dissent`](skills/think-authentic-dissent/SKILL.md) | assumption-and-belief-challenge | **S** | dissent audit |
 | [`think-ladder-of-inference-check`](skills/think-ladder-of-inference-check/SKILL.md) | assumption-and-belief-challenge | P | reasoning trace |
-| [`think-what-would-have-to-be-true`](skills/think-what-would-have-to-be-true/SKILL.md) | decision-and-option-evaluation | P | assumption ledger |
-| [`think-decision-option-review`](skills/think-decision-option-review/SKILL.md) | decision-and-option-evaluation | P (flag) | option matrix |
-| [`think-parallel-perspectives-review`](skills/think-parallel-perspectives-review/SKILL.md) | perspective-and-multi-lens | P (flag) | multi-lens review |
-| [`think-red-team-light`](skills/think-red-team-light/SKILL.md) | assumption-and-belief-challenge | P (flag) | adversarial critique |
-| [`think-scamper`](skills/think-scamper/SKILL.md) | divergent-ideation | P | expansion sheet |
-| [`think-question-burst`](skills/think-question-burst/SKILL.md) | divergent-ideation | P | ranked question set |
-| [`think-assumption-reversal`](skills/think-assumption-reversal/SKILL.md) | divergent-ideation | P | assumptions-and-reversals sheet |
-| [`think-brainwriting`](skills/think-brainwriting/SKILL.md) | divergent-ideation | **S** | idea pool |
-| [`think-futures-wheel`](skills/think-futures-wheel/SKILL.md) | systems-and-consequences | P | consequence map |
-| [`think-reference-class-forecasting`](skills/think-reference-class-forecasting/SKILL.md) | risk-and-resilience | **S** | reference-class estimate |
-| [`think-argument-mapping`](skills/think-argument-mapping/SKILL.md) | reasoning-clarity | **S** | argument map |
-| [`think-woop`](skills/think-woop/SKILL.md) | risk-and-resilience | **S** | WOOP commitment card |
-| [`think-authentic-dissent`](skills/think-authentic-dissent/SKILL.md) | assumption-and-belief-challenge | **S** | dissent audit and plan |
-| [`think-after-action-review`](skills/think-after-action-review/SKILL.md) | meta-thinking-and-reflection | S/M | after-action review |
-| [`think-far-analogy-ideation`](skills/think-far-analogy-ideation/SKILL.md) | divergent-ideation | **S** | far-analogy transfer sheet |
-| [`think-natural-frequency-bayesian`](skills/think-natural-frequency-bayesian/SKILL.md) | reasoning-clarity | **S** | natural-frequency breakdown |
-| [`think-issue-tree`](skills/think-issue-tree/SKILL.md) | reasoning-clarity | P | issue tree (MECE) |
-| [`think-affinity-mapping`](skills/think-affinity-mapping/SKILL.md) | synthesis | P | clustered theme map |
-| [`think-pyramid-principle`](skills/think-pyramid-principle/SKILL.md) | synthesis | P | answer-first pyramid |
-| [`think-abstraction-laddering`](skills/think-abstraction-laddering/SKILL.md) | problem-framing | P | abstraction ladder |
-| [`think-one-way-vs-two-way-door`](skills/think-one-way-vs-two-way-door/SKILL.md) | decision-and-option-evaluation | P | reversibility classification |
-| [`think-decision-journal`](skills/think-decision-journal/SKILL.md) | meta-thinking-and-reflection | P | decision journal entry |
-| [`think-iceberg-model`](skills/think-iceberg-model/SKILL.md) | systems-and-consequences | P | iceberg (4 levels) |
-| [`think-backcasting`](skills/think-backcasting/SKILL.md) | risk-and-resilience | P | backcast path |
-| [`think-stocks-and-flows-reasoning`](skills/think-stocks-and-flows-reasoning/SKILL.md) | systems-and-consequences | **S** | stock-flow map |
+| [`think-red-team-light`](skills/think-red-team-light/SKILL.md) | assumption-and-belief-challenge | P | adversarial critique |
+| [`think-decision-option-review`](skills/think-decision-option-review/SKILL.md) | decision-and-option-evaluation | P | option matrix |
+| [`think-expected-value-decision-tree`](skills/think-expected-value-decision-tree/SKILL.md) | decision-and-option-evaluation | P | decision tree ev |
+| [`think-fermi-estimation`](skills/think-fermi-estimation/SKILL.md) | decision-and-option-evaluation | M/P | fermi decomposition worksheet |
 | [`think-linear-model-aggregation`](skills/think-linear-model-aggregation/SKILL.md) | decision-and-option-evaluation | **S** | scoring model |
-| [`think-causal-loop-diagrams`](skills/think-causal-loop-diagrams/SKILL.md) | systems-and-consequences | M/P | signed causal loop diagram |
+| [`think-one-way-vs-two-way-door`](skills/think-one-way-vs-two-way-door/SKILL.md) | decision-and-option-evaluation | P | reversibility classification |
+| [`think-what-would-have-to-be-true`](skills/think-what-would-have-to-be-true/SKILL.md) | decision-and-option-evaluation | P | assumption ledger |
+| [`think-assumption-reversal`](skills/think-assumption-reversal/SKILL.md) | divergent-ideation | P | assumptions and reversals sheet |
+| [`think-brainwriting`](skills/think-brainwriting/SKILL.md) | divergent-ideation | **S** | idea pool |
+| [`think-far-analogy-ideation`](skills/think-far-analogy-ideation/SKILL.md) | divergent-ideation | **S** | far analogy transfer sheet |
+| [`think-question-burst`](skills/think-question-burst/SKILL.md) | divergent-ideation | P | ranked question set |
+| [`think-scamper`](skills/think-scamper/SKILL.md) | divergent-ideation | P | scamper expansion sheet |
+| [`think-after-action-review`](skills/think-after-action-review/SKILL.md) | meta-thinking-and-reflection | **S** | after action review |
+| [`think-belief-update-routine`](skills/think-belief-update-routine/SKILL.md) | meta-thinking-and-reflection | P | belief update ledger |
+| [`think-decision-journal`](skills/think-decision-journal/SKILL.md) | meta-thinking-and-reflection | P | decision journal entry |
+| [`think-parallel-perspectives-review`](skills/think-parallel-perspectives-review/SKILL.md) | perspective-and-multi-lens | P | multi lens review |
+| [`think-abstraction-laddering`](skills/think-abstraction-laddering/SKILL.md) | problem-framing | P | abstraction ladder |
+| [`think-boundary-critique`](skills/think-boundary-critique/SKILL.md) | problem-framing | C/P | boundary judgment audit |
+| [`think-contradiction-resolution`](skills/think-contradiction-resolution/SKILL.md) | problem-framing | M/P | contradiction resolution worksheet |
+| [`think-frame-creation`](skills/think-frame-creation/SKILL.md) | problem-framing | C/P | frame proposal |
+| [`think-problem-restatement`](skills/think-problem-restatement/SKILL.md) | problem-framing | M/P | problem frame set |
+| [`think-argument-mapping`](skills/think-argument-mapping/SKILL.md) | reasoning-clarity | **S** | argument map |
+| [`think-evidence-vs-inference-sort`](skills/think-evidence-vs-inference-sort/SKILL.md) | reasoning-clarity | P | evidence inference ledger |
+| [`think-issue-tree`](skills/think-issue-tree/SKILL.md) | reasoning-clarity | P | issue tree |
+| [`think-natural-frequency-bayesian`](skills/think-natural-frequency-bayesian/SKILL.md) | reasoning-clarity | **S** | natural frequency breakdown |
+| [`think-backcasting`](skills/think-backcasting/SKILL.md) | risk-and-resilience | P | backcast path |
+| [`think-premortem`](skills/think-premortem/SKILL.md) | risk-and-resilience | S/M | risk register |
+| [`think-reference-class-forecasting`](skills/think-reference-class-forecasting/SKILL.md) | risk-and-resilience | **S** | reference class estimate |
+| [`think-woop`](skills/think-woop/SKILL.md) | risk-and-resilience | **S** | woop card |
+| [`think-scenario-planning`](skills/think-scenario-planning/SKILL.md) | strategy-and-opportunity | P | scenario set |
+| [`think-affinity-mapping`](skills/think-affinity-mapping/SKILL.md) | synthesis | P | clustered theme map |
 | [`think-concept-mapping`](skills/think-concept-mapping/SKILL.md) | synthesis | M/P | concept map |
-| [`think-fermi-estimation`](skills/think-fermi-estimation/SKILL.md) | decision-and-option-evaluation | M/P | Fermi decomposition worksheet |
-| [`think-belief-update-routine`](skills/think-belief-update-routine/SKILL.md) | meta-thinking-and-reflection | P | belief-update ledger |
-| [`think-contradiction-resolution`](skills/think-contradiction-resolution/SKILL.md) | problem-framing | M/P | contradiction / IFR worksheet |
-| [`think-boundary-critique`](skills/think-boundary-critique/SKILL.md) | problem-framing | C/P | boundary-judgment audit |
-| [`think-frame-creation`](skills/think-frame-creation/SKILL.md) | problem-framing | C/P | new-frame brief |
-| [`think-theory-of-constraints`](skills/think-theory-of-constraints/SKILL.md) | systems-and-consequences | P | constraint-intervention plan |
-| [`think-expected-value-decision-tree`](skills/think-expected-value-decision-tree/SKILL.md) | decision-and-option-evaluation | P | EV decision tree |
-| [`think-scenario-planning`](skills/think-scenario-planning/SKILL.md) | strategy-and-opportunity | P | scenario set (2x2) |
+| [`think-pyramid-principle`](skills/think-pyramid-principle/SKILL.md) | synthesis | P | pyramid |
+| [`think-causal-loop-diagrams`](skills/think-causal-loop-diagrams/SKILL.md) | systems-and-consequences | M/P | signed causal loop diagram |
+| [`think-futures-wheel`](skills/think-futures-wheel/SKILL.md) | systems-and-consequences | P | consequence map |
+| [`think-iceberg-model`](skills/think-iceberg-model/SKILL.md) | systems-and-consequences | P | iceberg |
+| [`think-stocks-and-flows-reasoning`](skills/think-stocks-and-flows-reasoning/SKILL.md) | systems-and-consequences | **S** | stock flow map |
+| [`think-theory-of-constraints`](skills/think-theory-of-constraints/SKILL.md) | systems-and-consequences | P | constraint intervention plan |
 | [`think-framework-advisor`](skills/think-framework-advisor/SKILL.md) | meta (router) | M/C | Thinking Plan |
 
-40 skills, 11 at **S**/S-M tier - the named empirical core is fully shipped. **`think-framework-advisor` is the front door / meta-router:** describe a situation and it returns a prioritized, evidence-graded *Thinking Plan* of which of the other skills to use and why (graded M/C - honest that the routing itself is unvalidated; see its dossier). "(flag)" marks skills with a documented evidence or trademark caveat. See `docs/internal/research/framework-catalog.md` for the full framework universe and roadmap.
+40 skills, 11 at **S**/S-M tier - the named empirical core is fully shipped. **`think-framework-advisor` is the front door / meta-router:** describe a situation and it returns a prioritized, evidence-graded *Thinking Plan* of which of the other skills to use and why (graded M/C - honest that the routing itself is unvalidated; see its dossier). See `docs/internal/research/framework-catalog.md` for the full framework universe and roadmap.
+<!-- END GENERATED SKILLS -->
 
 ## Recipes
 
 Composable chains that solve a recurring job end to end. Each ships as a **workflow component** in [`_workflows/`](_workflows/) (a `steps:` list of skills) with human-readable prose in [`recipes/`](recipes/README.md). The plugin validates at **advanced (Gold)** tier, targeting Claude Code and Codex; native manifests are generated from `library.json` (do not hand-edit `.claude-plugin/` or `.codex-plugin/`).
 
+<!-- BEGIN GENERATED RECIPES (scripts/gen-agents.mjs from _workflows/) - do not hand-edit below this line -->
 | Recipe | Chain |
 |---|---|
-| [reframe-problem](recipes/reframe-problem.md) | restate -> evidence-sort -> perspectives |
-| [expand-options](recipes/expand-options.md) | restate -> scamper -> assumption-reversal |
-| [stress-test-decision](recipes/stress-test-decision.md) | option-review -> WWHTBT -> premortem -> reference-class |
-| [audit-reasoning](recipes/audit-reasoning.md) | evidence-sort -> ladder -> perspectives |
+| [audit-reasoning](recipes/audit-reasoning.md) | evidence-vs-inference-sort -> ladder-of-inference-check -> parallel-perspectives-review |
+| [expand-options](recipes/expand-options.md) | problem-restatement -> scamper -> assumption-reversal |
+| [first-principles](recipes/first-principles.md) | abstraction-laddering -> assumption-reversal |
+| [idea-quality-audit](recipes/idea-quality-audit.md) | decision-option-review -> red-team-light |
+| [reframe-problem](recipes/reframe-problem.md) | problem-restatement -> evidence-vs-inference-sort -> parallel-perspectives-review |
+| [stress-test-decision](recipes/stress-test-decision.md) | decision-option-review -> what-would-have-to-be-true -> premortem -> reference-class-forecasting |
+<!-- END GENERATED RECIPES -->
 
 ## Skill anatomy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented here. The format is based on 
 
 ## [Unreleased]
 
+### Added
+- `scripts/gen-agents.mjs` - the `AGENTS.md` Skills and Recipes tables are now **generated and drift-checked** from the same sources as everything else (the registry + each `SKILL.md` frontmatter + `skill.meta.yml` + `_workflows/`), spliced between `BEGIN/END GENERATED` markers. A new fifth layer of the conformance gate (`gen-agents.mjs --check`) byte-compares the committed tables against a fresh generation, so the agent-facing roster can no longer silently fall behind the catalog (it had drifted to a stale count since v0.3.0). The contributor guide joins the "no second store" principle: edit a source, regenerate, never hand-edit the table. Generating de-slugifies the artifact labels and drops the prior inline `(flag)` markers (each skill's caveats still live in its own `When NOT to Use` and the registry).
+
 ## [0.5.0] - 2026-06-09
 
 **Catalog expansion.** The catalog grows from 34 to 40 shipped frameworks (and from 10 to 11 cognitive-operation families). Three are de-branded problem-framing methods the `think-research-framework` engine discovered, vetted, and the library built end to end (contradiction-resolution, boundary-critique, frame-creation - the platform's first engine-discovered-to-shipped frameworks, and its first shipped C-tier methods); three come from the v0.5.0 phase-1 shortlist (theory-of-constraints, expected-value-decision-tree, and scenario-planning, which adds the 11th family). The same shortlist also reconciled four candidates honestly - two folds into premortem and two rejects - now published as rejected-with-reasoning Framework Library pages. The honesty bar held throughout: both "M-tier" candidates were downgraded to P before building, and the engine's high fold/reject rate kept breadth from diluting the grade.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,6 +41,7 @@ Nothing about a method is hand-duplicated. Every downstream surface is regenerat
 | `scripts/gen-recommendable.mjs` | the skills + recipes | the advisor's `recommendable.{json,md}` corpus (names, tiers, anti-triggers, when-not, overlaps); the registry cross-checks this corpus rather than feeding it |
 | `scripts/gen-site.mjs` | the skills + registry + recipes + intros | the Starlight site (frameworks, tools, families, recipes, library, explore lenses, map, chooser, bibliography) |
 | `scripts/gen-engine.mjs` | the shared applicator engine | the byte-identical copy of `engine.md` in `think-random-frameworks` |
+| `scripts/gen-agents.mjs` | the registry + skills + `_workflows/` | the `AGENTS.md` Skills + Recipes tables (the contributor/agent guide) |
 | agent-skills-toolkit `gen-manifest` / `gen-index` | `library.json` | the native plugin manifests + `INDEX.md` |
 
 ```mermaid
@@ -48,7 +49,7 @@ Nothing about a method is hand-duplicated. Every downstream surface is regenerat
 graph LR
   reg["frameworks/registry.mjs<br/>(the catalog: 105 methods)"]:::source
   skl["skills/ + library.json + _workflows/<br/>(the 40 shipped + 4 tools + 6 recipes)"]:::source
-  gen["gen-registry · gen-recommendable<br/>gen-site · gen-engine · gen-manifest"]:::build
+  gen["gen-registry · gen-recommendable · gen-site<br/>gen-engine · gen-agents · gen-manifest"]:::build
   views["catalog · why-not · advisor corpus<br/>Starlight site · plugin manifests · INDEX"]:::site
   pages["GitHub Pages + marketplace"]:::deploy
   reg --> gen
@@ -64,12 +65,13 @@ Every generated page carries a do-not-hand-edit banner, and the site output is g
 
 ## The conformance gate
 
-`scripts/check.mjs` is the single required gate (a status check on `main`); CI runs it on every PR. It runs four layers in order, and any failure is a red build:
+`scripts/check.mjs` is the single required gate (a status check on `main`); CI runs it on every PR. It runs five layers in order, and any failure is a red build:
 
 1. **Structural** - the `agent-skills-toolkit` validators (`evaluate.mjs`), pinned to a known-good ref, asserting the plugin meets the `advanced` tier with 0 errors / 0 warnings.
 2. **Eval cases** (`scripts/eval-cases.mjs`) - every `skills/*/eval/cases.md` is well-formed and name-safe (no case may reference a framework that does not exist).
 3. **Registry** (`scripts/check-registry.mjs`) - schema validation, generated-view drift, referential integrity (shipped <-> skill dir, fold targets resolve to a shipped skill, dossier paths and source URLs resolve), completeness, the IP/attribution lint, eval-coupling, tier consistency, and the registry <-> advisor recommendable cross-check.
 4. **Engine drift** (`scripts/gen-engine.mjs --check`) - the shared applicator engine copy is in sync.
+5. **AGENTS.md drift** (`scripts/gen-agents.mjs --check`) - the generated Skills + Recipes tables in the contributor/agent guide are in sync with the catalog, so the agent-facing roster cannot silently fall behind.
 
 The docs site adds two build-time guards run after `astro build` (family Astro site standard, clause 14.11): `scripts/check-rendered-links.mjs` (no browser-broken internal links) and `scripts/check-route-parity.mjs` (no silently dropped published route, against the committed `scripts/route-manifest.txt`).
 

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -3,16 +3,18 @@
 // contributor or CI runs to validate the plugin against the agent-skills-toolkit
 // Standard: `node scripts/check.mjs` (or `npm run check`).
 //
-// It runs four layers:
+// It runs five layers:
 //   1. the toolkit's portable STRUCTURAL validators (the toolkit is the source of truth;
 //      vendoring them here would drift),
 //   2. the repo-local static eval-case validator (scripts/eval-cases.mjs, SP1): every
 //      skills/*/eval/cases.md must be well-formed and name-safe,
 //   3. the registry conformance check (scripts/check-registry.mjs, SP3): frameworks/
 //      registry.mjs validates against its schema, its generated views are not stale, and
-//      its referential / IP / eval-coupling invariants hold, and
+//      its referential / IP / eval-coupling invariants hold,
 //   4. the shared applicator engine-copy drift check (scripts/gen-engine.mjs --check, SP7/SP8):
-//      the byte-identical engine.md copy stays in sync.
+//      the byte-identical engine.md copy stays in sync, and
+//   5. the AGENTS.md table drift check (scripts/gen-agents.mjs --check): the generated
+//      Skills + Recipes tables in the contributor guide stay in sync with the catalog.
 //
 // To reproduce a CI failure locally, clone the public toolkit next to this repo:
 //   git clone https://github.com/product-on-purpose/agent-skills-toolkit.git ../agent-skills-toolkit
@@ -74,5 +76,8 @@ const registry = spawnSync('node', [resolve(ROOT, 'scripts', 'check-registry.mjs
 console.log('\nRunning engine-copy drift check (scripts/gen-engine.mjs --check)\n');
 const engine = spawnSync('node', [resolve(ROOT, 'scripts', 'gen-engine.mjs'), '--check'], { stdio: 'inherit' });
 
+console.log('\nRunning AGENTS.md table drift check (scripts/gen-agents.mjs --check)\n');
+const agents = spawnSync('node', [resolve(ROOT, 'scripts', 'gen-agents.mjs'), '--check'], { stdio: 'inherit' });
+
 // Fail if any layer failed; all run so contributors see all problems at once.
-process.exit((structural.status ?? 1) || (evalCases.status ?? 1) || (registry.status ?? 1) || (engine.status ?? 1));
+process.exit((structural.status ?? 1) || (evalCases.status ?? 1) || (registry.status ?? 1) || (engine.status ?? 1) || (agents.status ?? 1));

--- a/scripts/gen-agents.mjs
+++ b/scripts/gen-agents.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// =============================================================================
+// gen-agents.mjs - generate the drift-checked tables in AGENTS.md.
+//
+// AGENTS.md is the contributor/agent guide. Its Skills and Recipes tables are a
+// view of the same sources everything else is generated from, so they used to
+// drift every time the catalog grew (a hand-maintained denormalized roster). This
+// regenerates them, and a `--check` byte-compare in the conformance gate fails CI
+// if the committed AGENTS.md ever falls out of sync.
+//
+// Two generated blocks, both in AGENTS.md:
+//   1. SKILLS - one row per shipped framework (Skill | Family | Evidence | Artifact)
+//      + the advisor meta-router row + the count line. Family + compound evidence
+//      tier come from each skills/think-<slug>/SKILL.md frontmatter; the artifact is
+//      the de-slugified primary_artifact_type from skill.meta.yml.
+//   2. RECIPES - one row per _workflows/think-<slug>.md (Recipe | Chain), the chain
+//      being the workflow's step list with the think- prefix stripped.
+//
+// Run `node scripts/gen-agents.mjs` to write; `--check` regenerates in memory and
+// byte-compares (exit 1 on drift). Zero-dependency, explicit UTF-8, LF newlines -
+// the gen-registry.mjs / gen-recommendable.mjs convention (.gitattributes pins LF so
+// the byte compare is identical on every platform).
+// =============================================================================
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import registry from '../frameworks/registry.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..');
+const CHECK = process.argv.includes('--check');
+const AGENTS = resolve(ROOT, 'AGENTS.md');
+
+const SKILLS_BEGIN = '<!-- BEGIN GENERATED SKILLS (scripts/gen-agents.mjs from frameworks/registry.mjs + skills/) - do not hand-edit below this line -->';
+const SKILLS_END = '<!-- END GENERATED SKILLS -->';
+const RECIPES_BEGIN = '<!-- BEGIN GENERATED RECIPES (scripts/gen-agents.mjs from _workflows/) - do not hand-edit below this line -->';
+const RECIPES_END = '<!-- END GENERATED RECIPES -->';
+
+const read = (p) => readFileSync(p, 'utf8');
+const escapePipes = (s) => String(s).replace(/\|/g, '\\|');
+
+// --- tiny, tolerant frontmatter reader (no YAML dependency) -------------------
+// Handles top-level `key: value`, one level of nesting under `metadata:`, and a
+// `steps:` list of `- item`. The same shape gen-recommendable.mjs parses.
+function frontmatter(text) {
+  const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return { metadata: {}, steps: [] };
+  const out = { metadata: {}, steps: [] };
+  let parent = null;
+  for (const raw of m[1].split('\n')) {
+    const line = raw.replace(/\r$/, '');
+    if (!line.trim()) continue;
+    const indented = /^\s+/.test(line);
+    const listItem = line.match(/^\s*-\s+(.*)$/);
+    if (parent === 'steps' && listItem) { out.steps.push(stripInline(listItem[1])); continue; }
+    const kv = line.match(/^(\s*)([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!kv) continue;
+    const [, , key, value] = kv;
+    if (!indented) {
+      if (key === 'metadata' && value === '') { parent = 'metadata'; }
+      else if (key === 'steps' && value === '') { parent = 'steps'; }
+      else { parent = null; out[key] = stripInline(value); }
+    } else if (parent === 'metadata') {
+      out.metadata[key] = stripInline(value);
+    }
+  }
+  return out;
+}
+// strip surrounding quotes and a trailing ` # comment` (skill.meta.yml uses inline comments)
+function stripInline(v) {
+  let s = String(v).replace(/\s+#.*$/, '').trim();
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) s = s.slice(1, -1);
+  return s.trim();
+}
+
+// --- per-skill metadata -------------------------------------------------------
+function skillMeta(slug) {
+  const dir = resolve(ROOT, 'skills', `think-${slug}`);
+  const fm = frontmatter(read(resolve(dir, 'SKILL.md')));
+  const family = fm.metadata.family || 'other';
+  const tier = fm.metadata['evidence-tier'] || '';
+  const metaYml = read(resolve(dir, 'skill.meta.yml'));
+  const am = metaYml.match(/^\s*primary_artifact_type:\s*(.+)$/m);
+  const artifact = am ? stripInline(am[1]).replace(/-/g, ' ') : '';
+  return { family, tier, artifact };
+}
+
+const tierCell = (tier) => (tier === 'S' ? '**S**' : tier);
+
+// --- block 1: the Skills table + count line -----------------------------------
+function skillsBlock() {
+  // sort by displayed family then slug, so the Family column is cleanly grouped
+  const shipped = registry.frameworks
+    .filter((e) => e.status === 'shipped')
+    .map((e) => ({ slug: e.slug, ...skillMeta(e.slug) }))
+    .sort((a, b) => a.family.localeCompare(b.family) || a.slug.localeCompare(b.slug));
+  const rows = shipped.map((s) =>
+    `| [\`think-${s.slug}\`](skills/think-${s.slug}/SKILL.md) | ${s.family} | ${tierCell(s.tier)} | ${escapePipes(s.artifact)} |`);
+  // the advisor is a meta-skill (no registry entry); special-cased as the router row
+  const advTier = frontmatter(read(resolve(ROOT, 'skills', 'think-framework-advisor', 'SKILL.md'))).metadata['evidence-tier'] || 'M/C';
+  rows.push(`| [\`think-framework-advisor\`](skills/think-framework-advisor/SKILL.md) | meta (router) | ${advTier} | Thinking Plan |`);
+
+  const sCount = shipped.filter((s) => /^S(\/|$)/.test(s.tier)).length;
+  const count = `${shipped.length} skills, ${sCount} at **S**/S-M tier - the named empirical core is fully shipped. **\`think-framework-advisor\` is the front door / meta-router:** describe a situation and it returns a prioritized, evidence-graded *Thinking Plan* of which of the other skills to use and why (graded ${advTier} - honest that the routing itself is unvalidated; see its dossier). See \`docs/internal/research/framework-catalog.md\` for the full framework universe and roadmap.`;
+
+  return ['| Skill | Family | Evidence | Artifact |', '|---|---|---|---|', ...rows, '', count].join('\n');
+}
+
+// --- block 2: the Recipes table -----------------------------------------------
+function recipesBlock() {
+  const files = readdirSync(resolve(ROOT, '_workflows')).filter((f) => f.endsWith('.md')).sort();
+  const rows = files.map((f) => {
+    const fm = frontmatter(read(resolve(ROOT, '_workflows', f)));
+    const slug = (fm.name || f.replace(/\.md$/, '')).replace(/^think-/, '');
+    const chain = fm.steps.map((s) => s.replace(/^think-/, '')).join(' -> ');
+    return `| [${slug}](recipes/${slug}.md) | ${escapePipes(chain)} |`;
+  });
+  return ['| Recipe | Chain |', '|---|---|', ...rows].join('\n');
+}
+
+// --- splice + write/check -----------------------------------------------------
+function splice(body, begin, end, block, label) {
+  const i = body.indexOf(begin);
+  const j = body.indexOf(end);
+  if (i === -1 || j === -1 || j < i) throw new Error(`gen-agents: ${label} markers not found (or out of order) in AGENTS.md`);
+  return `${body.slice(0, i + begin.length)}\n${block}\n${body.slice(j)}`;
+}
+
+const current = read(AGENTS);
+let next = splice(current, SKILLS_BEGIN, SKILLS_END, skillsBlock(), 'SKILLS');
+next = splice(next, RECIPES_BEGIN, RECIPES_END, recipesBlock(), 'RECIPES');
+
+if (CHECK) {
+  if (next !== current) {
+    console.error('gen-agents: AGENTS.md is out of date. Regenerate: node scripts/gen-agents.mjs');
+    process.exit(1);
+  }
+  console.log('gen-agents: OK (AGENTS.md tables in sync).');
+} else {
+  writeFileSync(AGENTS, next, 'utf8');
+  console.log('gen-agents: wrote AGENTS.md (Skills + Recipes tables).');
+}


### PR DESCRIPTION
## Why

The `AGENTS.md` Skills and Recipes tables were hand-maintained denormalized rosters that drifted on every catalog change. At v0.5.0 the Codex review caught the skills table stale at 34 (missing 7 frameworks - one since **v0.3.0**), and the recipes table was missing 2 recipes. This closes the root cause by making both tables generated and drift-checked, the same way every other downstream surface already is ("no second store").

## What

- **`scripts/gen-agents.mjs`** (the repo's 6th generator): emits both `AGENTS.md` tables between `BEGIN/END GENERATED` markers, sourced from `frameworks/registry.mjs` (shipped) + each `SKILL.md` frontmatter (family, compound evidence tier) + `skill.meta.yml` (`primary_artifact_type`) + the advisor meta-skill + `_workflows/` (recipes). Skills sorted by family then slug. `--check` byte-compares (negative-tested: it exits 1 on drift).
- **`scripts/check.mjs`**: a 5th conformance-gate layer (`gen-agents.mjs --check`) so a stale `AGENTS.md` fails CI instead of shipping silently.
- **`AGENTS.md`**: tables regenerated - skills **34 → 40** with clean family grouping; recipes **4 → 6**. (De-slugified artifact labels; dropped the inline `(flag)` markers, whose caveats still live in each skill's `When NOT to Use` + the registry.)
- **`docs/architecture.md`**: `gen-agents` added to the generator table + the pipeline diagram; the gate documented as five layers.
- **CHANGELOG** `[Unreleased]`: recorded.

## Verification

- Gate **advanced 0/0**, all 5 layers green (`gen-agents: OK (AGENTS.md tables in sync)`).
- npm test **43/43**.
- Drift guard negative-tested (corrupt a generated value → `--check` exits 1; regenerate → passes).
- No version bump: internal infra, normal development - merges to main and auto-deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)