### PR TITLE
chore: re-grade red-team-light P -> M (transferred) via the engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Each skill is built around four commitments, not just a prompt:
 | [`think-authentic-dissent`](skills/think-authentic-dissent/SKILL.md) | assumption-and-belief-challenge | **S** | dissent audit |
 | [`think-consider-the-unknowns`](skills/think-consider-the-unknowns/SKILL.md) | assumption-and-belief-challenge | M | known unknowns ledger |
 | [`think-ladder-of-inference-check`](skills/think-ladder-of-inference-check/SKILL.md) | assumption-and-belief-challenge | P | reasoning trace |
-| [`think-red-team-light`](skills/think-red-team-light/SKILL.md) | assumption-and-belief-challenge | P | adversarial critique |
+| [`think-red-team-light`](skills/think-red-team-light/SKILL.md) | assumption-and-belief-challenge | M | adversarial critique |
 | [`think-decision-option-review`](skills/think-decision-option-review/SKILL.md) | decision-and-option-evaluation | P | option matrix |
 | [`think-dialectical-bootstrapping`](skills/think-dialectical-bootstrapping/SKILL.md) | decision-and-option-evaluation | M | dialectical estimate |
 | [`think-expected-value-decision-tree`](skills/think-expected-value-decision-tree/SKILL.md) | decision-and-option-evaluation | P | decision tree ev |

--- a/docs/internal/research/framework-catalog.md
+++ b/docs/internal/research/framework-catalog.md
@@ -41,7 +41,7 @@ The empirical core (the evidence anchor): premortem, brainwriting/NGT, reference
 | Framework | Mechanism | Tier | Status |
 |---|---|---|---|
 | Parallel Perspectives Review | examine a decision through separated lenses (facts/upside/risk/intuition/alternatives/process) | P | `[shipped]` |
-| Red Team / Blue Team | construct the strongest adversarial case against a thesis | P | `[shipped]` |
+| Red Team / Blue Team | construct the strongest adversarial case against a thesis | M | `[shipped]` |
 | Stakeholder Lens Review | walk a proposal through each affected party's eyes | P | `[fold]` -> Parallel Perspectives Review |
 | Steelmanning | state the strongest version of an opposing view before responding | P | `[fold]` -> Red Team / Blue Team |
 | Six Thinking Hats | branded parallel-thinking ritual | X | `[flag]` (branded) |

--- a/frameworks/registry.mjs
+++ b/frameworks/registry.mjs
@@ -70,11 +70,11 @@ export default {
       slug: 'red-team-light',
       name: 'Red Team / Blue Team',
       family: 'perspective-shifting-and-multi-lens',
-      tier: 'P',
+      tier: 'M',
       status: 'shipped',
       verdict: 'shipped',
       oneLine: 'construct the strongest adversarial case against a thesis',
-      reasoning: "Shipped as red-team-light; absorbs steelmanning as its core move. Enrichment (v0.7.0): consider-the-opposite (Lord, Lepper and Preston 1984; Mussweiler, Strack and Pfeiffer 2000) and consider-an-alternative / multiple-explanation (Hirt and Markman 1995) supply strong controlled debiasing evidence for the core move of forcing the mind off its first agreeable framing to generate the contrary case, while Nemeth (2001) on authentic vs role-played dissent remains the load-bearing honesty flag - so the evidence base strengthens at the mechanism level without a hand tier change at the artifact level (flagged for a think-research-framework re-grade, P to possibly M).",
+      reasoning: "Shipped as red-team-light; absorbs steelmanning as its core move. Re-graded P -> M (transferred) 2026-06-19 via think-research-framework (engine verdict). The skill's core operation - suspend the first agreeable framing and construct the strongest contrary case - is the consider-the-opposite operation shown to reduce biased assimilation, anchoring, and overconfidence in controlled human debiasing studies (Lord, Lepper and Preston 1984; Mussweiler, Strack and Pfeiffer 2000; Hirt and Markman 1995); under the anti-laundering test this is the SAME operation, not a cousin's borrowed robustness (the added steelman/rank/rebuttal/verdict craft is artifact structure on the evidenced move), and the library already routes consider-the-opposite's M-tier evidence here in the inversion, counterfactual-reasoning, and dialectical-synthesis entries. Nemeth, Brown and Rogers (2001) does NOT cap the grade because it measures group minority dissent (role-played vs authentic), a different reference class from self-administered debiasing; it is retained as the load-bearing honesty flag that constructed dissent is not authentic dissent (seek a real dissenter at high stakes). Capped at M, not S, because all evidence is human-subject and not AI-agent-validated.",
       evalCases: 'skills/think-red-team-light/eval/cases.md',
       aliases: ['Red Team', 'Blue Team'],
       sources: [

--- a/site/public/catalog.json
+++ b/site/public/catalog.json
@@ -1041,7 +1041,7 @@
       "invocation": "think-red-team-light",
       "name": "Red Team / Blue Team",
       "family": "perspective-shifting-and-multi-lens",
-      "evidence_tier": "P",
+      "evidence_tier": "M",
       "mechanism": "construct the strongest adversarial case against a thesis",
       "when_to_use": "Use when a plan has too-easy consensus and needs pressure-testing, or to steelman the opposition before committing.",
       "artifact": "adversarial-critique",

--- a/site/public/evaluated.json
+++ b/site/public/evaluated.json
@@ -1143,7 +1143,7 @@
       "slug": "red-team-light",
       "name": "Red Team / Blue Team",
       "family": "perspective-shifting-and-multi-lens",
-      "tier": "P",
+      "tier": "M",
       "status": "shipped",
       "verdict": "shipped",
       "fold_into": null,

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -23,7 +23,7 @@ This is the expanded llms.txt: every invokable component inlined with its routin
 #### think-red-team-light
 - Name: Red Team / Blue Team
 - Family: perspective-shifting-and-multi-lens
-- Evidence tier: P
+- Evidence tier: M
 - Mechanism: construct the strongest adversarial case against a thesis
 - When to use: Use when a plan has too-easy consensus and needs pressure-testing, or to steelman the opposition before committing.
 - Produces: adversarial-critique

--- a/skills/think-framework-advisor/references/recommendable.json
+++ b/skills/think-framework-advisor/references/recommendable.json
@@ -1067,7 +1067,7 @@
       "name": "think-red-team-light",
       "id": "thinking-framework-skills.red-team-light",
       "family": "assumption-and-belief-challenge",
-      "tier": "P",
+      "tier": "M",
       "description": "Produces an adversarial critique by constructing the strongest case against a proposal or thesis (the best objections an intelligent adversary would raise), then judging which objections actually land and what would rebut them. Use when a plan has too-easy consensus and needs pressure-testing, or to steelman the opposition before committing.",
       "anti_triggers": [
         "\"The free-tier launch flopped last quarter. Walk us through what went wrong and what we'd do differently.\" (postmortem)",

--- a/skills/think-framework-advisor/references/recommendable.md
+++ b/skills/think-framework-advisor/references/recommendable.md
@@ -52,7 +52,7 @@
 | `think-process-tracing` | systems-and-consequences | P | Evaluates rival causal explanations of a single case by typing each piece of within-case evidence by its diagnosticity (hoop, smoking-gun, straw-in-the-wind, d... |
 | `think-pyramid-principle` | synthesis | P | Produces a pyramid that structures a recommendation answer-first - a single governing thought on top, a small set of MECE, deliberately ordered key arguments b... |
 | `think-question-burst` | divergent-ideation | P | Generates a rapid burst of questions about a problem (questions only, no answers), then ranks them for which would most change the approach and selects the sin... |
-| `think-red-team-light` | assumption-and-belief-challenge | P | Produces an adversarial critique by constructing the strongest case against a proposal or thesis (the best objections an intelligent adversary would raise), th... |
+| `think-red-team-light` | assumption-and-belief-challenge | M | Produces an adversarial critique by constructing the strongest case against a proposal or thesis (the best objections an intelligent adversary would raise), th... |
 | `think-reference-class-forecasting` | risk-and-resilience | S | Produces a reference-class estimate by defining a class of similar past cases, taking their base-rate distribution of outcomes, and anchoring the forecast on t... |
 | `think-role-storming` | perspective-and-multi-lens | P | Produces a persona-tagged divergent idea list, ideas generated while inhabiting a chosen non-self identity to lower self-censorship and shift associations. |
 | `think-scamper` | divergent-ideation | P | Generates a structured set of variations on an existing idea, product, or process by running it through seven transformation prompts (substitute, combine, adap... |

--- a/skills/think-red-team-light/SKILL.md
+++ b/skills/think-red-team-light/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   id: thinking-framework-skills.red-team-light
   family: assumption-and-belief-challenge
-  evidence-tier: "P"
+  evidence-tier: "M"
   version: 0.1.0
   standard: "0.8"
 ---

--- a/skills/think-red-team-light/evidence/dossier.md
+++ b/skills/think-red-team-light/evidence/dossier.md
@@ -6,7 +6,7 @@
 |---|---|
 | **Skill** | `thinking-framework-skills.red-team-light` (installable name `think-red-team-light`) |
 | **Family** | assumption-and-belief-challenge |
-| **Evidence tier** | **P** (flag: role-played dissent underperforms genuine dissent) |
+| **Evidence tier** | **M (transferred)** (flag: role-played dissent underperforms genuine dissent) |
 | **Confidence** | High that surfacing the strongest counter-case is useful; honest that constructed dissent is weaker than authentic dissent |
 | **Status** | draft (authored 2026-05-31 from the discovery corpus) |
 
@@ -25,9 +25,9 @@ No trademark. Named descriptively.
 
 ## 3. What the evidence shows, and what it does NOT show
 
-**Supported:** adversarial review surfaces objections that cooperative review misses; steelmanning the opposition is a sound reasoning discipline.
+**Supported (M, transferred):** red-team-light's core operation - suspend the first agreeable framing and construct the strongest contrary case - is the "consider the opposite" move shown in controlled human debiasing studies to reduce biased assimilation, anchoring, and overconfidence (Lord, Lepper & Preston 1984; Mussweiler, Strack & Pfeiffer 2000; Hirt & Markman 1995). Under the anti-laundering test this is the SAME cognitive operation the skill performs - the steelman / rank-by-force / rebuttal-test / verdict structure is artifact craft layered on the evidenced move, not a different untested operation - so the M-tier debiasing evidence is red-team-light's own, not a cousin's. Re-graded P -> M (transferred) 2026-06-19 via think-research-framework (engine verdict).
 
-**NOT shown:** that constructed/role-played dissent improves decisions as much as genuine dissent (Nemeth indicates it does not). Grade P with a flag; present it as a blind-spot finder, and where stakes are high, recommend seeking a real dissenting view, not just the model's.
+**NOT shown / the honesty flag:** that constructed / role-played dissent improves decisions as much as GENUINE dissent (Nemeth, Brown & Rogers 2001). That result is a group minority-dissent paradigm - a different reference class from self-administered debiasing - so it does NOT cap the consider-the-opposite grade or this one, but it remains the load-bearing flag: present red-team-light as a blind-spot finder, and where stakes are high, recommend seeking a real dissenting view, not just the model's. Capped at M, not S, because all evidence is human-subject, not AI-validated.
 
 ## 4. Transferred-evidence flag
 
@@ -51,6 +51,9 @@ An **adversarial critique**: the thesis stated fairly, then the strongest object
 ## 7. Sources
 
 1. Red teaming practice (military / intelligence / security).
-2. Nemeth, C. et al. (2001) - authentic dissent vs role-played devil's advocacy (role-play does not replicate the gains).
+2. Nemeth, C., Brown, K. & Rogers, J. (2001) - authentic dissent vs role-played devil's advocacy (role-play does not replicate the gains; the load-bearing honesty flag).
+3. Lord, C., Lepper, M. & Preston, E. (1984) - "consider the opposite" reduces biased assimilation (controlled, self-administered debiasing).
+4. Mussweiler, T., Strack, F. & Pfeiffer, T. (2000) - consider-the-opposite reduces anchoring.
+5. Hirt, E. & Markman, K. (1995) - consider-an-alternative / multiple-explanation improves calibration.
 
 > **Verification status:** the Nemeth finding is well-attested and is deliberately surfaced as the honesty flag. Do not present an AI red team as equivalent to genuine dissent.

--- a/skills/think-red-team-light/evidence/dossier.md
+++ b/skills/think-red-team-light/evidence/dossier.md
@@ -50,10 +50,12 @@ An **adversarial critique**: the thesis stated fairly, then the strongest object
 
 ## 7. Sources
 
-1. Red teaming practice (military / intelligence / security).
-2. Nemeth, C., Brown, K. & Rogers, J. (2001) - authentic dissent vs role-played devil's advocacy (role-play does not replicate the gains; the load-bearing honesty flag).
-3. Lord, C., Lepper, M. & Preston, E. (1984) - "consider the opposite" reduces biased assimilation (controlled, self-administered debiasing).
-4. Mussweiler, T., Strack, F. & Pfeiffer, T. (2000) - consider-the-opposite reduces anchoring.
-5. Hirt, E. & Markman, K. (1995) - consider-an-alternative / multiple-explanation improves calibration.
+1. Red teaming practice (military / intelligence / security) - the lineage; descriptive, not an outcome study.
+2. **Nemeth, C., Brown, K. & Rogers, J. (2001).** "Devil's advocate versus authentic dissent: stimulating quantity and quality." *European Journal of Social Psychology*, 31(6). Role-played devil's advocacy does not replicate the divergent-thinking gains of authentic minority dissent. **The load-bearing honesty flag** (a group-dissent paradigm, so it does not cap the self-administered debiasing grade).
+3. **Lord, C. G., Lepper, M. R. & Preston, E. (1984).** "Considering the opposite: a corrective strategy for social judgment." *Journal of Personality and Social Psychology*, 47(6). The "consider the opposite" instruction reduced biased assimilation of evidence, outperforming even "be unbiased" instructions. Controlled, self-administered - the M-tier core. [M]
+4. **Mussweiler, T., Strack, F. & Pfeiffer, T. (2000).** "Overcoming the inevitable anchoring effect: considering the opposite compensates for selective accessibility." *Personality and Social Psychology Bulletin*, 26(9). Considering the opposite reduced the anchoring bias. [M]
+5. **Hirt, E. R. & Markman, K. D. (1995).** "Multiple explanation: a consider-an-alternative strategy for debiasing judgments." *Journal of Personality and Social Psychology*, 69(6). Generating an alternative explanation improved calibration and reduced overconfidence. [M]
+
+Evidence chain (M, transferred): sources 3-5 are controlled human debiasing studies of the **consider-the-opposite** operation, which is red-team-light's core move (construct the strongest contrary case); the anti-laundering test passes because the skill's steelman / rank / rebuttal / verdict structure is artifact craft on that same evidenced operation, not a different untested one. Source 2 measures a different reference class (group minority dissent) and is retained as the honesty flag, not a tier ceiling. All five are human-subject; none tests an AI agent, so the grade is M (transferred), not S. Re-graded P -> M 2026-06-19 via think-research-framework.
 
 > **Verification status:** the Nemeth finding is well-attested and is deliberately surfaced as the honesty flag. Do not present an AI red team as equivalent to genuine dissent.


### PR DESCRIPTION
Runs the long-flagged `think-research-framework` NAME-mode re-grade on `red-team-light` and applies the **engine's** verdict (not a hand change). **This is a substantive catalog change - merging is the admission.**

## Verdict: P -> M (transferred); Nemeth flag retained

red-team-light's core operation - suspend the first agreeable framing and construct the strongest contrary case - is the **consider-the-opposite** move shown to reduce biased assimilation, anchoring, and overconfidence in controlled human debiasing studies (Lord, Lepper & Preston 1984; Mussweiler, Strack & Pfeiffer 2000; Hirt & Markman 1995) - **M-tier** evidence in this library's scale.

- **Anti-laundering test passes:** same operation, not a cousin's borrowed robustness. The steelman / rank-by-force / rebuttal / verdict structure is artifact craft on the evidenced move. The library *already* routes this M-tier evidence to red-team-light in the inversion, counterfactual-reasoning, and dialectical-synthesis entries.
- **Nemeth (2001) does not cap it:** that result is a *group minority-dissent* paradigm (a different reference class from self-administered debiasing), so it stays the load-bearing honesty flag (constructed dissent is not authentic dissent; seek a real dissenter at high stakes), not a tier ceiling.
- **Capped at M, not S:** all evidence is human-subject, not AI-validated.

## Applied
registry tier P->M + reasoning; SKILL.md `evidence-tier` P->M; dossier tier + evidence section + sources; regenerated framework-catalog, catalog.json, evaluated.json, llms-full.txt, recommendable.{json,md}, AGENTS.md.

## Verification
Gate 0/0 (8 layers incl. the registry-vs-frontmatter tier-consistency check), recommendable-drift clean, npm 52/52, site build 252pp, rendered-links 0 (STRICT). No new skill, no catalog-count change, no version bump.

If you'd rather hold red-team-light at P, just don't merge - nothing else depends on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)