### PR TITLE
feat: Track B Showcase - the cross-library tfs -> pm-skills thread (9 pages)

### DIFF
--- a/docs/internal/plans/2026-06-17-track-b-showcase.md
+++ b/docs/internal/plans/2026-06-17-track-b-showcase.md
@@ -1,0 +1,276 @@
+# Plan: Track B Showcase (the cross-library, tfs -> pm-skills thread)
+
+**Status:** proposed, build-ready (not started).
+**Type:** content build (hand-authored narrative pages, same surface as the v0.8.0 Track A Showcase).
+**One line:** nine Showcase pages - three companies, three decisions each - that each end by handing the reasoning artifact off to the pm-skills delivery artifact it feeds, so a reader follows one company from a messy situation to a shipped feature across both libraries.
+
+## Why this, and what makes it different
+
+Track A (shipped in v0.8.0: Mira / Daniel / Priya, 16 journeys) proves *a framework produces a good artifact*. Track B proves the thing only the product-on-purpose ecosystem can show: **tfs decides, pm-skills delivers.** Each page is a normal Showcase journey plus one new section - **the handoff** - that names the pm-skills artifact the reasoning feeds. It is the conversion-side asset that sells the whole marketplace, not tfs alone.
+
+Sources of truth (already in the repo):
+- The cast: `docs/internal/SCENARIO_PROFILES.md`, "Track B" section (Storevine, Brainshelf, Workbench, with profiles and prompt styles).
+- The handoff map: `_local/content-plan/2026-06-12_content-plans_aggregated.md` section 3.5 (which tfs artifact feeds which pm-skills artifact).
+- The page format + definition of done: `docs/internal/CONTENT-STYLE.md` and the exemplar `site/src/content/docs/showcase/mira-launch-premortem.md`.
+
+## The model: a Track A page + a handoff section
+
+Every Track B page follows the **established Showcase unit** (CONTENT-STYLE "Showcase page" DoD), then adds one section:
+
+1. Blockquote intro: who, the decision, the prompting style.
+2. `## The situation`
+3. `## The prompt` - the verbatim prompt in the company's style, in a fenced block.
+4. `## The output` - the **full** artifact, filling the skill's `references/TEMPLATE.md` (not a stub).
+5. `## Why this prompt worked`
+6. `## The handoff to pm-skills` - **NEW.** One short section naming the pm-skills delivery artifact this reasoning feeds, and what crosses the boundary (the decision, the constraints, the risks). See "Handoff rules" below.
+7. `## Next in the thread` - link to the next Track B page for the same company (the last page links back to the Showcase index).
+
+**All concrete facts - the numbers, the named people, the timeline, the constraints - come from the company's thread fact-sheet (the section below), not invented per page.** That shared, frozen context is what makes three independently-authored pages read as one real company making three decisions, rather than three unrelated runs. The pages do NOT have to feed one artifact into the next (these tools are not that linear); they have to sit in the same consistent world.
+
+### Handoff rules (critical - keep the build green and the coupling honest)
+
+- **The handoff is prose, never a hyperlink.** pm-skills is a separate library on a separate site; per `SCENARIO_PROFILES.md` the handoff is "a narrative reference, never a build-validated link." Name the pm-skills artifact in backticks as plain text (e.g. "feeds pm-skills' `define-problem-statement`"), do **not** link it. This is also what keeps `check-rendered-links.mjs` green (an external/non-existent route would fail the guard).
+- **No technical coupling.** Content reuse only. Do not import, require, or cross-reference pm-skills files.
+- Name the pm-skills artifact exactly as the handoff map (section 3.5) gives it.
+
+## The page set (9 journeys + 1 index edit)
+
+Three companies, each a three-page thread that mirrors a real product arc (frame -> decide -> de-risk), each page a distinct shipped skill (nine distinct skills total), each handing off per the map.
+
+| # | File (`site/src/content/docs/showcase/`) | Company / style | tfs skill | pm-skills handoff |
+|---|---|---|---|---|
+| SB-1 | `storevine-restate-campaigns.md` | Storevine / organized | `think-problem-restatement` | `define-problem-statement` |
+| SB-2 | `storevine-build-vs-buy.md` | Storevine / organized | `think-decision-option-review` | `develop-adr` / `develop-solution-brief` |
+| SB-3 | `storevine-red-team-launch.md` | Storevine / organized | `think-red-team-light` | risks section of `deliver-prd` |
+| BR-1 | `brainshelf-boundary-resurface.md` | Brainshelf / casual | `think-boundary-critique` | `define-problem-statement` / `define-hypothesis` |
+| BR-2 | `brainshelf-forecast-adoption.md` | Brainshelf / casual | `think-reference-class-forecasting` | `foundation-okr-writer` |
+| BR-3 | `brainshelf-premortem-digest.md` | Brainshelf / casual | `think-premortem` | `deliver-launch-checklist` |
+| WB-1 | `workbench-stakeholder-matrix.md` | Workbench / enterprise | `think-ethical-matrix` | `discover-stakeholder-summary` + constraints in `deliver-acceptance-criteria` |
+| WB-2 | `workbench-issue-tree-adoption.md` | Workbench / enterprise | `think-issue-tree` | structures `discover-competitive-analysis` |
+| WB-3 | `workbench-gate-model-ev.md` | Workbench / enterprise | `think-expected-value-decision-tree` | `develop-adr` |
+
+Note `think-stakeholder-lens-review` (named in the map) is **not a shipped skill** (cut for overlap); WB-1 uses `think-ethical-matrix`, which ships and produces the stakeholder-by-value grid the handoff needs.
+
+## The thread fact-sheets (the carry-forward context)
+
+The risk in authoring three pages per company with independent subagents is that each invents its own specifics - team size, metrics, names - so the thread ends up consistent in voice but contradictory in fact. The fix is **one frozen fact-sheet per company**, the shared world every page in that thread draws from. It extends the `SCENARIO_PROFILES.md` Track B profile (which fixes only identity and voice) with the concrete recurring detail the profile omits.
+
+**These three fact-sheets are authoritative.** Every page-subagent for a company is primed with that company's fact-sheet; the numbers, names, and timeline below must be reused, not re-invented per page. Keep facts plausible for the company's stage; round numbers are fine. This is the carry-forward context - a shared consistent world, NOT artifacts feeding into each other.
+
+### Storevine - fact-sheet
+- **Company:** B2B ecommerce platform (merchants run storefronts on Storevine). Series A, 70 staff, ~$10M ARR, 15K active merchants (a long tail of SMBs plus a few hundred mid-market). Organized, process-led culture.
+- **The feature:** "Campaigns" - native email/SMS so merchants reach buyers without leaving Storevine. Today ~40% of merchants export contact lists to a third-party ESP (Klaviyo / Mailchimp).
+- **The cast:** Dana Okafor, Group PM for Growth (runs the frameworks; organized prompter). Sam Reyes, eng lead on the Growth pod. Leah Chen, infra / deliverability. The CEO's stated goal this year is merchant retention.
+- **The pod + budget:** the Growth pod = Dana + 3 engineers + 1 designer; the budget under discussion is ~one quarter (~13 weeks) of that pod.
+- **Where the thread sits:** Q3 planning. Campaigns is the candidate; build-vs-buy is open at the start; nothing is committed until the red-team (page 3).
+- **Non-negotiables / live tensions:** deliverability is a hard requirement (a bad sender reputation would hurt every merchant); mid-market merchants care about data control; the running tension is time-to-value vs deliverability risk vs margin (an ESP integration carries a per-message cost).
+
+### Brainshelf - fact-sheet
+- **Company:** consumer personal-knowledge app (notes plus saved articles). Post-seed (~$3M raised), 20 staff, 22K monthly actives out of ~140K registered. Casual, founder-led, ships fast.
+- **The feature:** "Resurface" - a morning digest that resurfaces old notes and saved items. The believed problem: people forget what they saved.
+- **The cast:** Theo Almeida, founder / CEO (casual prompter; makes the calls himself). Nina Park, the engineer who would build it. No PM layer; Theo decides.
+- **The team + budget:** the product trio = Theo + 2 engineers; ~1 month to a launchable Resurface.
+- **Where the thread sits:** a next-quarter bet. Whether Resurface is even the right framing is open at the start (page 1); by page 3 it is being launched.
+- **Recurring numbers:** ~8% of users currently keep notifications on; D30 retention is the metric Theo worries about; there is no comparable in-app digest yet, so adoption is a guess he refuses to fabricate.
+- **Non-negotiables / live tensions:** the digest must feel valuable, not naggy; the core tension is engagement vs notification fatigue / churn, on a small team with little eng to spare.
+
+### Workbench - fact-sheet
+- **Company:** enterprise collaboration platform (shared workspaces, docs, workflows). Series B (~$40M raised), 200 staff, ~500 enterprise customers; ~30% are in regulated industries that need audit trails (SOC2, change-control).
+- **The feature:** "Blueprints" - reusable templates that route through reviewers via approval gates before they publish.
+- **The cast:** Priyanka Rao, Principal PM, Enterprise (detailed, accountable prompter). Marcus Hale, eng lead. Dr. Elena Voss, security & compliance lead. A customer advisory board of ~12 enterprise admins informs the work.
+- **The pod + budget:** the Blueprints pod = Priyanka + 4 engineers + Elena (part-time); a half-year roadmap slot.
+- **Where the thread sits:** Blueprints (the templates) is already shipping; **approval gates** is the contested addition this thread decides. Enterprise demand for strict governance is uncertain and varies by segment.
+- **Non-negotiables / live tensions:** least-privilege and auditability are table stakes for the regulated ~30%; the live tensions are speed-of-authoring vs control, author autonomy vs least-privilege, and a configurable gate model's flexibility vs its maintenance cost.
+
+## Per-page specs
+
+Each spec below gives the agent everything needed to author the page with no further design decisions. Pull the concrete facts (numbers, named people, timeline, constraints) from the company's **thread fact-sheet above** - weave the named cast into the situation and the artifact (e.g. owners in a risk register, the PM in the framing); fill the named skill's `references/TEMPLATE.md` for the artifact.
+
+### SB-1 - `storevine-restate-campaigns.md`
+- **Frontmatter:** title "Storevine reframes a build request"; description "An ecommerce platform turns 'build native Campaigns' into the actual problem before committing a quarter of eng."; `sidebar.label: "Storevine -> restate"`.
+- **Company / style:** Storevine (B2B ecommerce, 70 staff, 15K merchants, building "Campaigns" native email/SMS). Organized: a structured block (situation, constraints, what was considered).
+- **Situation:** merchants keep exporting lists to a third-party ESP; the team's reflex is "build the feature they asked for." Before scoping, restate the problem.
+- **Prompt (verbatim, organized):**
+  ```
+  /think-problem-restatement "Situation: merchants keep exporting contact lists to Mailchimp
+  because we have no native email/SMS. Proposal on the table: build 'Campaigns' natively this
+  quarter. Constraints: 70-person team, 15K merchants, ~one quarter of eng capacity, deliverability
+  is a hard requirement. Considered so far: native build vs deep integration with an ESP. Before we
+  scope, restate the problem so we aren't just defaulting to 'build the feature they named.'"
+  ```
+- **Artifact:** fill `think-problem-restatement` TEMPLATE - several reframings of the problem and the chosen restatement (e.g. "merchants need campaigns to reach buyers without leaving Storevine" -> "the job is owned reach + attribution, not an email tool").
+- **Handoff:** the chosen restatement feeds pm-skills' `define-problem-statement` - the decision layer hands the framed problem to the delivery layer that writes the canonical statement.
+- **Next in thread:** SB-2 (`storevine-build-vs-buy`).
+
+### SB-2 - `storevine-build-vs-buy.md`
+- **Frontmatter:** title "Storevine weighs build vs buy vs partner"; description "A weighted option matrix on Campaigns - native build, ESP integration, or partner - with an honest sensitivity note."; `sidebar.label: "Storevine -> build vs buy"`.
+- **Situation:** with the problem restated (SB-1), three real options: build natively, integrate an ESP under the hood, or partner/white-label.
+- **Prompt (organized):**
+  ```
+  /think-decision-option-review "Decision: how to deliver Campaigns. Options: (a) build native
+  email/SMS, (b) integrate an ESP under our UI, (c) partner/white-label. Criteria that matter:
+  time-to-value for merchants, deliverability risk, gross margin, eng load this quarter, and merchant
+  trust/data control. Give me a weighted matrix and tell me how sensitive the pick is to the weights."
+  ```
+- **Artifact:** fill `think-decision-option-review` TEMPLATE - criteria, weights, scored options, the pick, and the sensitivity note.
+- **Handoff:** the chosen option and its rationale feed pm-skills' `develop-adr` (the architecture decision record) and `develop-solution-brief`.
+- **Next in thread:** SB-3.
+
+### SB-3 - `storevine-red-team-launch.md`
+- **Frontmatter:** title "Storevine red-teams the Campaigns launch"; description "Before committing the quarter, the strongest case against shipping Campaigns, ranked by damage."; `sidebar.label: "Storevine -> red-team"`.
+- **Situation:** option chosen (SB-2); before the quarter is committed, stress the decision.
+- **Prompt (organized):**
+  ```
+  /think-red-team-light "We've decided to build Campaigns natively this quarter. Before we commit,
+  argue the strongest honest case against it - deliverability, support load, margin, merchant churn
+  risk - and rank the objections by how much damage each does if true."
+  ```
+- **Artifact:** fill `think-red-team-light` TEMPLATE - thesis stated fairly, ranked steelmanned objections, the can-it-answer column, verdict.
+- **Handoff:** the ranked objections feed the **risks section of pm-skills' `deliver-prd`** - the decision layer's red-team becomes the delivery doc's risk register.
+- **Next in thread:** back to the Showcase index (thread complete).
+
+### BR-1 - `brainshelf-boundary-resurface.md`
+- **Frontmatter:** title "Brainshelf draws the boundary on a digest"; description "A consumer note app checks whether a morning digest is even the right problem before building it."; `sidebar.label: "Brainshelf -> boundary"`.
+- **Company / style:** Brainshelf (consumer PKM, 20 staff, 22K MAU, building "Resurface" morning digest). Casual: a sentence or two, first person.
+- **Prompt (casual):**
+  ```
+  /think-boundary-critique "thinking about a morning digest ('Resurface') that resurfaces old notes.
+  but i'm not sure that's the real problem - people say they forget what they saved. help me draw
+  the boundary on what this is and isn't before we build it."
+  ```
+- **Artifact:** fill `think-boundary-critique` TEMPLATE - what is in / out of the system, whose framing is privileged, what the "digest" frame excludes (e.g. search, surfacing-in-context).
+- **Handoff:** the bounded problem feeds pm-skills' `define-problem-statement` and `define-hypothesis`.
+- **Next in thread:** BR-2.
+
+### BR-2 - `brainshelf-forecast-adoption.md`
+- **Frontmatter:** title "Brainshelf forecasts digest adoption from the outside"; description "Before setting an OKR, the base rate for daily-digest open rates instead of a hoped-for number."; `sidebar.label: "Brainshelf -> forecast"`.
+- **Prompt (casual):**
+  ```
+  /think-reference-class-forecasting "before we set a goal for Resurface i don't want to make up a
+  number. of our 22k users, what share will actually open a daily digest? what do comparable
+  digest / morning-summary / notification features actually get?"
+  ```
+- **Artifact:** fill `think-reference-class-forecasting` TEMPLATE - the reference class, the base rate (outside view), the case-specific adjustment, the forecast with its honesty caveat.
+- **Handoff:** the realistic range feeds pm-skills' `foundation-okr-writer` - a target grounded in a base rate, not optimism.
+- **Next in thread:** BR-3.
+
+### BR-3 - `brainshelf-premortem-digest.md`
+- **Frontmatter:** title "Brainshelf premortems the Resurface launch"; description "A casual one-line premortem yields a ranked risk register with tripwires for the digest launch."; `sidebar.label: "Brainshelf -> premortem"`.
+- **Prompt (casual):**
+  ```
+  /think-premortem "we're shipping Resurface (the morning digest) in a month. nervous it just becomes
+  notification spam people mute, or worse, makes the app feel naggy. what kills this?"
+  ```
+- **Artifact:** fill `think-premortem` TEMPLATE - the failure declared in past tense, ranked causes, each with a tripwire and kill criterion. (Carry the pre-printed evidence-caveat element.)
+- **Handoff:** the risk register feeds pm-skills' `deliver-launch-checklist` - each tripwire becomes a launch gate.
+- **Next in thread:** back to the Showcase index.
+
+### WB-1 - `workbench-stakeholder-matrix.md`
+- **Frontmatter:** title "Workbench maps stakeholders before approval gates"; description "An enterprise tool grids stakeholders against values before writing acceptance criteria for approval gates."; `sidebar.label: "Workbench -> stakeholders"`.
+- **Company / style:** Workbench (enterprise collaboration, 200 staff, 500 customers, building "Blueprints" templates + approval gates). Enterprise: detailed, formal, names roles and accountability.
+- **Prompt (detailed / enterprise):**
+  ```
+  /think-ethical-matrix "We're adding approval gates to Blueprints (templates that route through
+  reviewers before publish). Stakeholders: template authors, approvers/admins, end users who consume
+  published blueprints, and customer compliance/IT. Values in tension: speed of authoring, control
+  and auditability, autonomy of authors, and least-privilege. Map stakeholders against these values
+  before we write acceptance criteria, so we see whose interests the gate design trades off."
+  ```
+- **Artifact:** fill `think-ethical-matrix` TEMPLATE - the stakeholder-by-value grid, the conflicts surfaced, no single "right" answer manufactured.
+- **Handoff:** the grid feeds pm-skills' `discover-stakeholder-summary`, and its tensions become constraints in `deliver-acceptance-criteria`.
+- **Next in thread:** WB-2.
+
+### WB-2 - `workbench-issue-tree-adoption.md`
+- **Frontmatter:** title "Workbench structures the adoption question"; description "A MECE issue tree breaking 'will enterprises adopt Blueprints?' into what must be true."; `sidebar.label: "Workbench -> issue tree"`.
+- **Prompt (enterprise):**
+  ```
+  /think-issue-tree "Question: will our enterprise customers adopt Blueprints with approval gates?
+  Break it into a MECE tree of what must be true - admin demand for governance, fit with their
+  compliance regimes, migration cost off their current process, and competitive parity - so we know
+  what discovery to run."
+  ```
+- **Artifact:** fill `think-issue-tree` TEMPLATE - the MECE decomposition, the load-bearing branches flagged.
+- **Handoff:** the tree structures pm-skills' `discover-competitive-analysis` (each branch becomes a discovery question).
+- **Next in thread:** WB-3.
+
+### WB-3 - `workbench-gate-model-ev.md`
+- **Frontmatter:** title "Workbench prices the approval-gate model"; description "An expected-value decision tree on lightweight vs strict vs configurable approval gates under uncertain demand."; `sidebar.label: "Workbench -> EV tree"`.
+- **Prompt (enterprise):**
+  ```
+  /think-expected-value-decision-tree "Decide the approval-gate model for Blueprints: (a) lightweight
+  single-approver, (b) strict multi-stage, (c) configurable per-workspace. Enterprise demand for
+  strictness is uncertain - some segments need SOC2-grade audit trails, some want speed. Model the
+  chance nodes (high vs low governance demand) and roll back an expected value for each option."
+  ```
+- **Artifact:** fill `think-expected-value-decision-tree` TEMPLATE - decision and chance nodes, payoffs, probabilities that sum to one, the rolled-back EV, and the pick. (Flag any estimated inputs honestly.)
+- **Handoff:** the chosen model and its rationale feed pm-skills' `develop-adr`.
+- **Next in thread:** back to the Showcase index.
+
+## The index edit - `site/src/content/docs/showcase/index.md`
+
+Add a third browse section after "Browse by person", before "Browse by what you want to produce":
+
+```
+## Browse by company (cross-library: tfs decides, pm-skills delivers)
+
+Three companies take one feature each from a raw idea to a launch decision, then hand off to the
+delivery work in pm-skills. Follow a company down its thread to see the whole arc.
+
+### Storevine - a native Campaigns feature (organized prompts)
+- [Reframe the build request](./storevine-restate-campaigns/) -> pm-skills define-problem-statement
+- [Build vs buy vs partner](./storevine-build-vs-buy/) -> pm-skills develop-adr
+- [Red-team the launch](./storevine-red-team-launch/) -> the risks in pm-skills deliver-prd
+
+### Brainshelf - a morning digest (casual prompts)
+- [Draw the boundary](./brainshelf-boundary-resurface/) -> pm-skills define-problem-statement
+- [Forecast adoption from the outside](./brainshelf-forecast-adoption/) -> pm-skills foundation-okr-writer
+- [Premortem the launch](./brainshelf-premortem-digest/) -> pm-skills deliver-launch-checklist
+
+### Workbench - approval gates (enterprise prompts)
+- [Map stakeholders against values](./workbench-stakeholder-matrix/) -> pm-skills deliver-acceptance-criteria
+- [Structure the adoption question](./workbench-issue-tree-adoption/) -> pm-skills discover-competitive-analysis
+- [Price the gate model](./workbench-gate-model-ev/) -> pm-skills develop-adr
+```
+
+(The internal `./...` links are real Track B routes; the "-> pm-skills ..." names are plain text, not links.) Update the index `description` frontmatter to mention the cross-library track. Leave the Northwind anchor and the Track A sections untouched.
+
+## Agentic execution - the authoring Workflow
+
+Mirror the v0.8.0 Track A method (parallel subagents primed with a fixed context), batched to stay throttle-safe.
+
+1. **Pre-flight (deterministic, no agents):** confirm the 9 skills are shipped (done: all but `stakeholder-lens-review`, already swapped to `ethical-matrix`). Read each target skill's `SKILL.md`, `references/TEMPLATE.md`, and `references/EXAMPLE.md` so the artifacts match the template. The three **thread fact-sheets are already drafted in this plan** (above) - no authoring step needed; they are the frozen shared context. (If a fact-sheet needs richer detail, expand it here ONCE, before fan-out, so all three of a company's pages see the same version.)
+2. **Author pages - one subagent per page**, run as a `Workflow` over the 9 specs in serial groups of ~4 (the burst-throttle rule). Prime each subagent with, and only with:
+   - the exemplar page `showcase/mira-launch-premortem.md` (the format),
+   - this page's spec row + per-page section (above),
+   - the protagonist's profile from `SCENARIO_PROFILES.md`,
+   - **the company's thread fact-sheet (this plan)** - the authoritative numbers, names, timeline, and tensions to reuse,
+   - the target skill's `SKILL.md` + `references/TEMPLATE.md` + `references/EXAMPLE.md` (so the artifact is correct and concrete),
+   - `docs/internal/CONTENT-STYLE.md` (voice, the no-dash rule, the Showcase DoD, the link rules),
+   - the **handoff rules** (prose not link; exact pm-skills artifact name).
+   Each subagent writes exactly its own `site/src/content/docs/showcase/<file>.md` and returns nothing else.
+3. **Assemble the index** centrally (one edit, above) - do not let the page subagents touch `index.md` (avoid a write race).
+4. **Build + guard + fix loop** (below). Any page that fails the link guard or the DoD goes back to a single re-author subagent with the failure.
+
+The subagents write prose only; no registry, manifest, or generator changes - so the conformance gate is untouched by the page content itself.
+
+## Verification and definition of done
+
+- **Per page (CONTENT-STYLE Showcase DoD):** the three-part unit + handoff + next; the artifact matches the skill's `TEMPLATE.md` and is concrete and self-consistent; the protagonist's established voice/style; scenario distinct from Northwind and from the Track A pages; frontmatter has `title`, `description`, `sidebar.label`; internal links real and trailing-slashed; **handoff is prose, not a link**; any cold-run skill ships its evidence caveat in the artifact.
+- **Per thread (the carry-forward check):** the numbers, named people, timeline, and constraints across a company's three pages all match its thread fact-sheet - no contradictions (the same team size, the same cast, the same stage of the decision). Read the three pages of a thread together before sign-off; this is the check the fact-sheet exists to make pass.
+- **Build + guards:** `npm --prefix site run build` (now ~216 pages: 207 + 9); `STRICT_ANCHORS=1 node scripts/check-rendered-links.mjs site/dist` = 0 broken; `node scripts/check-route-parity.mjs site/dist` PASS (new routes are additive; the guard only fails on *removed* baseline routes, so no `route-manifest.txt` edit is needed).
+- **Gate:** `node scripts/check.mjs` 0/0 - unchanged, since no skills/registry/catalog changed. (Side effect to note, not required: a Showcase appearance counts for the example-coverage ratchet, so SB/BR/WB skills that were grandfathered may now have an example; the ratchet only *improves*.)
+- `npm test` green.
+- **No version bump / no marketplace re-pin** - site content only, the plugin (`skills/`) is unchanged.
+
+## Scope and phasing
+
+- **This plan = the core 9** (three full company threads). It is the complete, buildable Track B v1.
+- **Optional later:** a fourth journey per company (the handoff map has more pairs - e.g. `think-after-action-review` -> `iterate-pivot-decision`, `think-theory-of-constraints` -> `iterate-retrospective`); a "browse by handoff" table in the index; deep-linking once pm-skills exposes stable public artifact URLs (today the handoff is deliberately prose).
+- **Release:** ships as a docs/site update (a patch-style cut or folded into the next release PR), following `docs/internal/release-process.md`. No catalog count change.
+
+## Sources
+
+- `docs/internal/SCENARIO_PROFILES.md` (Track B cast).
+- `_local/content-plan/2026-06-12_content-plans_aggregated.md` section 3.5 (the handoff map) and the five-things shortlist.
+- `docs/internal/CONTENT-STYLE.md` (DoD) and `site/src/content/docs/showcase/mira-launch-premortem.md` (exemplar).
+- `docs/internal/release-plans/plan_v0.8.0/README.md` (Track A as built; Track B listed as the deferred follow-on).

--- a/scripts/example-coverage-baseline.txt
+++ b/scripts/example-coverage-baseline.txt
@@ -4,7 +4,6 @@ assumption-reversal
 authentic-dissent
 backcasting
 belief-update-routine
-boundary-critique
 brainwriting
 causal-layered-analysis
 concept-mapping
@@ -12,7 +11,6 @@ consider-the-unknowns
 contradiction-resolution
 contradiction-tension-mapping
 dialectical-bootstrapping
-expected-value-decision-tree
 far-analogy-ideation
 fermi-estimation
 frame-creation
@@ -26,8 +24,6 @@ one-way-vs-two-way-door
 parallel-perspectives-review
 pyramid-principle
 question-burst
-red-team-light
-reference-class-forecasting
 role-storming
 scamper
 scenario-planning

--- a/site/src/content/docs/showcase/brainshelf-boundary-resurface.md
+++ b/site/src/content/docs/showcase/brainshelf-boundary-resurface.md
@@ -1,0 +1,76 @@
+---
+title: "Brainshelf draws the boundary on a digest"
+description: A consumer note app checks whether a morning digest is even the right problem before building it.
+sidebar:
+  label: "Brainshelf -> boundary"
+---
+
+> **Theo Almeida**, founder and CEO of Brainshelf, a 20-person post-seed consumer note app. The decision: whether "Resurface," a morning digest of old notes, is even the right problem to solve. Prompting style: casual.
+
+This is a complete run, prompt to artifact. Framework: [Boundary Critique](../../frameworks/think-boundary-critique/). For the cast and the other journeys, see the [Showcase index](../).
+
+## The situation
+
+Brainshelf has 22K monthly actives out of ~140K registered, and Theo keeps hearing the same complaint: people forget what they saved. The obvious next bet is "Resurface," a morning digest that pushes old notes and saved articles back at users. Nina Park, the engineer who would build it, has it roughly scoped to a month. But Theo has been around long enough to be suspicious of the obvious bet. Before he points the product trio at a month of work, he wants to know whether "morning digest" is even the right frame, or whether he is about to solve a tidy problem for a frame that has already quietly decided who matters. He types what is on his mind.
+
+## The prompt
+
+```
+/think-boundary-critique "thinking about a morning digest ('Resurface') that resurfaces old notes.
+but i'm not sure that's the real problem - people say they forget what they saved. help me draw
+the boundary on what this is and isn't before we build it."
+```
+
+That is the whole prompt. Casual, first person, the doubt named plainly. The framework supplies the audit.
+
+## The output
+
+> **Boundary-Judgment Audit - "Resurface" morning digest**
+
+## Frame under audit
+
+- **Frame as given:** "Build 'Resurface,' a morning push digest that resurfaces old notes and saved articles, because people forget what they saved."
+- **Improvement it claims:** Re-engagement - users open the app more often and re-encounter saved value, lifting D30 retention.
+- **The user's actual goal:** People get value out of what they already saved, at the moment it would actually help them, without the app becoming a thing they mute or resent.
+
+## Summary (top of the artifact)
+
+The Resurface frame is drawn tightly around one beneficiary (Brainshelf's retention metric) and one delivery mechanism (a scheduled morning push). Audited in is/ought terms, three boundary judgments show real gaps: the beneficiary is the D30 number rather than the user's actual recall problem (motivation); the decision sits with Theo and the growth instinct, while the ~92% of users who keep notifications off, and the support load Nina would carry, are outside the decision environment (power); and the worldview treated as authoritative is "more opens is better," which has no standing for the user who wants to find a note when they need it rather than be pushed one each morning (knowledge and legitimacy). The most consequential affected-but-excluded parties are the notifications-off majority, for whom a push digest is invisible or unwelcome, and the user who forgets a note in context (mid-task) rather than at 8am. **This audit surfaces those boundary questions; it does not decide whether to build Resurface.** It hands the digest-versus-recall and the push-versus-in-context gaps to a decision step, with the excluded parties now on the table.
+
+## The four sources (is vs ought)
+
+| Source (boundary question) | Is (how the frame draws it now) | Ought (how it should) | Gap |
+|---|---|---|---|
+| **Motivation - who benefits** (client/beneficiary; purpose; measure of success) | The beneficiary is *Brainshelf's D30 retention*; the purpose is more app opens; success is digest open rate. The "improvement" is the retention chart, full stop. | The beneficiary should be the *user who saved something and wants it back when it helps*. Success should be "the user actually re-used a saved item usefully," not "the user opened a push." | **Large.** The frame optimizes Theo's retention number and treats the recall complaint as a reason to send a push, not as the problem to solve on its own terms. |
+| **Power/control - who decides** (decision-maker; what is controlled; the decision environment) | Theo decides, on the growth instinct; the digest schedule and content are under the product trio's control. The ~92% of users who keep notifications off, and Nina's support and maintenance load, are treated as the *environment* - outside the decision. | The notifications-off majority should shape the decision (a push-only feature cannot reach them), and Nina - who carries the build and the "why is this app nagging me" tickets - should have a real seat, because the decision spends *her* month and her on-call patience. | **Large.** The person deciding is reasoning from the 8% who allow pushes; the feature's reach and its cost both live outside the frame he is deciding inside. |
+| **Knowledge - whose expertise counts** (who is expert; what expertise applies; the assumed guarantors) | Founder intuition and the "people forget what they saved" anecdote are authoritative. The assumed guarantor is "a daily digest will fix forgetting." | The user's *moment of need* (when and where they actually want a forgotten note) should count, and so should the eng read on notification fatigue. "A morning push fixes forgetting" is a *false guarantor* if the real need is in-context surfacing or better search. | **Moderate-to-large.** The expertise admitted is the expertise that supports a digest; the knowledge that would surface search, in-context resurfacing, or "they forget mid-task, not at breakfast" is outside the frame. |
+| **Legitimacy - who has standing** (witness for the affected-not-involved; authoritative worldview; reconciling worldviews) | The authoritative worldview is "more opens is better; a daily touchpoint is healthy engagement." Standing belongs to whatever moves D30. | The user who wants *quiet, reliable retrieval* (no push, just the note when searched for) and the user who finds a digest naggy should have standing. Someone must witness for them, since neither is in the room and neither shows up in an open-rate metric. | **Large.** No one currently witnesses for the affected-but-excluded; the engagement worldview has no category for "a user helped by never being pushed at all." |
+
+## Affected-but-excluded
+
+The move the rest of the library does not have. List the parties with a real stake in the consequences who hold no seat, no voice, and no expertise-standing inside the frame. These are not in-scope stakeholders to be voiced - they are outside the line.
+
+| Affected-but-excluded party | Stake in the consequences | Who (if anyone) witnesses for them now |
+|---|---|---|
+| **The notifications-off majority (~92% of users)** | A push-only digest is invisible to them, so a feature justified by "people forget" reaches the people least able to receive it; if Brainshelf escalates to re-prompt for notification permission, they get nagged. | No one - the frame reasons from the 8% who allow pushes and treats the rest as a conversion target, not a constituency. |
+| **The in-context forgetter (forgets mid-task, not at 8am)** | Their real need is to find a saved note *when it is relevant* (search, surfacing while writing a related note), which a fixed morning digest cannot serve; the digest frame spends the month without touching their problem. | No one - the digest worldview has no standing for a need that does not arrive on a morning schedule. |
+| **The notification-fatigued / churn-risk user** | A digest that feels naggy is exactly the trigger that makes a small consumer app get muted or deleted; this user bears the downside of the engagement bet but has no voice in the frame that optimizes opens. | No one - the open-rate metric counts the open, never the resentment or the uninstall that follows. |
+| **Nina (eng) and the support load** | Absorbs the build, the maintenance, and the "stop nagging me" tickets the digest creates, on a trio with little eng to spare and a one-month budget. | Partially - only if her load is forced into the decision rather than left in the environment. |
+
+## What this audit does NOT do
+
+- **It surfaces the boundary question; it does not adjudicate it.** Whether Brainshelf *should* build Resurface is still open. What the audit establishes is that the current frame answers "whose improvement, decided by whom, on whose knowledge, with whose standing" in a way that excludes the people the recall complaint actually came from - so a build decision made inside this frame would optimize morning opens for the 8% while leaving the in-context forgetter and the notifications-off majority unserved, and risk nagging the very users it means to retain.
+- **Onward route (where a real gap exists):** take the widened frame to `think-decision-option-review` - compare "morning push digest as framed," "in-context resurfacing / better search," and "a quiet, opt-in digest" *with the excluded parties' stakes now on the table* - so the choice is made under the real boundary rather than the tidy one. The audit informs that decision; it is not the decision.
+- **Evidence caveat:** this audit surfaces who the frame illegitimately includes or excludes, descriptively versus normatively. The method's evidence is conceptual (tier C) and transferred from human practice; it is not a measured improvement in decisions.
+
+## Why this prompt worked
+
+Theo did not over-specify. He named the **proposal** ("morning digest"), named the **doubt** ("not sure that's the real problem"), and named the **observed evidence** ("people say they forget what they saved"). That triple - a frame, a suspicion the frame is wrong, and the raw complaint the frame was built on - is exactly what boundary critique needs to take the frame itself as the suspect object. The framework did the rest: it separated the user's actual goal (re-use saved value) from the frame's beneficiary (the retention metric), audited each boundary judgment in is and ought modes, and surfaced the parties a normal stakeholder walk-through of the product trio could never reach - the notifications-off majority and the in-context forgetter, both outside the line the digest frame had already drawn.
+
+## The handoff to pm-skills
+
+The bounded problem crosses into pm-skills' `define-problem-statement` and `define-hypothesis`. What the decision layer hands over is not "build a digest" but the audited frame: the actual goal (users re-use saved value at the moment it helps), the boundary gaps that a digest-shaped statement would paper over (push reaches only ~8%; the real forgetting may be in-context, not morning), and the affected-but-excluded parties the eventual problem statement and hypothesis must not silently exclude. The delivery layer writes the canonical problem statement and the testable hypothesis against the wider frame, not the tidy one.
+
+## Next in the thread
+
+Theo has a frame he trusts, but no number for how many users would actually engage. Next in the thread: he refuses to invent an adoption target and forecasts it from the outside in [Brainshelf forecasts digest adoption](../brainshelf-forecast-adoption/).

--- a/site/src/content/docs/showcase/brainshelf-forecast-adoption.md
+++ b/site/src/content/docs/showcase/brainshelf-forecast-adoption.md
@@ -1,0 +1,66 @@
+---
+title: "Brainshelf forecasts digest adoption from the outside"
+description: Before setting an OKR, the base rate for daily-digest open rates instead of a hoped-for number.
+sidebar:
+  label: "Brainshelf -> forecast"
+---
+
+> **Theo Almeida**, founder and CEO of Brainshelf, a 20-person consumer notes app. The decision: what adoption target to set for "Resurface," a morning digest shipping next quarter. Prompting style: casual.
+
+This is a complete run, prompt to artifact. Framework: [Reference Class Forecasting](../../frameworks/think-reference-class-forecasting/). For the cast and the other journeys, see the [Showcase index](../).
+
+## The situation
+
+Brainshelf has 22K monthly actives out of ~140K registered, and Theo's metric of record is D30 retention. Resurface is the next-quarter bet: a morning digest that resurfaces old notes and saved items. Nina Park, the engineer who would build it, has about a month of runway scoped. Before Theo sets a goal, he wants a number he can defend. The trouble is there is no comparable in-app digest in the product yet, so he has no internal data to anchor on, and he flatly refuses to make one up. Roughly 8% of users keep notifications on today, which he suspects is the real ceiling. He types the question the way he thinks it.
+
+## The prompt
+
+```
+/think-reference-class-forecasting "before we set a goal for Resurface i don't want to make up a
+number. of our 22k users, what share will actually open a daily digest? what do comparable
+digest / morning-summary / notification features actually get?"
+```
+
+That is the whole prompt. Casual, first person, the decision and the thing he refuses to do (invent a number). The framework supplies the outside view.
+
+## The output
+
+> **Reference-Class Estimate - Resurface daily-digest adoption**
+
+## What is being forecast
+
+- **Quantity:** the share of Brainshelf's 22K monthly actives who open the Resurface daily digest in a given week (the open / engagement rate), and what that implies for a launch OKR.
+- **Inside-view estimate (if any):** none committed on purpose. Theo's gut ceiling is "~8%, because that is how many keep notifications on," but he has refused to set a target off a hoped-for number, which is why this run exists.
+
+## Reference class
+
+- **The class:** published engagement rates for recurring consumer digest / morning-summary / re-engagement features that arrive by push or email - daily-summary push notifications in consumer apps, "on this day" / resurfacing features (photos, social), and editorial morning-briefing digests. Brainshelf has no in-product digest of its own, so the class is necessarily external precedents, not Brainshelf's own history.
+- **Why comparable:** all are unprompted, recurring, low-commitment nudges to re-open an app or read a summary the user did not explicitly request that morning - the same behavior Resurface asks for. The class is deliberately not narrowed to a single flattering success story (e.g. one viral "On This Day" launch); it spans typical performers so the base rate is not cherry-picked.
+
+## Base rates
+
+- **Data source:** FLAG - external proxies, not Brainshelf data. These are published industry ranges for consumer push-notification open rates and recurring email-digest engagement, plus reported figures for resurfacing features. They are real, but they are other companies' numbers; Brainshelf has zero internal base rate because Resurface does not exist yet. Treat the numbers as a directional outside view, not a measured fact about Brainshelf's users.
+- **Typical outcome:** recurring daily-digest and summary features in consumer apps commonly see single-digit to low-double-digit weekly open rates among the eligible base - roughly 5% to 15% engaging in a typical week once novelty fades. Brainshelf's own ~8% notification opt-in rate sits squarely inside that band and acts as a hard upper bound on push-delivered reach.
+- **Worst-case / tail:** the realistic bad end is a digest that spikes for a week or two on novelty, then settles to 2% to 4% sustained while quietly raising mute and uninstall rates - the "naggy notification people turn off" failure. A few resurfacing features do break 20%, but those are the flattering tail, not the median, and depend on content people already love (photos of their kids), which Brainshelf has not demonstrated for old notes.
+
+## Outside-anchored estimate
+
+- **Anchored estimate (range):** ~5% to 12% of monthly actives opening Resurface in a typical week after the novelty period - centered around 8%, capped by the current notification opt-in ceiling.
+- **Conservative adjustment for specifics:** two small, justified nudges, no return to optimism. Down: only ~8% keep notifications on, so push-delivered reach cannot exceed that without first moving opt-in; an in-app or email surface could lift the ceiling but is not yet built. Slight up: Resurface targets engaged actives (people who already save notes), a more receptive audience than a cold base, which nudges the engaged-cohort rate toward the upper half of the band. Resisted the inside-view pull to assume "our users love their notes, so this will overperform the class."
+- **Final forecast:** ~5% to 12% weekly open rate post-novelty, with a planning center near 8%, low-to-moderate confidence. The main uncertainty is the notification opt-in ceiling and whether the digest earns its place or gets muted. Implication for the OKR: a launch target like "10% of monthly actives open Resurface weekly by day 60, with mute rate held under [X]%" is defensible against this class; a target of 30%-plus would be setting up to miss. Pair the open-rate target with a guardrail metric (mute / opt-out and D30 retention) so adoption is not bought at the cost of churn.
+
+---
+
+*Note: the value here is refusing to invent Brainshelf's number and anchoring on what comparable digests actually get (~5% to 12%, with an 8% opt-in ceiling). The honesty rule is load-bearing: these base rates are external proxies, not Brainshelf data, because Resurface has no history yet - the right move is to flag that and forecast a range, not to dress up a guess as a measurement. This pairs naturally with a premortem on the "people just mute it" failure.*
+
+## Why this prompt worked
+
+It named the **decision** (set a goal for Resurface), the **quantity** (what share of 22K open a daily digest), and - critically - the **constraint** ("i don't want to make up a number"). That last clause is what the framework is built for: it forced the outside view instead of an inside-view guess. With no internal data to anchor on, the method did the honest thing - reached for a published reference class, flagged the base rates as external proxies rather than Brainshelf's own, and returned a defensible range with its ceiling and uncertainty named. Theo did not have to supply a methodology or a spreadsheet; he had to supply the one thing he had, which was a refusal to fabricate.
+
+## The handoff to pm-skills
+
+The realistic range crosses into pm-skills' `foundation-okr-writer`. What hands off is a target grounded in a base rate rather than optimism: the key result becomes "10% of monthly actives open Resurface weekly by day 60" anchored on the 5% to 12% class, with the 8% notification ceiling carried over as a known constraint and the mute / opt-out and D30 retention guardrails carried over as the risks the target must not trade away. The decision layer says how ambitious is honest; the delivery layer writes the objective and key results around that, so the OKR is set against evidence instead of hope.
+
+## Next in the thread
+
+With the target grounded, Theo turns to what could sink the launch. Next in his thread: he premortems the Resurface launch in [Brainshelf premortems the Resurface launch](../brainshelf-premortem-digest/).

--- a/site/src/content/docs/showcase/brainshelf-premortem-digest.md
+++ b/site/src/content/docs/showcase/brainshelf-premortem-digest.md
@@ -1,0 +1,60 @@
+---
+title: "Brainshelf premortems the Resurface launch"
+description: A casual one-line premortem yields a ranked risk register with tripwires for the digest launch.
+sidebar:
+  label: "Brainshelf -> premortem"
+---
+
+> **Theo Almeida**, founder and CEO of Brainshelf, a 20-person consumer note app. The decision: ship "Resurface," a morning digest, in a month. Prompting style: casual.
+
+This is a complete run, prompt to artifact. Framework: [Premortem](../../frameworks/think-premortem/). For the cast and the other journeys, see the [Showcase index](../).
+
+## The situation
+
+Brainshelf is shipping Resurface, a morning digest that resurfaces old notes and saved articles, in about a month. By now Theo has bounded the problem and forecast adoption from the outside; the bet is made and Nina Park is building it. What is left is the part Theo trusts least: a launch on a 20-person team where ~8% of users keep notifications on, where the digest could just as easily read as nagging. He does not write a brief. He types the worry that is keeping him up.
+
+## The prompt
+
+```
+/think-premortem "we're shipping Resurface (the morning digest) in a month. nervous it just becomes
+notification spam people mute, or worse, makes the app feel naggy. what kills this?"
+```
+
+That is the whole prompt. Casual, one situation, the two worries on his mind. The framework supplies the rest.
+
+## The output
+
+> **Premortem Risk Register - Resurface launch**
+
+**Decision:** Ship Resurface, a daily morning digest that resurfaces old notes and saved items, to all Brainshelf users in one month.
+**Intended outcome:** Resurface lifts daily engagement and D30 retention by giving people a reason to return, without driving notification opt-outs or making the app feel naggy.
+**Horizon:** 3 months after launch.
+**Reversibility:** Two-way door on the feature, one-way door on trust. We can pull or soften the digest, but a wave of notification opt-outs or uninstalls does not come back when we do.
+
+**The failure, declared.** *It is three months after launch. Resurface shipped on time and it failed quietly. The notification opt-in rate fell from ~8% toward 5% as people muted the digest within the first week; the users who kept it on opened it a few times and then stopped, so daily opens are back to where they were pre-launch. D30 retention did not move. Worse, our app-store reviews picked up a thread of "stop nagging me" complaints, and Nina spent three of her four launch weeks tuning notification timing instead of the content that would have made the digest worth opening.*
+
+**Top risks and what we will do.** The three most likely ways this dies: (1) the digest **feels naggy, so people mute notifications** and we lose the channel - we will ship a one-tap frequency control and a quiet default, and treat the opt-out rate as a launch tripwire, not a post-launch metric; (2) the **content is not worth opening** because we resurface stale or random notes - we will rank what surfaces by recency and save-signal before launch and watch open-through rate from day one; (3) **the small team over-invests in delivery plumbing** (timing, channels) and under-invests in whether the digest is good - we will timebox the plumbing and protect Nina's time for content quality. Each has a tripwire and a kill criterion below.
+
+| # | Cause of failure | Likelihood | Impact | Leading signal / tripwire | Mitigation | Owner | Kill criterion |
+|---|---|---|---|---|---|---|---|
+| 1 | The digest reads as naggy, so users mute notifications and we lose the channel | H | H | Notification opt-out rate among Resurface recipients above 3% in week 1; "stop nagging" sentiment in reviews | Quiet, low-frequency default; one-tap frequency control (daily / weekly / off) in the digest itself; soft in-app intro before the first push | Theo | Opt-in rate falls below 6% (from ~8%) within 2 weeks and is attributable to Resurface |
+| 2 | What we surface is not worth opening (stale, random, or already-seen notes) | H | H | Digest open-through rate below 25% by week 2; opens decline week over week among opted-in users | Rank surfaced items by recency + save-signal before launch; cap at a few high-signal items; suppress items seen recently | Nina | Open-through rate stays below 20% for 3 straight weeks with no content fix in flight |
+| 3 | The 3-person product trio burns the month on notification plumbing, not digest quality | M | H | By week 2, most of Nina's time is on timing/channel work; the ranking logic is still unstarted | Timebox delivery plumbing to week 1; freeze it; protect at least half of Nina's remaining weeks for content/ranking | Theo | Ranking logic not testable by the week-3 internal check, forcing a thin random-surface launch |
+| 4 | Early adopters try it, see no lasting value, and churn - D30 does not move | M | H | Week-4 D30 for the launch cohort flat vs the pre-launch baseline; opened-once-then-stopped pattern dominates | Instrument repeat-open, not just first-open, from day one; ship a "why am I seeing this" line so value is legible | Theo | After 8 weeks, D30 for Resurface-exposed users is no better than the pre-launch baseline |
+| 5 | A timing/delivery bug makes the digest land at 3am or duplicate, poisoning first impressions | M | M | QA finds timezone or duplicate-send edge cases in week 3; no staged rollout planned | Send to an internal + small beta cohort first; verify timezone handling; cap to one send per user per day | Nina | Duplicate or off-hours sends reach real users at launch, or the timezone test is not green by launch-minus-3-days |
+
+**Watch list.** Digest cannibalizes ordinary app opens (people read the summary instead of opening Brainshelf) - monitor, likely minor at this scale. Saved-article licensing/preview edge cases in the digest - low likelihood, standard handling. Brand read ("another app pinging me") - tied to risk 1, covered by the quiet default.
+
+*Evidence note: a premortem reliably surfaces more and more specific risks and reduces overconfidence in a plan; it does not promise a better launch outcome. The often-quoted "30%" figure is about the number of reasons generated, not decision quality, and the evidence is transferred from human studies, not validated for AI-augmented use. See the [dossier](../../frameworks/think-premortem/).*
+
+## Why this prompt worked
+
+It named the **decision** ("shipping Resurface in a month"), a **horizon was implied** by "in a month," and it surfaced the **two real worries** (notification spam, the app feeling naggy). That was enough for the framework to do its job: declare the failure in the past tense, generate causes beyond the two Theo named (stale content, the team burning the month on plumbing, a flat D30, a timing bug), and force each into a tripwire and a kill criterion. No structure or polish was required of Theo, and the casual one-liner lost nothing for it.
+
+## The handoff to pm-skills
+
+The ranked register is where the decision layer ends and delivery begins. Theo carries it into pm-skills' `deliver-launch-checklist`, where each tripwire becomes a launch gate: the opt-out-rate threshold, the open-through floor, the timezone-test green light, and the staged-rollout step all move from "things we worried about" to "checks that must pass before and during launch." What crosses the boundary is the decision (ship Resurface in a month), the constraints (a 3-person trio, ~8% notifications on, D30 as the metric that matters), and the risks with their pre-decided kill criteria - so the checklist is built around the failure modes the premortem found, not a generic launch template.
+
+## Next in the thread
+
+That closes the Brainshelf thread: from drawing the boundary, to forecasting adoption from the outside, to premorteming the launch. Back to the [Showcase index](../) for the other companies and journeys.

--- a/site/src/content/docs/showcase/index.md
+++ b/site/src/content/docs/showcase/index.md
@@ -1,6 +1,6 @@
 ---
 title: Showcase
-description: Watch the frameworks used on real decisions, prompt to artifact. Three people - a founder, an engineer, and a policy analyst - work hard problems end to end, so you can see the quality bar before you run anything.
+description: Watch the frameworks used on real decisions, prompt to artifact. Three people work hard problems end to end, and three companies carry a decision across to pm-skills, so you can see the quality bar before you run anything.
 sidebar:
   label: Showcase
   order: 0
@@ -42,6 +42,28 @@ Decisions with ethical dimensions and public accountability, often worked on pap
 - [Audit the argument in a proposal](./priya-argument-mapping/) - the load-bearing premise made explicit.
 - [Record a decision before a public commitment](./priya-decision-journal/) - a journal entry built for later calibration.
 - [Work a contested docket](./priya-ipa-recipe/) - the issue-position-argument recipe across many conflicting comments.
+
+## Browse by company (cross-library: tfs decides, pm-skills delivers)
+
+Three companies take one feature each from a raw idea to a launch decision, then hand off to the delivery work in pm-skills. Follow a company down its thread to see the whole arc.
+
+### Storevine - a native Campaigns feature (organized prompts)
+
+- [Reframe the build request](./storevine-restate-campaigns/) -> pm-skills define-problem-statement
+- [Build vs buy vs partner](./storevine-build-vs-buy/) -> pm-skills develop-adr
+- [Red-team the launch](./storevine-red-team-launch/) -> the risks in pm-skills deliver-prd
+
+### Brainshelf - a morning digest (casual prompts)
+
+- [Draw the boundary](./brainshelf-boundary-resurface/) -> pm-skills define-problem-statement
+- [Forecast adoption from the outside](./brainshelf-forecast-adoption/) -> pm-skills foundation-okr-writer
+- [Premortem the launch](./brainshelf-premortem-digest/) -> pm-skills deliver-launch-checklist
+
+### Workbench - approval gates (enterprise prompts)
+
+- [Map stakeholders against values](./workbench-stakeholder-matrix/) -> pm-skills deliver-acceptance-criteria
+- [Structure the adoption question](./workbench-issue-tree-adoption/) -> pm-skills discover-competitive-analysis
+- [Price the gate model](./workbench-gate-model-ev/) -> pm-skills develop-adr
 
 ## Browse by what you want to produce
 

--- a/site/src/content/docs/showcase/storevine-build-vs-buy.md
+++ b/site/src/content/docs/showcase/storevine-build-vs-buy.md
@@ -1,0 +1,86 @@
+---
+title: "Storevine weighs build vs buy vs partner"
+description: A weighted option matrix on Campaigns - native build, ESP integration, or partner - with an honest sensitivity note.
+sidebar:
+  label: "Storevine -> build vs buy"
+---
+
+> **Dana Okafor**, Group PM for Growth at Storevine, a Series A B2B ecommerce platform (70 staff, 15K merchants, ~$10M ARR). The decision: how to deliver "Campaigns," the native email/SMS feature ~40% of merchants currently leave Storevine for. Prompting style: organized.
+
+This is a complete run, prompt to artifact. Framework: [Decision Option Review](../../frameworks/think-decision-option-review/). For the cast and the other journeys, see the [Showcase index](../).
+
+## The situation
+
+In the first step of this thread, Dana restated the problem: the job is owned reach and attribution, not "an email tool." With that framing fixed, three real ways to deliver it are on the table for Q3 planning, and the choice is genuinely open. Build native email/SMS inside Storevine. Integrate a third-party ESP under Storevine's UI so merchants never see Klaviyo or Mailchimp. Or partner and white-label an existing sender.
+
+The criteria are in tension and nobody has said them out loud. Time-to-value matters because retention is the CEO's stated goal this year. Deliverability is a hard requirement - a bad sender reputation would hurt every merchant on the platform, and Leah Chen on infra has been clear about that. Margin matters because an ESP integration carries a per-message cost that a native build avoids. The Growth pod (Dana plus Sam Reyes' three engineers and one designer) has about one quarter of capacity, so eng load is a real constraint. And mid-market merchants care about data control. Rather than let intuition settle it on shifting, unstated grounds, Dana asks for the tradeoffs made explicit.
+
+## The prompt
+
+```
+/think-decision-option-review "Decision: how to deliver Campaigns. Options: (a) build native
+email/SMS, (b) integrate an ESP under our UI, (c) partner/white-label. Criteria that matter:
+time-to-value for merchants, deliverability risk, gross margin, eng load this quarter, and merchant
+trust/data control. Give me a weighted matrix and tell me how sensitive the pick is to the weights."
+```
+
+A short structured block: the decision, the three real options, the five criteria that matter, and an explicit ask for the sensitivity. Organized, the way Dana runs everything. The framework supplies the weighting discipline and the honesty about where the scoring is soft.
+
+## The output
+
+> **Criteria-Weighted Option Matrix - Delivering Campaigns**
+
+## Decision
+
+- How to deliver Campaigns (native email/SMS for Storevine merchants), committing roughly one quarter of the Growth pod.
+
+## Options
+
+- A: Build native email/SMS sending inside Storevine (own the infra, the IP-warming, the reputation).
+- B: Integrate a third-party ESP under Storevine's UI (merchants never leave; we broker the send).
+- C: Partner / white-label an existing sender (resell a partner's product under co-brand).
+
+## Matrix
+
+| Criterion (weight H/M/L, why) | A: Native build | B: ESP integration | C: Partner / white-label |
+|---|---|---|---|
+| Deliverability risk (H - a hard requirement; bad sender reputation hurts every merchant) | 2 - we own warming + reputation from scratch, the riskiest path; *soft, depends on hiring deliverability expertise we do not have today* | 5 - inherit a mature ESP's reputation + compliance | 4 - partner owns deliverability, but we control it least |
+| Time-to-value for merchants (H - retention is the CEO goal; the longer this slips, the more merchants stay on Klaviyo) | 2 - the slowest; full quarter+ before merchants send | 4 - an integration ships within the quarter | 3 - fast to launch, slow to feel native |
+| Gross margin (H - per-message cost erodes the unit economics at 15K merchants' scale) | 5 - best long-run margin once infra is paid down | 2 - per-message ESP fee on every send, permanently | 2 - rev-share with the partner caps the upside |
+| Eng load this quarter (M - the pod is Dana + 3 eng + 1 designer for ~13 weeks) | 2 - consumes the whole quarter and likely overruns | 3 - fits the quarter with focus | 5 - lightest lift; mostly integration + co-brand |
+| Merchant trust / data control (M - mid-market merchants care who touches their buyer lists) | 5 - data never leaves Storevine | 3 - data transits a third party under our contract | 2 - buyer data lives with the partner |
+
+Score scale 1-5; 5 = best on that criterion. **Flagged soft scores:** A's deliverability (2) is the softest number in the matrix - it assumes we build sender reputation from zero without a deliverability hire, and the whole case for A turns on it. B's time-to-value (4) assumes the ESP's API is as clean as their docs claim, unverified until a spike. Treat both as estimates, not measurements.
+
+## Tradeoffs
+
+- **Option A** gives up time-to-value and deliverability safety this quarter for the best long-run margin and the strongest data-control story. It is the right *destination* and the wrong *first move*: it bets a full quarter of the pod on reputation-building the team has never done.
+- **Option B** gives up per-message margin, permanently, in exchange for shipping inside the quarter on someone else's proven deliverability. It buys time-to-value and de-risks the hard requirement at the cost of unit economics that worsen as Campaigns scales.
+- **Option C** gives up margin and data control for the lightest eng lift, but scores worst on the two things mid-market merchants and Leah's team care most about, so it is hard to recommend despite the easy build.
+
+## Factors that resist scoring
+
+- **Sequencing.** The matrix scores each option as a standalone bet, but B and A are not mutually exclusive over time: B this quarter could be the path that funds and de-risks A later. The single-quarter frame hides that.
+- **Negotiating leverage.** Integrating an ESP (B) now gives Storevine real send volume, which is leverage in any future partner or build-vs-buy renegotiation. Not a number, but it shifts the long game.
+- **Merchant perception of "native."** A white-label (C) may technically work yet still feel like a bolt-on to mid-market merchants, undercutting the retention goal in a way no criterion above captures.
+
+## Recommendation
+
+- **Recommended:** **B (ESP integration) for this quarter** - confidence **M**. It is the only option that meets the hard deliverability requirement without a team we do not have, ships time-to-value inside the quarter, and fits the pod's capacity. Treat A (native build) as the deferred destination, explicitly gated on a deliverability hire and on Campaigns proving demand under B. Reject C: it loses on the two criteria (data control, native feel) that the retention goal most depends on.
+- **Would flip if:** the per-message ESP economics prove untenable at 15K-merchant scale (then A's margin advantage outweighs its risk and we build sooner), **or** Leah's team can credibly own sender reputation this quarter via a deliverability hire (then A's softest score firms up and native becomes viable now), **or** a partner offers terms that fix both margin and data control (then C re-enters).
+
+---
+
+*Note: the value is that the two high-weighted criteria the team would have under-weighted on instinct - deliverability and margin - pull in opposite directions, and a single weighted total would have hidden that B wins by being least-bad on the hard requirement, not by being best overall. This is a lightweight multi-criteria aid (evidence tier P, transferred from human decision practice, not AI-validated); the weighted scores support Dana's judgment, they do not replace it. The pick is sensitive to one number: A's deliverability score. Pressure-test the recommendation before committing the quarter.*
+
+## Why this prompt worked
+
+It named the **decision**, listed the **three real, distinct options**, and - the part most teams skip - it named the **five criteria that actually matter and asked which weights the pick is sensitive to.** That was enough for the framework to do its job: assign honest weights with a reason each, score every option on a stated scale, flag the soft scores instead of laundering them into a clean total, and say out loud what each leading option gives up. Dana did not get a number that "decided" for her. She got a defensible comparison that showed the close call turning on a single soft input, which is exactly the thing to go verify before spending a quarter.
+
+## The handoff to pm-skills
+
+The chosen option and its rationale cross the boundary into the delivery layer. The recommendation - integrate an ESP this quarter, gate the native build on a deliverability hire, reject the white-label - feeds pm-skills' `develop-adr`, where the decision, the options considered, and the flip conditions become a durable architecture decision record, and `develop-solution-brief`, where the constraints (deliverability as a hard requirement, the per-message margin watch, mid-market data control) and the flagged risks (sender reputation, unverified ESP API) become the scope and the open questions the build has to answer. The decision layer hands over a defended choice with its assumptions exposed; the delivery layer turns that choice into a buildable plan.
+
+## Next in the thread
+
+Before committing the quarter to the chosen option, Dana stress-tests it: next in her thread, she [red-teams the Campaigns launch](../storevine-red-team-launch/).

--- a/site/src/content/docs/showcase/storevine-red-team-launch.md
+++ b/site/src/content/docs/showcase/storevine-red-team-launch.md
@@ -1,0 +1,62 @@
+---
+title: "Storevine red-teams the Campaigns launch"
+description: Before committing the quarter, the strongest case against shipping Campaigns, ranked by damage.
+sidebar:
+  label: "Storevine -> red-team"
+---
+
+> **Dana Okafor**, Group PM for Growth at Storevine (B2B ecommerce, 70 staff, 15K merchants). The decision: commit the Growth pod for a quarter to build Campaigns natively. Prompting style: organized.
+
+This is a complete run, prompt to artifact. Framework: [Red Team Light](../../frameworks/think-red-team-light/). For the cast and the other journeys, see the [Showcase index](../).
+
+## The situation
+
+The option is chosen. Storevine restated the problem (owned reach, not an email tool), then ran a weighted option matrix that picked a native build over an ESP integration or a partner. Now Dana has to ask her Q3 planning group for a full quarter of the Growth pod - herself, three engineers, and a designer - on Campaigns. The room agrees. That easy agreement is exactly what makes her want to hear the strongest case against it before the commitment is signed, not after. So she points the red team at her own decision.
+
+## The prompt
+
+```
+/think-red-team-light "We've decided to build Campaigns natively this quarter. Before we commit,
+argue the strongest honest case against it - deliverability, support load, margin, merchant churn
+risk - and rank the objections by how much damage each does if true."
+```
+
+Organized: the decision stated plainly, the four risk surfaces named, and one instruction - rank by damage. The framework supplies the adversary.
+
+## The output
+
+> **Adversarial Critique - Native Campaigns, Q3 build**
+
+## Thesis under attack
+
+- Building Campaigns (native email/SMS) ourselves this quarter is the right way to keep merchants from exporting their lists to a third-party ESP, because owned reach drives the retention the CEO has made this year's goal, and a native build keeps the margin and the data inside Storevine.
+
+## Strongest objections (ranked by force)
+
+| Rank | Objection (steelmanned) | Damage if true | How the thesis must answer it | Can it? |
+|---|---|---|---|---|
+| 1 | Deliverability is a multi-quarter operations problem, not a build. A native sender pooled across 15K merchants means one bad actor can tank the shared sender reputation, and every merchant's mail lands in spam. A native MVP in 13 weeks will not have warmed IPs, complaint-rate monitoring, or per-merchant authentication mature enough to be safe. | Fatal - if shared deliverability degrades, the feature actively harms the merchants it was meant to retain, and the harm is invisible until inboxes go cold | Show a credible deliverability and sender-reputation plan that Leah's infra team has scoped inside the quarter, including isolation of bad senders | Not yet; the deliverability scope has not been costed against the 13 weeks |
+| 2 | The retention thesis is unproven. We assume merchants who export to Klaviyo will adopt a native tool and that doing so reduces churn, but we have no evidence the export is why they leave - they may stay for the storefront and leave for unrelated reasons. A quarter buys a feature that may not move the metric the CEO is judging us on. | Severe - we spend the pod's quarter and retention does not move, and Campaigns becomes a feature we cannot kill without admitting the bet failed | Cite or pilot the link between native reach and merchant retention, even a cohort read on exporters vs non-exporters | Weakly; we have the 40%-export figure but no churn correlation |
+| 3 | Support and abuse load will swamp a team sized to build, not to operate. Email/SMS invites spam complaints, opt-out compliance (CAN-SPAM, TCPA), and "why did my campaign bounce" tickets across a long tail of SMBs. Sam's three engineers cannot both ship and run an abuse desk. | Severe - operational load eats the pod after launch and there is no separate ops owner staffed | Name who operates Campaigns after launch and budget the support and compliance load, not just the build | Not yet; no post-launch operating owner is named |
+| 4 | Margin may be worse native than the ESP integration we rejected. We assumed owning the pipe protects margin, but at 15K merchants the deliverability tooling, compliance, and on-call we now have to build and run may cost more than the per-message ESP fee we were avoiding. | Moderate - weakens the central margin argument for build over integrate | Show the all-in native cost (build plus ongoing ops) against the per-message ESP cost at our volume | Not on current numbers; only the per-message ESP cost was modeled |
+| 5 | Thirteen weeks forces a thin, compliance-light path. Opt-out handling, consent records, and rate-limiting are not optional for email/SMS, and under time pressure they are the first things cut. | Moderate - regulatory and reputational exposure, but manageable with a hard scope gate | Commit to a compliance gate and cut feature scope, not the legal floor | Yes, if scope is frozen early and the gate is real |
+
+## Verdict
+
+- **Decisive objections** (would sink or substantially change the plan): #1 (deliverability) and #2 (the unproven retention link). Either, if true, undermines the whole commitment. #1 is the more dangerous because it can harm every merchant, not just waste our quarter; it must be scoped by Leah's infra team before the pod is committed. #2 is cheap to test - a cohort read on whether exporters churn more - and should be checked before, not after, the build.
+- **Survivable objections:** #3 (real, but addressable by naming a post-launch operating owner and budgeting the support and compliance load now), #4 (forces an honest all-in cost comparison, may still favor build), and #5 (manageable with a frozen scope and a compliance gate).
+- **Genuine dissent needed?** Yes. Committing a quarter of the Growth pod with the CEO's retention goal riding on it is close to a one-way door once the team is staffed and the roadmap is public. This critique is constructed dissent - the model role-playing the adversary - and role-played dissent does not carry the weight of someone who genuinely believes Campaigns is the wrong bet. Before the commitment is signed, have Leah argue #1 and someone who actually doubts the retention thesis argue #2, rather than relying on this critique alone.
+
+*Note: the value is ranking deliverability and the unproven retention link as decisive while support load, margin, and compliance are survivable with named owners and gates. The honesty flag matters here: the model can articulate the case against its own plan, but on a near-one-way-door commitment the team should hear #1 and #2 from people who actually hold them, especially Leah on deliverability.*
+
+## Why this prompt worked
+
+It named the **decision** ("build Campaigns natively this quarter"), named the four **risk surfaces** Dana already half-feared (deliverability, support load, margin, churn), and gave the one instruction the framework needs - **rank by damage, not by ease**. That was enough for the red team to do its job: state the thesis fairly, build steelmanned objections beyond the four she named (it added the compliance-light path), order them by how much each hurts if true, and flag that the two decisive objections deserve a real dissenter, not just constructed dissent. Dana did not have to script the adversary; she had to name what she was committing to and trust the framework to argue the other side honestly.
+
+## The handoff to pm-skills
+
+The ranked objections do not stay in the decision layer. They become the risks section of pm-skills' `deliver-prd`, the delivery doc Sam's pod writes before the build starts. What crosses the boundary is the commitment (a native Campaigns build, one quarter of the Growth pod), the constraints that survived the critique (deliverability must be scoped by infra, a post-launch operating owner must be named, a compliance gate is a launch floor not a follow-up), and the two decisive risks with their cheap tests - the deliverability scope and the exporter-churn cohort read - so the delivery team inherits a risk register that already knows which objections are fatal and which are survivable.
+
+## Next in the thread
+
+That closes Storevine's thread: reframe the request, weigh build vs buy vs partner, then red-team the launch before committing. Back to the [Showcase index](../) for the other companies and journeys.

--- a/site/src/content/docs/showcase/storevine-restate-campaigns.md
+++ b/site/src/content/docs/showcase/storevine-restate-campaigns.md
@@ -1,0 +1,74 @@
+---
+title: "Storevine reframes a build request"
+description: An ecommerce platform turns "build native Campaigns" into the actual problem before committing a quarter of eng.
+sidebar:
+  label: "Storevine -> restate"
+---
+
+> **Dana Okafor**, Group PM for Growth at Storevine (B2B ecommerce, 70 staff, 15K merchants). The decision: whether to build "Campaigns," a native email/SMS feature, this quarter. Prompting style: organized.
+
+This is a complete run, prompt to artifact. Framework: [Problem Restatement](../../frameworks/think-problem-restatement/). For the cast and the other journeys, see the [Showcase index](../).
+
+## The situation
+
+About 40% of Storevine's merchants export their contact lists to a third-party ESP (Klaviyo or Mailchimp) to send email and SMS, because Storevine has no native way to do it. The asks have piled up, and the obvious move is "build the feature they keep requesting." Dana runs the Growth pod (herself, three engineers, and one designer), and the budget on the table is roughly one quarter of that pod, about 13 weeks. The CEO's stated priority this year is merchant retention. Before she lets the team scope "Campaigns," she wants to be sure they are solving the merchant's actual problem and not just defaulting to the solution someone named in a ticket. So she writes a tight, structured prompt.
+
+## The prompt
+
+```
+/think-problem-restatement "Situation: merchants keep exporting contact lists to Mailchimp
+because we have no native email/SMS. Proposal on the table: build 'Campaigns' natively this
+quarter. Constraints: 70-person team, 15K merchants, ~one quarter of eng capacity, deliverability
+is a hard requirement. Considered so far: native build vs deep integration with an ESP. Before we
+scope, restate the problem so we aren't just defaulting to 'build the feature they named.'"
+```
+
+Organized and complete: the situation, the proposal, the constraints, and what has already been considered, all front-loaded. The framework supplies the reframings.
+
+## The output
+
+> **Problem Frame Set - Campaigns**
+
+## Problem as given
+
+- **Stated problem (verbatim):** "Merchants keep exporting contact lists to Mailchimp because we have no native email/SMS. Build 'Campaigns' natively this quarter."
+- **Framed by:** Dana Okafor, Group PM for Growth (carrying the accumulated merchant requests).
+- **Flags:** Names a presupposed solution ("build Campaigns natively") for an unstated goal. The export behavior is a symptom, not the problem. The infra/deliverability viewpoint (Leah Chen) and the margin viewpoint are absent from the framing; so is the CEO's actual objective, retention.
+
+## Restatements
+
+| # | Restated problem | Move used | Why this might be the real problem |
+|---|---|---|---|
+| 1 | How do we increase merchant retention by making Storevine the place merchants run their whole business from? | altitude up (goal) | The CEO's stated goal is retention; "Campaigns" is one lever toward it, not the objective. Solving for retention may not require a full native ESP. |
+| 2 | Why do 40% of merchants leave Storevine to reach their own buyers, and what does that export step actually cost them? | altitude down (concrete) | The concrete failure is a broken workflow (export, re-import, manage two tools), not the absence of a feature called Campaigns. |
+| 3 | What is the lowest-risk way to give merchants owned reach to their buyers from inside Storevine, with deliverability we can stand behind? | goal vs implementation | "Build native email/SMS" is an implementation. The job-to-be-done is reliable owned reach plus attribution, which an ESP integration could also deliver. |
+| 4 | How do we add Campaigns without Leah's team owning a sender reputation that one bad merchant could wreck for all 15K? | stakeholder shift (infra / deliverability) | Surfaces the hard constraint the original framing buries: deliverability is shared infrastructure, and a native build makes Storevine the sender of record for every merchant. |
+| 5 | How would we guarantee Campaigns ships, gets adopted, and still loses us money and merchants? | inversion | Exposes the buried assumptions: that merchants want to switch tools, that per-message cost is bearable, that we can run deliverability at ESP quality inside one quarter. |
+| 6 | This is a problem of merchants needing owned reach and attribution inside Storevine; it is NOT necessarily a problem of Storevine needing to be its own ESP. | is / is not | Bounds scope and challenges the leap from "merchants export to Mailchimp" to "we must build a native ESP." |
+
+## How Might We angles
+
+- How might we keep merchants' buyer relationships inside Storevine without owning ESP-grade deliverability ourselves?
+- How might we give merchants owned reach and attribution at the lowest irreversible cost this quarter?
+- How might we test whether merchants will actually switch off Mailchimp before we build for it?
+- How might we serve both the long-tail SMB (wants it easy) and the mid-market (wants data control) with one approach?
+
+## Chosen working frame
+
+- **Working frame:** "What is the lowest-risk way to give merchants owned reach and attribution to their buyers from inside Storevine, with deliverability we can stand behind, this quarter?"
+- **Why:** It keeps the real goal (retention through owned reach) central, demotes "build native Campaigns" from a given to one testable option, and pulls the deliverability constraint and the build-vs-integrate question into the frame instead of leaving them downstream. It does not foreclose the native build; it refuses to assume it.
+- **Hands off to:** option generation and then a decision skill to choose among native build, ESP integration, and partner/white-label, then a premortem on the chosen option.
+
+*Note on evidence: that how a problem is framed affects the quality of the solution has moderate support transferred from human problem-finding and design research, not AI-validated; this skill sharpens the problem, it does not guarantee a better solution. Full grading: the [dossier](../../frameworks/think-problem-restatement/).*
+
+## Why this prompt worked
+
+Dana front-loaded the four things the framework needs to do real work: the **situation** (the export behavior), the **proposed solution** (build Campaigns natively), the **constraints** (team size, one quarter, deliverability), and **what had already been considered** (build vs integrate). That let the framework separate the goal from the named implementation, state the problem from the infra and margin viewpoints she had left out, and bound the scope with an explicit is/is-not, rather than reword "build Campaigns" into a synonym. The organized style did not produce a better artifact than a casual prompt would have; it just meant fewer assumptions had to be guessed.
+
+## The handoff to pm-skills
+
+The chosen working frame is the input the delivery layer needs. It feeds pm-skills' `define-problem-statement`, where Dana's team turns the framed problem into the canonical, one-page problem statement that anchors the rest of the build. What crosses the boundary is the decision (solve for owned reach and attribution, not for "a native ESP"), the constraints that must survive scoping (one quarter of the Growth pod, deliverability as a hard requirement, the mid-market data-control concern), and the open risk the inversion surfaced (merchants may not actually switch off Mailchimp). tfs framed the problem; pm-skills writes it down and carries it forward.
+
+## Next in the thread
+
+With the problem reframed as "owned reach at the lowest risk," the three real options are in play. Next, Dana runs a weighted option matrix on build vs buy vs partner: [Build vs buy vs partner](../storevine-build-vs-buy/).

--- a/site/src/content/docs/showcase/workbench-gate-model-ev.md
+++ b/site/src/content/docs/showcase/workbench-gate-model-ev.md
@@ -1,0 +1,104 @@
+---
+title: "Workbench prices the approval-gate model"
+description: An expected-value decision tree on lightweight vs strict vs configurable approval gates under uncertain enterprise demand, with the probability assumptions made explicit.
+sidebar:
+  label: "Workbench -> EV tree"
+---
+
+> **Priyanka Rao**, Principal PM for Enterprise at Workbench (Series B, 200 staff, ~500 enterprise customers). The decision: which approval-gate model to build for Blueprints when demand for strict governance is genuinely uncertain. Prompting style: detailed and accountable.
+
+This is a complete run, prompt to artifact. Framework: [Expected Value Decision Tree](../../frameworks/think-expected-value-decision-tree/). For the cast and the other journeys, see the [Showcase index](../).
+
+## The situation
+
+Blueprints, Workbench's reusable templates, is already shipping. The contested addition is approval gates: routing a Blueprint through reviewers before it can publish. About 30% of Workbench's customers are in regulated industries that need SOC2-grade audit trails, and the customer advisory board of ~12 enterprise admins is split. Some segments want strict, multi-stage governance; others want speed and would resent a heavy gate. Priyanka has three real models on the table and a half-year roadmap slot to spend. The arguments in the room are about which segment matters more, which is a disagreement about a number nobody has named. Before her pod (herself, four engineers, and Dr. Elena Voss part-time on compliance) commits, she wants the uncertainty priced, not debated.
+
+## The prompt
+
+```
+/think-expected-value-decision-tree "Decide the approval-gate model for Blueprints: (a) lightweight
+single-approver, (b) strict multi-stage, (c) configurable per-workspace. Enterprise demand for
+strictness is uncertain - some segments need SOC2-grade audit trails, some want speed. Model the
+chance nodes (high vs low governance demand) and roll back an expected value for each option."
+```
+
+Detailed and accountable, in Priyanka's voice: the three named options, the source of the uncertainty (which segment dominates), and an explicit instruction to model the chance nodes rather than argue the options in prose. The framework supplies the tree, the arithmetic, and the what-flips-it note.
+
+## The output
+
+> **Expected Value Decision Tree - Blueprints approval-gate model**
+
+## Decision
+
+- Which approval-gate model to build for Blueprints, given uncertain enterprise demand for strict governance: lightweight single-approver, strict multi-stage, or configurable per-workspace.
+
+## Options
+
+- A: **Lightweight** - a single named approver gates publish. Fast to author, cheap to maintain, thin audit trail.
+- B: **Strict** - mandatory multi-stage review (author -> approver -> compliance sign-off) with a full audit log. Heavy governance, slower authoring, the most build and maintenance cost.
+- C: **Configurable** - each workspace admin chooses the gate depth (off, single, or multi-stage) per Blueprint type. Serves both segments, but a configurable gate engine is the most expensive thing to build and the most expensive to maintain.
+
+## Tree
+
+Choice nodes are squares (Priyanka's pod controls them); chance nodes are circles (the market controls them). The load-bearing uncertainty is the same across all three options: whether **governance demand across the ~500 customers lands high** (the regulated ~30% plus enough of the mid-segment to set the requirement) or **low** (most customers want speed and treat a heavy gate as friction). Values are the net 12-month contribution of the roadmap slot, in $K, net of build and maintenance cost and net of the renewal/expansion effect on the affected segment. The probability of "high" is sourced, not guessed (see the probability note).
+
+```
+[Decision]
+ |
+ |--[A: Lightweight] ----( governance demand )-- p=0.45 high [advisory board + segment data] --> +300
+ |                                                p=0.55 low                                   --> +900
+ |
+ |--[B: Strict] ---------( governance demand )-- p=0.45 high                                   --> +1400
+ |                                                p=0.55 low                                   --> -200
+ |
+ |--[C: Configurable] -- build/maint -350 --( governance demand )-- p=0.45 high --> +1400
+ |                                                                  p=0.55 low  --> +900
+```
+
+## Outcome values
+
+- A, high demand: **+300** (lightweight ships fast and wins the speed segment, but the regulated ~30% cannot adopt without a real audit trail, so the governance-driven expansion is left on the table).
+- A, low demand: **+900** (the speed segment is most of the market; a thin, fast gate is exactly what they want, and maintenance is cheap).
+- B, high demand: **+1400** (strict governance unlocks the regulated segment's renewals and expansion; the audit trail becomes a competitive differentiator in deals).
+- B, low demand: **-200** (the heavy gate is friction for the majority speed segment, authoring slows, some workspaces route around Blueprints entirely, and the build/maintenance cost is not recovered).
+- C, high demand: **+1400 gross, then -350** for the configurable gate engine's build and ongoing maintenance (the most complex of the three to build and keep correct under least-privilege rules) -> the rollback applies the -350 to the option, not the leaf.
+- C, low demand: **+900 gross, then -350** -> same engine cost applies.
+- **Common unit:** $K net 12-month contribution of the roadmap slot vs not building gates.
+- **Incommensurable / unpriced:** Workbench's reputation with the regulated segment if it ships a gate that later fails an audit (a SOC2 finding is a trust event, not a line item), and the author-autonomy cost of any gate (least-privilege vs author freedom is a values tension, surfaced in the WB-1 stakeholder matrix). Both are real and are flagged here as judgment inputs, not forced into a dollar figure.
+
+## Rollback (fold back, right to left)
+
+- **Probability note:** p(high) = 0.45 is not invented inside the tree. It is anchored on the customer base (the regulated ~30% are near-certain to need strict governance) adjusted upward for the share of the mid-segment that the advisory board reported would require audit trails within the year. The honest read is that 0.45 carries real estimation error; it is treated below as the single most fragile input. Sourcing a tighter base rate would use `think-reference-class-forecasting`, not a sharper guess inside the tree.
+- **Option A chance node:** EV = 0.45 x 300 + 0.55 x 900 = 135 + 495 = **+630**.
+- **Option B chance node:** EV = 0.45 x 1400 + 0.55 x (-200) = 630 - 110 = **+520**.
+- **Option C chance node:** EV = 0.45 x 1400 + 0.55 x 900 = 630 + 495 = 1125, then subtract the configurable-engine build/maintenance of 350 -> **+775**.
+- **Per-option EV:** A = +630; B = +520; C = **+775**.
+
+## Recommendation
+
+- **Chosen:** C, **Configurable per-workspace** - EV **+775**, the highest of the three.
+- **Path that produces it:** build the gate engine so each workspace admin sets the gate depth per Blueprint type; the regulated segment turns on multi-stage review with a full audit trail, the speed segment runs single-approver or off. Configurable wins because it captures the high-demand upside (the +1400 governance leaf) without eating the -200 catastrophe that Strict suffers if demand is actually low. It pays a flat 350 premium for that insurance against being wrong about p(high), which is precisely the input we are least sure of.
+
+## What-flips-it (sensitivity)
+
+- **Most fragile input:** the configurable-engine's build and maintenance cost (the 350 premium), closely followed by p(high).
+- **Flip threshold:** Configurable (C) beats Lightweight (A) only while the engine premium stays below about **495** (at p=0.45, C's gross 1125 must clear A's 630, a 495 cushion); if the engine proves more expensive to build and keep correct than 495, **Lightweight (A)** wins and the right move is to serve the speed segment now and revisit strict governance later. On the probability side, Strict (B) overtakes Configurable only if p(high) rises above about **0.79** (where B's 0.79 x 1400 + 0.21 x -200 = 1106 - 42 = 1064 clears C's net 1064-ish); we are at 0.45, far below that, so a single-model strict bet is not justified on the current read. The recommendation is robust to p(high) but genuinely sensitive to the engine cost, which is exactly where the pod's estimate should be pressure-tested before committing.
+
+## Ruin / risk flag
+
+- **Ruin check:** no branch carries literal ruin (no outcome ends the company), but two asymmetric tails are understated by the dollar figures. Strict (B) under low demand is the worst-case: a -200 financial loss that also drags author adoption and could push workspaces to abandon Blueprints, a hard-to-reverse trust loss once authors have routed around the feature. And any model that ships a gate which later fails a customer's SOC2 audit is a reputational event with the regulated segment that no leaf value captures. Configurable's flat premium is, in effect, the price of not betting the regulated segment's trust on a single guess about p(high). This asymmetry is part of why the decision earns a tree rather than a quick call.
+- **Risk attitude:** Workbench is a Series B selling governance to regulated enterprises, so a mild risk aversion toward the -200 strict-misfire branch is a real preference, not a bias. It reinforces C (which has no negative leaf) over B. Surfaced here, not used to override the arithmetic, which already points to C.
+
+*Evidence caveat: this framework is tier P (practitioner-grade, transferred). Expected-value maximization is the normatively correct rule given coherent probabilities, but the claim that building a tree makes a real decider choose better than a cheaper rule rests on practitioner evidence from human deciders, none of it from AI-produced trees. The value here is pricing the uncertainty and making the assumptions inspectable, not a measured gain in decision outcomes. See the [dossier](../../frameworks/think-expected-value-decision-tree/) for the full grading.*
+
+## Why this prompt worked
+
+It named the **decision** (which gate model), listed the **three real options**, and pointed at the **one genuine uncertainty** - whether governance demand lands high or low - that should drive the chance nodes. That was enough for the framework to do its job: lay out the tree, force the disputed segment question into a single named probability, roll the arithmetic back to an EV per option, and run the what-flips-it step. The room's argument ("the regulated segment matters more" vs "most customers want speed") became a disagreement about p(high) = 0.45 and a 350 engine premium, both of which can be pressure-tested. Priyanka did not have to know decision theory; she had to know her options and her uncertainty.
+
+## The handoff to pm-skills
+
+The chosen model (configurable per-workspace), its EV rationale, and the two flip thresholds cross the boundary into pm-skills' `develop-adr`. The decision layer hands the delivery layer a real architecture decision record input: the option selected, the alternatives considered and why they lost (Strict's -200 low-demand tail, Lightweight's left-on-the-table regulated upside), the load-bearing assumption (p(high) = 0.45) that the ADR should record as a revisit trigger, and the constraint that the configurable engine must stay correct under least-privilege rules below a ~495 cost ceiling or the calculus flips. The reasoning is the why; the ADR makes it the durable record.
+
+## Next in the thread
+
+This is the last page in Workbench's thread. Back to the [Showcase index](../) for the other companies and journeys.

--- a/site/src/content/docs/showcase/workbench-issue-tree-adoption.md
+++ b/site/src/content/docs/showcase/workbench-issue-tree-adoption.md
@@ -1,0 +1,134 @@
+---
+title: "Workbench structures the adoption question"
+description: A MECE issue tree breaking "will enterprises adopt Blueprints?" into what must be true.
+sidebar:
+  label: "Workbench -> issue tree"
+---
+
+> **Priyanka Rao**, Principal PM for Enterprise at Workbench (Series B collaboration platform, 200 staff, ~500 enterprise customers). The decision: whether enterprise customers will adopt Blueprints with approval gates, and what discovery to run before committing the half-year roadmap slot. Prompting style: detailed and accountable, names roles and what each branch is owned by.
+
+This is a complete run, prompt to artifact. Framework: [Issue Tree](../../frameworks/think-issue-tree/). For the cast and the other journeys, see the [Showcase index](../).
+
+## The situation
+
+Blueprints (the reusable templates) is already shipping. The contested addition this quarter is **approval gates** - routing a template through reviewers before it can publish. Marcus Hale, the eng lead, can scope the build. The harder problem is that nobody knows whether enterprises will actually turn the gates on. The customer advisory board of ~12 admins is split, and "will they adopt it?" is too big to answer as one yes/no. Before Priyanka spends a single discovery cycle, she wants the question broken into the parts that must each be true, so the discovery she does run is aimed, not scattered.
+
+## The prompt
+
+```
+/think-issue-tree "Question: will our enterprise customers adopt Blueprints with approval gates?
+Break it into a MECE tree of what must be true - admin demand for governance, fit with their
+compliance regimes, migration cost off their current process, and competitive parity - so we know
+what discovery to run."
+```
+
+That is the whole prompt. Detailed, in the enterprise voice: it names the root question, the dimensions Priyanka already suspects matter, and the downstream use (deciding discovery). The framework supplies the MECE discipline, the leaf register, and the prioritization.
+
+## The output
+
+> **Issue Tree - Will enterprises adopt Blueprints with approval gates?**
+
+## Root question
+
+- **Question:** Will Workbench's enterprise customers adopt Blueprints with approval gates?
+- **Why it cannot be answered as posed:** It bundles at least four separate judgments (do admins want governance, does the gate model fit their compliance regime, is the switching cost off their current process tolerable, and are we at parity with what they can buy elsewhere) into one adoption yes/no, so a direct answer would hide which condition is actually in doubt and across which customer segment.
+- **A tree is warranted because:** the decision gates a half-year roadmap slot, adoption is multi-cause, and the ~12-admin advisory board is split - so the analysis needs to be split into non-overlapping branches the team can run discovery against in parallel.
+
+## Summary (top of the artifact)
+
+The root "will enterprises adopt approval gates?" is broken on a single material axis: **the conditions that must all hold for an enterprise admin to turn gates on and keep them on** - demand for the governance, fit with their compliance regime, switching cost off their current process, and competitive parity. These four are mutually exclusive (each measures a different thing) and collectively exhaustive (sustained adoption needs all four; a clear "no" on any one stalls it for that segment). The leaves most likely to carry the decision are **whether the regulated ~30% who need audit trails will require gates rather than merely tolerate them** (1A) and **whether our gate model maps onto their existing change-control and SOC2 evidence requirements** (2A): the first is where the real pull lives, the second is where a plausible-looking feature most easily fails to satisfy an auditor. Competitive parity (branch 4) is least in doubt and is deprioritized.
+
+## Issue tree
+
+```
+Will enterprises adopt Blueprints with approval gates?
+- Top-level split axis: the conditions that must ALL hold for an enterprise to turn gates
+  on and keep them on (chosen because adoption is a conjunction of independent tests across
+  segments, not a single demand estimate)
+
+  1. Is there real DEMAND for the governance, not just stated interest?
+     - Split axis: regulated need vs. discretionary preference
+       - 1A  Required - do the regulated ~30% (SOC2 / change-control) NEED gates to pass audit?
+             answered by: compliance interviews with regulated admins; do current audits cite
+             the lack of pre-publish review as a finding? (owner: Dr. Elena Voss, compliance)
+       - 1B  Preferred - do the non-regulated ~70% want gates enough to configure them?
+             answered by: advisory-board survey; share who would enable gates if shipped
+             (owner: Priyanka Rao)
+
+  2. Does the gate model FIT their compliance regime?
+     - Split axis: control mapping vs. evidence/audit output
+       - 2A  Control fit - does pre-publish review map to their change-control policy
+             (separation of duties, least-privilege approver roles)?
+             answered by: map our role model against 5-6 customers' written control policies
+             (owner: Elena Voss + Marcus Hale)
+       - 2B  Evidence fit - does the gate produce an audit trail their auditors will accept
+             (who approved, when, what changed, immutable)?
+             answered by: review the proposed audit-log schema with 2-3 customer auditors
+             (owner: Elena Voss)
+
+  3. Is the MIGRATION COST off their current process tolerable?
+     - Split axis: process switching cost vs. author-workflow disruption
+       - 3A  Process cost - how much rework to move from their current approval tooling
+             (email sign-off, separate GRC tools) onto Blueprints gates?
+             answered by: current-state interviews; count of steps/tools replaced vs. added
+             (owner: Priyanka Rao)
+       - 3B  Author friction - do template authors accept the added gate step, or route
+             around it (publish outside Blueprints)?
+             answered by: prototype walkthrough with authors; measured added time-to-publish
+             (owner: Marcus Hale)
+
+  4. Are we at COMPETITIVE PARITY with what they could buy or build instead?
+     - Split axis: feature parity vs. switching incentive
+       - 4A  Parity - do competing platforms / homegrown workflows already offer equivalent
+             gated publishing?
+             answered by: competitive scan of the alternatives admins name (owner: Priyanka Rao)
+       - 4B  Differentiation - is gated Blueprints enough better/cheaper to justify enabling it?
+             answered by: advisory-board preference vs. their current workaround (owner: Priyanka Rao)
+
+  - Other / not covered above: pricing/packaging of the governance tier, and rollout/change-
+    management inside the customer's org
+    answered by: a quick screen with 2-3 customers; surfaced here so the level stays
+    exhaustive, low priority for the go/no-go
+```
+
+## Leaf register (the answerable parts)
+
+| Leaf sub-question | Parent branch | What would answer it (data / metric / owner / judgment) | Priority (H/M/L) |
+|---|---|---|---|
+| Do the regulated ~30% require gates to pass audit (vs. merely tolerate them)? | 1A | Compliance interviews with regulated admins; whether current audits cite missing pre-publish review as a finding (owner: Elena Voss) | H |
+| Does our approver/role model map onto their change-control policy (separation of duties, least-privilege)? | 2A | Map the role model against 5-6 customers' written control policies (owner: Elena Voss + Marcus Hale) | H |
+| Does the gate produce an audit trail their auditors will accept? | 2B | Review the audit-log schema with 2-3 customer auditors (owner: Elena Voss) | M |
+| Will template authors accept the gate step rather than route around it? | 3B | Prototype walkthrough; measured added time-to-publish (owner: Marcus Hale) | M |
+| Process switching cost off their current approval tooling | 3A | Current-state interviews; steps/tools replaced vs. added (owner: Priyanka Rao) | M |
+| Do non-regulated customers want gates enough to enable them? | 1B | Advisory-board survey; share who would turn gates on (owner: Priyanka Rao) | M |
+| Competitive parity with alternatives admins already use | 4A | Competitive scan of named alternatives (owner: Priyanka Rao) | L |
+
+**Column notes:**
+- **What would answer it:** the concrete data, interview, or judgment needed to resolve the leaf, and the named owner who returns it. A leaf nobody can answer is not yet a leaf - split it further or restate it.
+- **Priority:** 1A and 2A are flagged High because the real pull for gates lives in the regulated segment's requirement, and the fastest way a plausible feature fails is an audit-control mismatch; competitive parity (4A) is deprioritized as least in doubt.
+
+## MECE check
+
+- **Mutually exclusive:** the four top branches measure different things (demand, compliance fit, migration cost, competitive position); no leaf is counted twice. Watched borderline: 1A (regulated demand) and 2A (control fit) are adjacent, so 1A is scoped to *whether they require gates at all* and 2A to *whether our specific model satisfies the control* once they do - kept exclusive so a "yes, they need it" does not absorb "but our design does not fit."
+- **Collectively exhaustive:** sustained adoption requires all four conditions; the explicit "Other" branch holds pricing/packaging and internal rollout so nothing material falls outside the level.
+- **Split-axis sanity:** the top split is on the conjunction of conditions that gate adoption, which is the material axis - a tidier split (for example "by customer segment" or "by feature area") would have scattered the compliance-fit question across owners and hidden that 2A is where the design most plausibly breaks.
+
+## Pruned / out-of-scope branches
+
+- Detailed gate-model choice (lightweight single-approver vs. strict multi-stage vs. configurable per-workspace) - that is the next decision, priced separately once adoption conditions are understood; noted, not branched here.
+- UI design of the approver inbox - downstream execution, not a condition for adoption; cut.
+- Workbench's own internal maintenance cost of a configurable gate model - a real tension, but it bears on *which model to build*, not on *whether enterprises would adopt gates at all*; deferred to the model decision.
+
+*Evidence note: the issue tree is a practitioner-grade method (tier P). It structures the adoption question for coverage and tractability and tells the team where to aim discovery; it does not by itself answer whether enterprises will adopt, and a MECE-clean tree split on the wrong axis can be tidy and useless. The value here is that "will they adopt?" became four owned, testable conditions - not a better answer on its own. See the [dossier](../../frameworks/think-issue-tree/) for the full grading and caveats.*
+
+## Why this prompt worked
+
+It named the **root question**, supplied the **candidate dimensions** Priyanka already suspected (demand, compliance fit, migration cost, parity), and stated the **downstream use** ("so we know what discovery to run"). That was enough for the framework to do its real job: enforce MECE so the four dimensions did not overlap, drive each branch down to leaves that name a concrete owner and data source, and flag the two leaves (1A regulated requirement, 2A control fit) most likely to carry the decision. The detailed, role-naming style paid off directly - because Priyanka named accountability in the prompt's spirit, the tree could assign Elena Voss the compliance leaves, Marcus Hale the author-friction leaf, and Priyanka the demand and competitive leaves, turning a vague "will they adopt?" into a discovery plan with owners.
+
+## The handoff to pm-skills
+
+Each branch of the tree becomes a discovery question, which is exactly the input pm-skills' `discover-competitive-analysis` needs to be structured rather than ad hoc. What crosses the boundary is the decomposition itself: the four conditions (regulated demand, compliance-regime fit, migration cost, competitive parity), the high-priority leaves Workbench must validate first (the regulated segment's requirement and the audit-control mapping), and the named owners for each. The decision layer hands the delivery layer a question already broken into what must be true, so the competitive analysis is organized around the conditions that gate adoption instead of a generic feature comparison.
+
+## Next in the thread
+
+Priyanka has the adoption question structured and the discovery aimed. Next she has to pick the actual gate model under genuinely uncertain demand: [Workbench prices the approval-gate model](../workbench-gate-model-ev/).

--- a/site/src/content/docs/showcase/workbench-stakeholder-matrix.md
+++ b/site/src/content/docs/showcase/workbench-stakeholder-matrix.md
@@ -1,0 +1,96 @@
+---
+title: "Workbench maps stakeholders before approval gates"
+description: An enterprise tool grids stakeholders against values before writing acceptance criteria for approval gates.
+sidebar:
+  label: "Workbench -> stakeholders"
+---
+
+> **Priyanka Rao**, Principal PM for Enterprise at Workbench (Series B, 200 staff, ~500 enterprise customers). The decision: how to design approval gates for Blueprints, the reusable templates that route through reviewers before they publish. Prompting style: detailed and enterprise, naming roles and accountability.
+
+This is a complete run, prompt to artifact. Framework: [Ethical Matrix](../../frameworks/think-ethical-matrix/). For the cast and the other journeys, see the [Showcase index](../).
+
+## The situation
+
+Blueprints (the templates) is already shipping. The contested addition this quarter is approval gates: routing a template through reviewers before it publishes. About 30% of Workbench's customers are in regulated industries that need audit trails and change-control, and least-privilege is table stakes for them. The rest want speed. Priyanka's pod (herself, four engineers, and Dr. Elena Voss part-time on compliance) has a half-year roadmap slot, and a customer advisory board of about twelve enterprise admins is watching. Before the team writes acceptance criteria, Priyanka wants to see whose interests the gate design trades off, so the criteria encode those trade-offs deliberately rather than by accident.
+
+## The prompt
+
+```
+/think-ethical-matrix "We're adding approval gates to Blueprints (templates that route through
+reviewers before publish). Stakeholders: template authors, approvers/admins, end users who consume
+published blueprints, and customer compliance/IT. Values in tension: speed of authoring, control
+and auditability, autonomy of authors, and least-privilege. Map stakeholders against these values
+before we write acceptance criteria, so we see whose interests the gate design trades off."
+```
+
+Detailed and enterprise: the proposal, the named stakeholder roster, the values in tension, and the explicit reason for running it now (before acceptance criteria). The framework supplies the grid, the tags, and the trade-off read-out.
+
+## The output
+
+> **Ethical Matrix - Approval gates on Blueprints**
+
+> The matrix maps the moral terrain; it does NOT weigh it. It is not ranked, not scored, and emits no verdict. The value is the trade-off pattern read-out, not the filled grid.
+
+### Option under analysis
+
+- **Option:** Add approval gates to Blueprints so that a template must route through one or more designated reviewers (approvers/admins) and clear them before it can publish to the workspace, with the routing and sign-off captured in an audit trail.
+
+(This is one specific proposal - gating publication on reviewer approval - not a choice among gate models. The comparison of lightweight versus strict versus configurable gate designs is a separate decision; here we map who one gating proposal helps and burdens, on which principles.)
+
+### Affected parties (rows)
+
+- **Template authors** (the people who build Blueprints; want to ship fast and keep autonomy)
+- **Approvers / admins** (the reviewers and workspace administrators who own the gate and the sign-off)
+- **End users who consume published Blueprints** (the broad population who run a published template - **voiceless** here: they are not in the design conversation but inherit whatever quality and access the gate enforces)
+- **Customer compliance / IT** (Elena's counterparts at the ~500 customers, sharpest among the regulated ~30% who need audit trails and least-privilege)
+- **Future workspace members and auditors** - **voiceless**: the people downstream, including external auditors, who inherit the audit record and the access norms this gate sets, and who never participated in choosing them
+
+(Who counts as affected was checked first. The two voiceless rows - end users and future members/auditors - are easy to omit because nobody in the advisory board represents them, which is exactly the omission to guard against. They are in because the gate affects them whether or not anyone speaks for them.)
+
+### Principle columns
+
+The values Priyanka named map onto an adapted column set. Stated, not silent:
+
+- **Wellbeing** (beneficence and non-maleficence together - here, speed and quality of the authoring-and-publishing experience, and the harm of a bad or unreviewed template reaching users)
+- **Autonomy** (freedom, consent, self-determination - here, author autonomy to ship without a gatekeeper)
+- **Fairness** (justice - distribution of the gate's benefits and burdens across the parties)
+- **Control and auditability** - **adapted column. Justification:** auditability and least-privilege are not reducible to the standard three for this case; for the regulated ~30% they are the whole point of the feature, and a benefit on this column is often paid for by a burden on autonomy, so the trade-off only becomes visible if control gets its own axis. Adapted deliberately rather than folded silently into fairness.
+
+### The grid
+
+| Affected party | Wellbeing | Autonomy | Fairness | Control and auditability |
+|---|---|---|---|---|
+| **Template authors** | Lose authoring speed - a gate adds a wait and a round-trip before publish **[factual]**; gain confidence that a reviewed template will not embarrass them **[contested]** | Autonomy is directly reduced - they can no longer publish on their own judgment; a reviewer now stands between them and the workspace **[factual]** | They carry the heaviest process burden of any party so that others (compliance, end users) get assurance they do not personally need **[contested]** | They inherit a control regime they did not ask for; for a low-risk template the audit step is pure overhead to them **[contested]** |
+| **Approvers / admins** | Gain a lever to keep quality up; bear a new review workload that can become a bottleneck on a small admin team **[factual]** | Their discretion expands - they decide what publishes - which is power that can be used well or to obstruct **[contested]** | They receive authority over authors' work; the fairness question is whether that authority is matched by accountability for delays they cause **[contested]** | This is their principal benefit - a defensible record of who approved what, when **[factual]** |
+| **End users who consume Blueprints** *(voiceless)* | Benefit from higher-quality, reviewed templates and fewer broken or unsafe ones reaching them **[factual]** | Unaffected on their own autonomy; they consume rather than author **[factual]** | They gain assurance they did not have to pay for in process cost - the burden falls upstream on authors **[contested]** | They inherit a safer published surface without ever seeing the gate **[factual]** |
+| **Customer compliance / IT** | The feature reduces their compliance risk and audit-prep effort materially **[factual]** | Largely unaffected on autonomy; the gate serves their mandate rather than constraining it **[factual]** | For the regulated ~30% this is the party the gate most serves; the fairness question is whether the other ~70% are made to pay for a control only this segment needs **[contested]** | This is the core benefit - least-privilege routing and an audit trail are exactly what their regime requires **[factual]** |
+| **Future workspace members and auditors** *(voiceless)* | Inherit a more trustworthy template library, or a slower-moving one, depending on how heavy the gate is set **[contested]** | Inherit whatever default expectation of author freedom this gate normalizes across the platform **[contested]** | If the gate is set for the strictest segment and applied to all, the speed burden is locked in for everyone who comes after **[contested]** | They inherit the audit record itself - its completeness later depends entirely on choices made now **[factual]** |
+
+### Trade-off pattern read-out
+
+Read the grid as a pattern, not a sum. This is the payoff.
+
+- **Who bears the burdens, and on which principle:** the burden concentrates on **template authors** - on autonomy (a reviewer now gates their work) and on wellbeing (lost authoring speed). They carry the heaviest process cost so that other parties gain assurance. **Approvers/admins** carry a secondary burden: a review workload that can become a bottleneck.
+- **Where one party's benefit is paid for by another's burden:** customer compliance/IT's control-and-auditability benefit and end users' wellbeing benefit (reviewed, safer templates) are both paid for by template authors' lost autonomy and speed. That is the central crossing - the gate moves cost upstream to authors and assurance downstream to consumers and compliance. A second crossing: the regulated ~30% get a control they need; if the same gate is imposed on all, the ~70% who want speed pay for a benefit they do not use.
+- **The contested cells the assessment turns on:** the author-autonomy-and-fairness cells (is it acceptable to make every author route through a gate for a risk only some templates carry?) and the compliance-fairness cell (should the whole customer base bear the strictest segment's control cost?). The whole judgment hangs on these - which is where deliberation, and the acceptance criteria, should focus.
+- **Voiceless parties' exposure:** the grid makes plain that the two parties with no one in the room - end users and future members/auditors - mostly *benefit* (safer templates, a complete audit trail), but their benefit depends entirely on choices the present parties make now; a gate set too light to satisfy compliance, or so heavy authors route around it, fails the voiceless rows silently because nobody is there to object.
+
+### No-verdict footer
+
+> This matrix maps the moral terrain of adding approval gates to Blueprints across affected parties and principles. It is **not a score, a ranking, or a recommendation**, and it emits **no verdict**. It surfaces that the cost concentrates on authors' autonomy and speed while assurance flows to compliance and end users, and that the judgment turns on whether the strictest segment's control needs should set the gate for everyone; the weighing of those cells - what the gate should require, and for whom - is left to deliberation among the people who must decide (Schroeder and Palmer, 2003: the matrix is helpful for unpacking and fact-finding but "much less helpful" for weighing).
+
+### Evidence caveat (ships with the artifact)
+
+> **Evidence tier: P (practitioner).** The ethical matrix has roughly twenty-five years of multi-domain application and serious methodological scrutiny, but **no controlled outcome study** exists - there is no measured evidence that using it produces better or more defensible ethical assessments, and no effect size is claimed here. All of that evidence is **human group-deliberation practice; none is on AI agents**, so this agent-produced matrix is a transferred-evidence application, not a validated one. Treat it as a trade-off-mapping aid that made the trade-offs visible and contestable - not as a measure of how ethical the gate design is, and not as a decision. See `evidence/dossier.md`.
+
+## Why this prompt worked
+
+It named one concrete **option** (gating publication on reviewer approval), gave an explicit **stakeholder roster** including the parties who consume but do not author, and named the **values in tension** - which mapped cleanly onto principle columns, with control-and-auditability earning its own adapted axis. Critically, Priyanka asked for the grid **before** writing acceptance criteria, which is the right order: the matrix is a terrain map, not a verdict, so its job is to make the trade-offs visible while the design is still open. Naming the values up front let the framework do the thing it does best - hold both axes at once so the author-versus-compliance trade-off could not slide out of view.
+
+## The handoff to pm-skills
+
+The filled grid feeds pm-skills' `discover-stakeholder-summary` - the decision layer hands the delivery layer a stakeholder picture that already names who gains and who pays, not just who exists. And the matrix's contested cells become explicit constraints in pm-skills' `deliver-acceptance-criteria`: the author-autonomy burden and the regulated-segment-versus-everyone fairness tension cross the boundary as design constraints the criteria must honor (for example, that a low-risk template should not pay the strictest segment's process cost), so the trade-offs the matrix surfaced get encoded deliberately rather than discovered late.
+
+## Next in the thread
+
+Next in Workbench's thread: with the stakeholders mapped, Priyanka structures the open question of whether enterprises will actually adopt gated Blueprints. See [Workbench structures the adoption question](../workbench-issue-tree-adoption/).


### PR DESCRIPTION
## What

The Track B Showcase: three companies (Storevine, Brainshelf, Workbench), three decisions each, every page ending by handing the reasoning artifact off to the pm-skills delivery artifact it feeds - **tfs decides, pm-skills delivers**. Plan: `docs/internal/plans/2026-06-17-track-b-showcase.md`.

## The 9 pages (9 distinct shipped skills)
- **Storevine** (organized): problem-restatement, decision-option-review, red-team-light
- **Brainshelf** (casual): boundary-critique, reference-class-forecasting, premortem
- **Workbench** (enterprise): ethical-matrix, issue-tree, expected-value-decision-tree

Each page is a full prompt-to-artifact run with a prose handoff to a named pm-skills artifact and a next-in-thread link.

## How
Authored via a 9-subagent Workflow primed with the exemplar + cast profile + a per-company **thread fact-sheet** (the carry-forward context keeping cast/numbers/timeline consistent across a thread). Handoffs are prose, not links (pm-skills is a separate site). Index gains a "Browse by company" section.

## Side effect
Example coverage 17/56 -> 21/56; baseline tightened 39 -> 35.

## Verification
Gate 0/0 (8 layers), npm 52/52, site build 216pp, rendered-links 0 (STRICT, after fixing 6 sibling-link paths), route-parity 208/208. Site content only - no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)