### PR TITLE
docs: surface the Samples corpus + Track B from the top-level pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ Browse them on the [live site](https://thinking-framework-skills.productonpurpos
 | If you want to... | Start here |
 |---|---|
 | Get unstuck or decide, now | The [**Framework Advisor**](https://thinking-framework-skills.productonpurpose.com/tools/think-framework-advisor/) - describe your situation, get a plan |
+| See real decisions worked prompt-to-artifact (incl. the cross-library tfs -> pm-skills handoff) | The [**Showcase**](https://thinking-framework-skills.productonpurpose.com/showcase/) |
+| See one quick worked example of every framework | The [**Samples**](https://thinking-framework-skills.productonpurpose.com/samples/) shelf |
 | Browse by the job you need done | [Explore by job](https://thinking-framework-skills.productonpurpose.com/explore/by-job/) |
 | See only the strong-evidence methods | [Explore by evidence](https://thinking-framework-skills.productonpurpose.com/explore/by-evidence/) |
 | Filter by your situation, live | The [interactive chooser](https://thinking-framework-skills.productonpurpose.com/explore/chooser/) |
@@ -386,7 +388,7 @@ Browse them on the [live site](https://thinking-framework-skills.productonpurpos
 
 ## 📖 Documentation
 
-- **[Live site](https://thinking-framework-skills.productonpurpose.com/)** - the full, searchable, interactive experience (per-framework pages, learning tracks, explorers, the bibliography). This is the home for *using* the library.
+- **[Live site](https://thinking-framework-skills.productonpurpose.com/)** - the full, searchable, interactive experience (per-framework pages, learning tracks, explorers, the bibliography, the [Showcase](https://thinking-framework-skills.productonpurpose.com/showcase/) and per-framework [Samples](https://thinking-framework-skills.productonpurpose.com/samples/)). This is the home for *using* the library.
 - **[`docs/`](docs/)** - the repo-browser and contributor layer: [architecture](docs/architecture.md), [concepts](docs/concepts.md), [contributing](docs/contributing.md), [conformance](docs/conformance.md), the [authoring loop](docs/internal/AUTHORING.md), and the [release process](docs/internal/release-process.md).
 - **[`skills/`](skills/)** - the frameworks themselves (the source of truth the site renders).
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -42,7 +42,10 @@ A library of thinking frameworks (premortem, reference-class forecasting, argume
 
 <CardGrid>
   <Card title="Show me it working" icon="rocket">
-    The [Showcase](showcase/) walks real decisions from prompt to finished artifact: a founder, an engineer, and a policy analyst working hard problems end to end.
+    The [Showcase](showcase/) walks real decisions from prompt to finished artifact: a founder, an engineer, and a policy analyst, plus three companies that carry a decision across to pm-skills (tfs decides, pm-skills delivers).
+  </Card>
+  <Card title="Just show me one example" icon="document">
+    The [Samples](samples/) shelf has one compact worked example for every framework: a situation, the prompt, and the full artifact, so you can scan the whole catalog by example.
   </Card>
   <Card title="I'm not sure where to start" icon="puzzle">
     Read [the Framework Advisor](frameworks/think-framework-advisor/): describe your situation and get a prioritized plan of which frameworks to use and why.

--- a/site/src/content/docs/learn/index.mdx
+++ b/site/src/content/docs/learn/index.mdx
@@ -9,6 +9,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 **Two essentials first.** [Using the frameworks](./using-the-frameworks/) is the operating guide - how to invoke, describe a situation well, iterate, chain, and use the power-user patterns. The [Prompt Gallery](./prompt-gallery/) shows real prompts in three styles so you can see that a sparse prompt works fine.
 
+**Prefer to learn by example?** Watch the frameworks run end to end in the [Showcase](../showcase/), or scan one compact worked example of every framework on the [Samples](../samples/) shelf.
+
 Then six curated paths. Each is an ordered sequence of frameworks with the reasoning for the order, so you learn a coherent move set rather than a pile of tools. New here? Start with the 30-minute sampler.
 
 <CardGrid>


### PR DESCRIPTION
Today's new content (the 56-skill **Samples** corpus and the **Track B** cross-library Showcase threads) was only reachable from the sidebar - the landing page, Learn index, and README did not mention either. This surfaces them from the front door:

- **Landing page**: the Showcase card now names the cross-library company threads; a new "Just show me one example" card points at the Samples shelf.
- **README "Find your way in"**: added Showcase + Samples rows (both were missing); the live-site bullet now names them.
- **Learn index**: a learn-by-example pointer to Showcase + Samples.

Gate 0/0, build 252pp, rendered-links 0 (STRICT), route-parity 208/208. Docs/site only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)