### PR TITLE
docs: note the 3 output-eval-flagged skills were tightened by construction

### DIFF
--- a/site/src/content/docs/start/does-this-work.mdx
+++ b/site/src/content/docs/start/does-this-work.mdx
@@ -46,7 +46,7 @@ A separate measurement. For each skill, a producer agent runs it on a real promp
     **386 of 389** individual output checks passed across freshly produced artifacts. **53 of 56** skills satisfied every single check.
   </Card>
   <Card title="The misses were specific" icon="information">
-    The three misses were specific: two skills dropped the evidence caveat when run cold, and one filled unknown payoff cells with illustrative numbers instead of flagging them. Precise, fixable gaps, not a vague score. The eval is non-deterministic, so the exact skills vary run to run, but the pattern - the evidence caveat is the single easiest element to drop - is stable.
+    The three misses were specific: two skills dropped the evidence caveat when run cold, and one filled unknown payoff cells with illustrative numbers instead of flagging them. Precise, fixable gaps, not a vague score - and all three were then tightened by construction (the caveat and a payoff-provenance line now ship from the template), verified by a targeted re-run. The eval is non-deterministic, so the exact skills vary run to run, but the pattern - the evidence caveat is the single easiest element to drop - is stable.
   </Card>
 </CardGrid>
 


### PR DESCRIPTION
One-clause update to the trust page (`does-this-work.mdx`): the 3 output-eval misses were fixed by construction in #70, so the page no longer reads as if they are open gaps. Full-run snapshot numbers (53/56) unchanged. Build 207pp, links/parity clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)