### PR TITLE
docs: contested-lenses spec + plan_v0.11.0 (agentic execution plan)

### DIFF
--- a/docs/internal/release-plans/plan_v0.11.0/README.md
+++ b/docs/internal/release-plans/plan_v0.11.0/README.md
@@ -1,0 +1,102 @@
+# plan_v0.11.0 - Contested lenses (the famous-but-weak frameworks, caveat-first)
+
+**Status:** planned, build-ready (not started). Intended for a fresh session to execute agentically.
+**Theme:** ship the distinct-but-weak rejected frameworks (SWOT, MBTI, OODA, Cynefin, ...) as honest, low-tier, caveat-first skills. The plugin helps a user through a lens they asked for while teaching its deficiency, instead of a flat refusal. The honest-grading brand made stronger, not diluted.
+**Spec (the contract):** `docs/internal/specs/2026-06-19-contested-lenses.md`. Read it first.
+**Version:** minor, **v0.11.0** (new skills). Catalog ~56 -> ~74 shipped.
+
+This plan is written to be run by a new session via dynamic agentic Workflows, with `codex:codex-rescue` adversarial reviews at the brand-critical gates. The phases are ordered to **de-risk before scaling**: prove the caveat-first construction on one hand-authored exemplar and get it adversarially reviewed before any batch fan-out.
+
+## Guardrails (read before any phase)
+
+- **Do not start building skills until Phase 0 finalizes membership and Phase 1's exemplar passes codex review.** The brand-critical risk is a caveat that overclaims or launders; one bad exemplar would replicate across the batch.
+- **The honest tier never changes.** A contested lens keeps its current low grade (X / V / C / A / P). `check-registry.mjs` enforces registry tier == SKILL.md frontmatter evidence-tier; do not "round up."
+- **Caveat-first is the whole feature.** Every SKILL.md leads with the deficiency; every `references/TEMPLATE.md` pre-prints a leading caveat block; every produced artifact opens with it. A lens you can run without seeing its weakness is a failed build.
+- **Reuse the dossier.** Each framework's critique already exists as its Framework Library why-not page (`frameworks/<slug>/dossier.md` or the registry `dossierPath`). Consume it; do not re-research from scratch.
+- **No em-dashes / en-dashes anywhere** (the PreToolUse hook enforces it on Edit/Write; it does NOT catch `fs.writeFileSync` from a node script, so keep script-written content dash-clean and scan after).
+
+## Phase 0 - Finalize membership (deterministic + one classification pass)
+
+Goal: the exact list of contested lenses to build, each with its dossier (the caveat source).
+
+1. For every `excl`/`flag` framework, read its registry `reasoning`. Classify **distinct-but-weak** (no shipped skill performs its core move; rejected on evidence/efficacy/branding) vs **overlap-with-shipped** (the reasoning names a shipped skill as the home of the move). The working split is in the spec; the heuristic is rough, so the borderline excl entries (eisenhower-moscow-pareto, note-and-vote, sensemaking-matrix, insight-statement-generation, concept-knowledge-theory, estimate-talk-estimate, scaled-participation-formats, analysis-of-competing-hypotheses, reflective-equilibrium, qualitative-comparative-analysis) get a per-framework call.
+2. **Codex review (light):** hand codex the candidate list + each one's reasoning and ask it to challenge the distinctness call - is any "distinct" lens actually a near-twin of a shipped skill (which would re-introduce routing ambiguity)? Resolve disputes by dropping the contested entry to documented-only.
+3. Output: `plan_v0.11.0/membership.md` - the final list (~18-22), each with slug, current tier, dossierPath, branded?(TM), and the one-line deficiency the caveat must lead with.
+
+## Phase 1 - Infra + the exemplar (the de-risking gate; one PR, codex-reviewed)
+
+Goal: establish the contested-lens posture and prove it on ONE hand-authored skill before any batch.
+
+1. **The `skill.meta.yml` marker:** add `quality.caveat_first: true` (final name TBD here). Decide how `gen-site.mjs` renders the "use with caution" treatment (a badge variant + a leading admonition on the framework page); decide how the advisor (`gen-recommendable.mjs`) carries the marker so it can surface the caveat.
+2. **The generators + gate accept the new posture:** `excl/flag -> shipped` at low tier; `check-counts.mjs` accepts the higher shipped total; `check-registry.mjs` still passes (tier consistency, IP lint for branded ones, eval-coupling). Update `check-counts` FAMILIES / surfaces as needed.
+3. **Hand-author ONE exemplar end to end:** `think-swot` (distinct, famous, tier X, well-documented deficiency). Full caveat-first anatomy: SKILL.md (deficiency leads), `references/TEMPLATE.md` (pre-printed caveat block), `references/EXAMPLE.md`, `skill.meta.yml` (marker), `eval/cases.md` (Output checks include "leads with the caveat, does not overclaim"); registry `swot: excl/X -> shipped/X`; a caveat-first sample under `samples/`. Regenerate everything; gate 0/0; build + guards.
+4. **Codex adversarial review of the exemplar + infra:** does the caveat honestly represent SWOT's deficiency (Hill & Westbrook 1997) without overclaiming or laundering? Does the artifact lead with it? Does the site "use with caution" treatment read honestly? Have codex WRITE findings to `_agent-context/` + confirm the file exists; fall back to inline review if not retrievable. Resolve.
+5. Merge Phase 1 as its own PR. **This is the template + the proven posture the batch copies.**
+
+## Phase 2 - Batch-build the rest (agentic Workflow)
+
+Goal: author the remaining ~17-21 contested lenses from the exemplar pattern.
+
+- A `Workflow` over the Phase 0 list (minus the exemplar), in serial groups of ~4-5 (the burst-throttle rule; a >20-way fan-out trips a server-side limit). One `general-purpose` subagent per lens, primed with, and only with:
+  - the **exemplar** `think-swot` skill (the caveat-first format to match),
+  - the framework's **dossier** (the deficiency source - do not re-research),
+  - the registry **reasoning** + its tier + branded?(TM),
+  - the **caveat-first rules** (deficiency leads SKILL.md; TEMPLATE pre-prints the caveat; the artifact opens with it; branded -> descriptive name + attribution + TM),
+  - `docs/internal/CONTENT-STYLE.md` (voice, no-dash, links) and the eval-cases requirement (Output checks include the caveat check).
+  - Each subagent writes ONLY its own `skills/think-<slug>/` anatomy + a caveat-first `samples/<slug>.md`. The registry status changes are applied CENTRALLY after the batch (avoid a write race on registry.mjs).
+- Workflow gotchas: the result is wrapped under `.result` in the task output file (the notification truncates - parse the output file); `agentType: 'general-purpose'` so the agent can Write; `resumeFromRunId` recovers any rate-limited stragglers from cache.
+
+## Phase 3 - Integrate + regenerate + gate
+
+- Apply all `excl/flag -> shipped` registry status changes centrally (a surgical text-replace keeps the other entries byte-identical; the em-dash hook does not catch a node script).
+- Regenerate every derived surface: `gen-registry`, `gen-recommendable`, `gen-site`, `gen-agents`, `gen-catalog`; then `gen-manifest` + `gen-index` (at the cut).
+- Sweep the **count surfaces** (not all gated): README's four surfaces + the prose, `docs/architecture.md` (shipped count + the new contested posture + add to the generators if needed), `docs/getting-started.md`, `docs/README.md`, the catalog-table headers, the gen-site family intros. (This session found architecture.md prose drift the gate does not catch - sweep it deliberately.)
+- Example coverage: each new shipped skill has its caveat-first sample (or grandfather it, with reason). `check-example-coverage.mjs --update`.
+- Gate green: `node scripts/check.mjs` 0/0 (8 layers); `gen-recommendable.mjs --check` (separate CI job); `npm test`; `npm --prefix site run build` + `check-rendered-links.mjs` (STRICT) + `check-route-parity.mjs`.
+
+## Phase 4 - Evals (the caveat-enforcing measurement)
+
+- Run the existing harness (`scripts/eval/`) on the new skills, both evals:
+  - **Trigger:** confirms routing stays clean - the distinct lenses route to themselves; **0 false-fires must hold** (a contested lens must not over-grab a situation meant for a stronger shipped skill). Batch serial groups of ~4 (throttle); `resumeFromRunId` for stragglers.
+  - **Output:** the per-skill "Output checks" include **"leads with the caveat and does not overclaim"** - so the output eval *enforces* the caveat-first design. The misses (if any) are the precise skills to tighten.
+- Write dated scorecards under `docs/internal/eval-results/`; stamp `trigger_eval_status` / `output_eval_status`. Report the contested subset's numbers distinctly in the scorecard (so the graded-skills headline stays legible), but they are honestly-graded skills, so they are part of the run.
+
+## Phase 5 - Adversarial review (codex, brand-critical)
+
+- `codex:codex-rescue` reviews the built batch for: (1) **evidence-honesty** - does each caveat honestly represent the framework's deficiency per its dossier, with no laundering, no overclaim, no false endorsement? (2) **distinctness** - does any lens compete with a shipped skill in routing? (3) **IP** - branded ones attributed + TM-flagged? (4) **caveat-first construction** - does every artifact lead with the deficiency? (5) any famous framework whose deficiency is *understated*.
+- Retrievability lesson: instruct codex to WRITE findings to `_agent-context/v0.11.0-codex-review.md` and confirm the file exists; if it does not (the known codex-rescue sandbox limitation), do the review **inline and deterministically** instead (do not claim a codex review happened if no findings landed). Resolve all blockers/majors.
+- Consider a parallel **reviewer Workflow** (one reviewer per built skill) as this session used for the 44-page content - it catches dishonest or overclaiming caveats that structural checks and spot-reads miss.
+
+## Phase 6 - Release cut v0.11.0
+
+Per `docs/internal/release-process.md` (the v0.10.0 cut in `plan_v0.10.0` is the worked precedent):
+1. CHANGELOG `[Unreleased]` -> `[0.11.0]` + a milestone line + fresh `[Unreleased]`; compare-link footer.
+2. Version 0.10.0 -> 0.11.0 (`library.json` + `package.json`); regen manifests + INDEX (the diff is version + the new roster - confirm only the contested lenses changed, not unexpected drift).
+3. RELEASE-NOTES v0.11.0 - lead with the **brand framing**: "every skill is evidence-graded, including the famous-but-weak ones we now hand you caveat-first." For-everyone + for-builders.
+4. README: version badge + project-status + current-version + a release-history row; sweep the shipped count (~74) across the four count surfaces.
+5. Reconcile `release-plans/README.md` (this row Planned -> Shipped) and this plan's status.
+6. **Codex review of the cut** (counts/version consistency across all surfaces, CHANGELOG/RELEASE-NOTES accuracy, the new-count sweep) - inline-fallback if not retrievable.
+7. Gated steps (human authorizes): tag `v0.11.0` on the merge commit + push + GitHub release; **marketplace re-pin** on `product-on-purpose/agent-plugins` (use a git worktree off `origin/main`; update the tfs `sha` + `version` + bump `metadata.version`; `validate-registry.mjs` with `GITHUB_TOKEN`). Verify the deploy + footer.
+
+## Reusable lessons carried in (from the 2026-06-19 session)
+
+- **Batch agentic fan-outs into serial groups of ~4-5**; a >20-way Opus fan-out trips a server-side burst throttle ("not your usage limit"). `resumeFromRunId` recovers stragglers from cache.
+- **Workflow output is wrapped** (`{summary, logs, result}`) in the task `.output` file; the notification truncates - read the file and parse `.result`.
+- **codex:codex-rescue results are often not retrievable** (encrypted rollout / sandbox); have codex write findings to a repo file AND confirm it exists, or do the review inline. Never claim a review that produced no retrievable findings.
+- **A reviewer Workflow catches what structural checks miss** - it found fabricated arithmetic on a page that passed sections/dashes/links/build. Run an adversarial verify on the built artifacts (here: dishonest/overclaiming caveats).
+- **Prose-doc drift is not gated.** architecture.md had a stale gate-layer count (6, actually 8) and method count (105, actually 135) despite the count gate. Sweep the hand-authored docs by hand on a count change.
+- **gen-manifest is not per-PR**; it catches up the roster at the cut. **recommendable-drift is a separate CI job** (`gen-recommendable --check`). The native-manifest diff at the cut should be version + the new roster only.
+- **Showcase/sample link rules:** sibling showcase links use `../<slug>/` (a page is served at `/showcase/<slug>/`); samples link `../../frameworks/think-<slug>/` and `../../showcase/`.
+- **IP lint:** branded -> attribution + trademark required; descriptive naming.
+
+## Continuation prompt (paste into the new session)
+
+```
+Build plan_v0.11.0: ship the distinct-but-weak rejected frameworks as honest, low-tier, CAVEAT-FIRST skills (the "contested lenses"). Repo: E:/Projects/product-on-purpose/thinking-framework-skills. Read FIRST: docs/internal/specs/2026-06-19-contested-lenses.md (the contract) and docs/internal/release-plans/plan_v0.11.0/README.md (this plan). This is an agentic build via dynamic Workflows with codex:codex-rescue adversarial reviews at the brand-critical gates.
+
+Hard rules: caveat-first is the whole feature (deficiency leads the SKILL.md AND the artifact; reuse each framework's existing why-not dossier as the caveat source). The honest low tier never changes. No em-dashes. Distinct-only (anything that overlaps a shipped skill stays documented-only - it would degrade routing).
+
+Order (de-risk before scaling): Phase 0 finalize membership (per-framework distinctness call + a light codex challenge) -> Phase 1 infra + ONE hand-authored exemplar (think-swot) + codex review of it BEFORE any batch (this is the template the batch copies) -> Phase 2 batched authoring Workflow (serial groups of ~4-5, one general-purpose subagent per lens, primed with the exemplar + the dossier + the caveat-first rules; registry changes applied centrally) -> Phase 3 integrate + regen all generators + sweep the count surfaces (incl. the un-gated prose docs) + example coverage + gate 0/0 -> Phase 4 run both evals (the output eval ENFORCES the caveat; trigger must hold 0 false-fires) -> Phase 5 codex evidence-honesty + distinctness + IP review of the batch (write findings to a file + confirm, or inline) -> Phase 6 cut v0.11.0 per release-process.md (CHANGELOG/version/manifests/RELEASE-NOTES/README/reconcile), codex-review the cut, then the gated tag + push + GitHub release + agent-plugins marketplace re-pin (worktree off origin/main).
+
+Do NOT start building skills until Phase 0 membership is final and Phase 1's exemplar passes codex review. Gate mechanics: node scripts/check.mjs (8 layers) + gen-recommendable.mjs --check (separate) + npm test + site build + rendered-links (STRICT_ANCHORS=1) + route-parity. Throttle: batch ~4-5; resumeFromRunId recovers stragglers; Workflow output is under .result in the task .output file.
+```

--- a/docs/internal/release-plans/plan_v0.11.0/README.md
+++ b/docs/internal/release-plans/plan_v0.11.0/README.md
@@ -1,102 +1,97 @@
 # plan_v0.11.0 - Contested lenses (the famous-but-weak frameworks, caveat-first)
 
-**Status:** planned, build-ready (not started). Intended for a fresh session to execute agentically.
-**Theme:** ship the distinct-but-weak rejected frameworks (SWOT, MBTI, OODA, Cynefin, ...) as honest, low-tier, caveat-first skills. The plugin helps a user through a lens they asked for while teaching its deficiency, instead of a flat refusal. The honest-grading brand made stronger, not diluted.
-**Spec (the contract):** `docs/internal/specs/2026-06-19-contested-lenses.md`. Read it first.
-**Version:** minor, **v0.11.0** (new skills). Catalog ~56 -> ~74 shipped.
+**Status:** approved in principle; **revised after codex adversarial review** (`_agent-context/v0.11.0-spec-codex-review.md`). NOT build-ready until Phase 0 finalizes the contract (membership, the marker, the advisor policy, the site rendering, the eval-reporting posture). For a fresh session to execute agentically.
+**Theme:** ship the small set of rejected frameworks that are genuinely *agent-runnable but weak* (SWOT and a few peers) as honest, low-tier, caveat-first skills; handle the famous-but-unrunnable instruments (MBTI and friends) with a single cautionary redirect. Honest-grading made stronger, not diluted.
+**Spec (the contract):** `docs/internal/specs/2026-06-19-contested-lenses.md`. Read it first - it was tightened by the review and the buildable set is much smaller than the first draft implied (~5-12, SWOT the worked example).
+**Version:** minor, **v0.11.0**. Catalog 56 core -> 56 core + N contested (reported as separate cohorts, not a single "74").
 
-This plan is written to be run by a new session via dynamic agentic Workflows, with `codex:codex-rescue` adversarial reviews at the brand-critical gates. The phases are ordered to **de-risk before scaling**: prove the caveat-first construction on one hand-authored exemplar and get it adversarially reviewed before any batch fan-out.
+De-risk before scale: prove the caveat-first contract (the validator + one exemplar) and get it adversarially reviewed before any batch fan-out. The review confirmed this ordering is right; it also found the contract itself was under-built (no validator, no advisor policy, missing registration steps) - all folded in below.
 
-## Guardrails (read before any phase)
+## Guardrails
 
-- **Do not start building skills until Phase 0 finalizes membership and Phase 1's exemplar passes codex review.** The brand-critical risk is a caveat that overclaims or launders; one bad exemplar would replicate across the batch.
-- **The honest tier never changes.** A contested lens keeps its current low grade (X / V / C / A / P). `check-registry.mjs` enforces registry tier == SKILL.md frontmatter evidence-tier; do not "round up."
-- **Caveat-first is the whole feature.** Every SKILL.md leads with the deficiency; every `references/TEMPLATE.md` pre-prints a leading caveat block; every produced artifact opens with it. A lens you can run without seeing its weakness is a failed build.
-- **Reuse the dossier.** Each framework's critique already exists as its Framework Library why-not page (`frameworks/<slug>/dossier.md` or the registry `dossierPath`). Consume it; do not re-research from scratch.
-- **No em-dashes / en-dashes anywhere** (the PreToolUse hook enforces it on Edit/Write; it does NOT catch `fs.writeFileSync` from a node script, so keep script-written content dash-clean and scan after).
+- **Do not build any skill until Phase 0 produces the final list AND Phase 1's validator + exemplar pass codex review.** The brand risk is a caveat that overclaims or launders, replicated by a batch.
+- **Caveat-first is a CHECKED contract, not a style** - `scripts/check-contested.mjs` (new, Phase 1) enforces caveat placement; a build that puts the caveat late or omits it from the template is a red gate.
+- **The honest low tier never changes** (`check-registry` enforces registry tier == frontmatter evidence-tier). `caveat_first` is a posture marker, not a second tier.
+- **Three-test admission** (Phase 0): distinct AND agent-runnable (procedure + reusable artifact + a caveated mode that does not reproduce the falsified claim) AND in-charter. Anything failing any test stays documented-only or goes to the cautionary applicator. SWOT is the model.
+- **No em-dashes / en-dashes** (the hook does not catch `fs.writeFileSync` from a node script - keep script-written content clean and scan after).
 
-## Phase 0 - Finalize membership (deterministic + one classification pass)
+## Phase 0 - Finalize the contract (membership + the decisions, not "discovered")
 
-Goal: the exact list of contested lenses to build, each with its dossier (the caveat source).
+Goal: the final qualifying list AND the contract decisions Phase 1 will implement.
 
-1. For every `excl`/`flag` framework, read its registry `reasoning`. Classify **distinct-but-weak** (no shipped skill performs its core move; rejected on evidence/efficacy/branding) vs **overlap-with-shipped** (the reasoning names a shipped skill as the home of the move). The working split is in the spec; the heuristic is rough, so the borderline excl entries (eisenhower-moscow-pareto, note-and-vote, sensemaking-matrix, insight-statement-generation, concept-knowledge-theory, estimate-talk-estimate, scaled-participation-formats, analysis-of-competing-hypotheses, reflective-equilibrium, qualitative-comparative-analysis) get a per-framework call.
-2. **Codex review (light):** hand codex the candidate list + each one's reasoning and ask it to challenge the distinctness call - is any "distinct" lens actually a near-twin of a shipped skill (which would re-introduce routing ambiguity)? Resolve disputes by dropping the contested entry to documented-only.
-3. Output: `plan_v0.11.0/membership.md` - the final list (~18-22), each with slug, current tier, dossierPath, branded?(TM), and the one-line deficiency the caveat must lead with.
+1. **Three-bucket classification, per framework, from the registry's own reasoning** (not a heuristic): `distinct-runnable-weak` (ships as a contested-lens skill) / `overlap-with-shipped` (documented-only) / `out-of-charter-or-not-agent-runnable` (documented-only or the cautionary applicator). Record a one-line pass/fail on each of the three tests for every excl/flag entry. Expect the ships-as-skill set to be small (~5-12). SWOT passes; MBTI/DISC/Enneagram/learning-styles/strong-interest/belbin/cliftonstrengths fail (instrument / overlap); porters/jtbd/blue-ocean/ice-rice-wsjf fail (pm-domain); dot-voting/note-and-vote/scaled-participation fail (human-only); ooda fails (agent-architecture).
+2. **IP screen** for any branded survivor: pick a descriptive slug/name (no `think-mbti`/`think-cynefin`/`think-porters-five-forces`); keep the branded term as an attributed alias in caveat prose, or exclude if the trademarked name is inseparable from the skill.
+3. **Decide the contract** (these were "open questions"; resolve them now, not while authoring): the exact `skill.meta.yml` marker (`quality.caveat_first` + `quality.recommendation_policy: explicit_request_only`); how `gen-site.mjs` renders the "use with caution" admonition + non-green badge; how `gen-recommendable.mjs` + `check-registry.mjs` become policy-aware so a contested lens is in the corpus but never a default recommendation; the eval-reporting posture (core-56 and contested reported as separate cohorts).
+4. **Codex review (light):** challenge the distinctness + runnability calls - is any "ships" candidate actually a near-twin of a shipped skill or not agent-runnable? Drop disputed ones.
+5. Output: `plan_v0.11.0/membership.md` (final list + per-framework three-test record + chosen descriptive names + dossierPath) and a short `contract.md` (the marker schema, the advisor policy, the rendering, the eval posture).
 
-## Phase 1 - Infra + the exemplar (the de-risking gate; one PR, codex-reviewed)
+## Phase 1 - Build the contract + the exemplar (the de-risking gate; one PR, codex-reviewed)
 
-Goal: establish the contested-lens posture and prove it on ONE hand-authored skill before any batch.
+Goal: the enforcement + posture infra, proven on ONE skill, before any batch.
 
-1. **The `skill.meta.yml` marker:** add `quality.caveat_first: true` (final name TBD here). Decide how `gen-site.mjs` renders the "use with caution" treatment (a badge variant + a leading admonition on the framework page); decide how the advisor (`gen-recommendable.mjs`) carries the marker so it can surface the caveat.
-2. **The generators + gate accept the new posture:** `excl/flag -> shipped` at low tier; `check-counts.mjs` accepts the higher shipped total; `check-registry.mjs` still passes (tier consistency, IP lint for branded ones, eval-coupling). Update `check-counts` FAMILIES / surfaces as needed.
-3. **Hand-author ONE exemplar end to end:** `think-swot` (distinct, famous, tier X, well-documented deficiency). Full caveat-first anatomy: SKILL.md (deficiency leads), `references/TEMPLATE.md` (pre-printed caveat block), `references/EXAMPLE.md`, `skill.meta.yml` (marker), `eval/cases.md` (Output checks include "leads with the caveat, does not overclaim"); registry `swot: excl/X -> shipped/X`; a caveat-first sample under `samples/`. Regenerate everything; gate 0/0; build + guards.
-4. **Codex adversarial review of the exemplar + infra:** does the caveat honestly represent SWOT's deficiency (Hill & Westbrook 1997) without overclaiming or laundering? Does the artifact lead with it? Does the site "use with caution" treatment read honestly? Have codex WRITE findings to `_agent-context/` + confirm the file exists; fall back to inline review if not retrievable. Resolve.
-5. Merge Phase 1 as its own PR. **This is the template + the proven posture the batch copies.**
+1. **`scripts/check-contested.mjs`** (new gate layer, wired into `check.mjs` - the gate becomes 9 layers): identifies contested skills by the marker; asserts the leading-caveat contract on SKILL.md / TEMPLATE / EXAMPLE / sample / eval-cases, and (branded) the attribution + trademark in the leading caveat block. Negative-test it (a late caveat must red the gate).
+2. **Advisor policy plumbing:** `skill.meta.yml` marker schema; `gen-recommendable.mjs` carries `recommendation_policy` + `caveat_first`; `check-registry.mjs` shipped==recommendable becomes policy-aware; the advisor SKILL.md + its eval cases enforce explicit-request-only for contested lenses.
+3. **Generators:** `gen-site.mjs` renders the "use with caution" admonition + badge from the marker; `gen-catalog.mjs` carries the marker.
+4. **Hand-author ONE exemplar end to end: SWOT** (distinct, agent-runnable, tier X). Full caveat-first anatomy passing `check-contested`: SKILL.md (deficiency leads), TEMPLATE (pre-printed caveat block), EXAMPLE, `skill.meta.yml` (markers), `eval/cases.md` (caveat output-check); **register it in `library.json`**; registry `swot: excl/X -> shipped/X`; update `scripts/route-manifest.txt` for `/frameworks/think-swot/`; a caveat-first sample at `site/src/content/docs/samples/swot.md`. Regenerate everything; gate 0/0 (incl. check-contested); build + link/route guards.
+5. **The cautionary applicator** (for the famous-but-unrunnable instruments): a single, non-recommendable, explicit-request-only skill that, when a user names a debunked instrument (MBTI, ...), states the limits and redirects to an evidence-based alternative. Build it here as part of the posture (it is the honest answer for the failed-the-gate famous names).
+6. **Codex adversarial review of the validator + exemplar + applicator** before any batch: is the SWOT caveat honest (Hill & Westbrook 1997) and leading? Does the validator actually bite? Does the applicator redirect honestly without administering the instrument? Write findings to `_agent-context/` + confirm; inline-fallback. Resolve. Merge Phase 1 as its own PR.
 
-## Phase 2 - Batch-build the rest (agentic Workflow)
+## Phase 2 - Batch-build the remaining survivors (agentic Workflow)
 
-Goal: author the remaining ~17-21 contested lenses from the exemplar pattern.
-
-- A `Workflow` over the Phase 0 list (minus the exemplar), in serial groups of ~4-5 (the burst-throttle rule; a >20-way fan-out trips a server-side limit). One `general-purpose` subagent per lens, primed with, and only with:
-  - the **exemplar** `think-swot` skill (the caveat-first format to match),
-  - the framework's **dossier** (the deficiency source - do not re-research),
-  - the registry **reasoning** + its tier + branded?(TM),
-  - the **caveat-first rules** (deficiency leads SKILL.md; TEMPLATE pre-prints the caveat; the artifact opens with it; branded -> descriptive name + attribution + TM),
-  - `docs/internal/CONTENT-STYLE.md` (voice, no-dash, links) and the eval-cases requirement (Output checks include the caveat check).
-  - Each subagent writes ONLY its own `skills/think-<slug>/` anatomy + a caveat-first `samples/<slug>.md`. The registry status changes are applied CENTRALLY after the batch (avoid a write race on registry.mjs).
-- Workflow gotchas: the result is wrapped under `.result` in the task output file (the notification truncates - parse the output file); `agentType: 'general-purpose'` so the agent can Write; `resumeFromRunId` recovers any rate-limited stragglers from cache.
+- A `Workflow` over the Phase 0 list minus SWOT, serial groups of ~4-5 (throttle). One `general-purpose` subagent per lens, primed with: the **SWOT exemplar** (the caveat-first format that passes `check-contested`), the framework's **dossier** (caveat source), the registry reasoning + tier + branded?(descriptive name from Phase 0), the **caveat-first + IP rules**, `CONTENT-STYLE.md`, and the eval-cases caveat requirement. Each writes ONLY its own `skills/think-<slug>/` anatomy + a caveat-first `site/src/content/docs/samples/<slug>.md`. Registry + `library.json` + route-manifest edits are applied CENTRALLY (Phase 3) to avoid write races.
+- Gotchas: Workflow result is under `.result` in the task `.output` file (the notification truncates); `agentType: 'general-purpose'` to Write; `resumeFromRunId` recovers rate-limited stragglers.
 
 ## Phase 3 - Integrate + regenerate + gate
 
-- Apply all `excl/flag -> shipped` registry status changes centrally (a surgical text-replace keeps the other entries byte-identical; the em-dash hook does not catch a node script).
-- Regenerate every derived surface: `gen-registry`, `gen-recommendable`, `gen-site`, `gen-agents`, `gen-catalog`; then `gen-manifest` + `gen-index` (at the cut).
-- Sweep the **count surfaces** (not all gated): README's four surfaces + the prose, `docs/architecture.md` (shipped count + the new contested posture + add to the generators if needed), `docs/getting-started.md`, `docs/README.md`, the catalog-table headers, the gen-site family intros. (This session found architecture.md prose drift the gate does not catch - sweep it deliberately.)
-- Example coverage: each new shipped skill has its caveat-first sample (or grandfather it, with reason). `check-example-coverage.mjs --update`.
-- Gate green: `node scripts/check.mjs` 0/0 (8 layers); `gen-recommendable.mjs --check` (separate CI job); `npm test`; `npm --prefix site run build` + `check-rendered-links.mjs` (STRICT) + `check-route-parity.mjs`.
+1. **Register every new skill in `library.json`** (path, version, tier, status) - BEFORE the generators (PC-01; `gen-catalog` throws if library skill count != registry shipped count).
+2. Apply all `excl/flag -> shipped` registry status changes centrally (surgical text-replace keeps other entries byte-identical).
+3. **Update `scripts/route-manifest.txt`** for the new `/frameworks/think-<slug>/` routes (PC-02): build -> `node scripts/check-route-parity.mjs --update` (or hand-add) -> then `gen-catalog`.
+4. Regenerate: `gen-registry`, `gen-recommendable` (policy-aware), `gen-site`, `gen-agents`, `gen-catalog`; `gen-manifest` + `gen-index` at the cut.
+5. **Example coverage:** each new skill has its caveat-first sample at `site/src/content/docs/samples/<slug>.md` (PC-03). Do NOT `--update` to grandfather; a deferral needs a written exception.
+6. Sweep the **un-gated count/prose surfaces** (the review and this session both flag these): README's four count surfaces + prose, `docs/architecture.md` (shipped count + the new contested posture + the check-contested gate layer + the cautionary applicator), `docs/getting-started.md`, `docs/README.md`, catalog headers, gen-site family intros. Keep the **cohort framing** ("56 core + N contested"), not a merged 74.
+7. Gate green: `node scripts/check.mjs` 0/0 (9 layers incl. check-contested); `gen-recommendable.mjs --check`; `npm test`; site build + `check-rendered-links.mjs` (STRICT) + `check-route-parity.mjs`.
 
-## Phase 4 - Evals (the caveat-enforcing measurement)
+## Phase 4 - Evals (the caveat-enforcing measurement, with release thresholds)
 
-- Run the existing harness (`scripts/eval/`) on the new skills, both evals:
-  - **Trigger:** confirms routing stays clean - the distinct lenses route to themselves; **0 false-fires must hold** (a contested lens must not over-grab a situation meant for a stronger shipped skill). Batch serial groups of ~4 (throttle); `resumeFromRunId` for stragglers.
-  - **Output:** the per-skill "Output checks" include **"leads with the caveat and does not overclaim"** - so the output eval *enforces* the caveat-first design. The misses (if any) are the precise skills to tighten.
-- Write dated scorecards under `docs/internal/eval-results/`; stamp `trigger_eval_status` / `output_eval_status`. Report the contested subset's numbers distinctly in the scorecard (so the graded-skills headline stays legible), but they are honestly-graded skills, so they are part of the run.
+- Run both evals on the new skills (`scripts/eval/`), serial groups of ~4; `resumeFromRunId` for stragglers.
+- **Release-blocking thresholds (PC-04):** **0 false-fires is hard-blocking**; no contested lens may route a generic strategy/people/prioritization prompt away from a stronger shipped skill (verify the advisor explicit-only policy holds in the trigger eval); **every caveat output-check must pass** (the output eval enforces the caveat-first design); the core-56 routing/output numbers must not regress.
+- **Report cohorts separately** (core-56 vs contested) in the scorecard; the public headline stays the core-56 numbers. Stamp the meta; write dated scorecards.
 
 ## Phase 5 - Adversarial review (codex, brand-critical)
 
-- `codex:codex-rescue` reviews the built batch for: (1) **evidence-honesty** - does each caveat honestly represent the framework's deficiency per its dossier, with no laundering, no overclaim, no false endorsement? (2) **distinctness** - does any lens compete with a shipped skill in routing? (3) **IP** - branded ones attributed + TM-flagged? (4) **caveat-first construction** - does every artifact lead with the deficiency? (5) any famous framework whose deficiency is *understated*.
-- Retrievability lesson: instruct codex to WRITE findings to `_agent-context/v0.11.0-codex-review.md` and confirm the file exists; if it does not (the known codex-rescue sandbox limitation), do the review **inline and deterministically** instead (do not claim a codex review happened if no findings landed). Resolve all blockers/majors.
-- Consider a parallel **reviewer Workflow** (one reviewer per built skill) as this session used for the 44-page content - it catches dishonest or overclaiming caveats that structural checks and spot-reads miss.
+- `codex:codex-rescue` (and/or a per-skill reviewer Workflow) reviews the batch for: evidence-honesty (each caveat honestly represents the deficiency per its dossier, no laundering/overclaim/false-endorsement, no famous deficiency understated); distinctness (none competes with a shipped skill in routing); IP (branded -> descriptive name + attribution/TM in the artifact, not only the registry); caveat-first construction (every artifact leads with the deficiency, passing `check-contested`).
+- Write findings to `_agent-context/v0.11.0-batch-review.md` + confirm; inline-fallback if not retrievable (do not claim a review that produced no findings). Resolve blockers/majors.
 
 ## Phase 6 - Release cut v0.11.0
 
-Per `docs/internal/release-process.md` (the v0.10.0 cut in `plan_v0.10.0` is the worked precedent):
-1. CHANGELOG `[Unreleased]` -> `[0.11.0]` + a milestone line + fresh `[Unreleased]`; compare-link footer.
-2. Version 0.10.0 -> 0.11.0 (`library.json` + `package.json`); regen manifests + INDEX (the diff is version + the new roster - confirm only the contested lenses changed, not unexpected drift).
-3. RELEASE-NOTES v0.11.0 - lead with the **brand framing**: "every skill is evidence-graded, including the famous-but-weak ones we now hand you caveat-first." For-everyone + for-builders.
-4. README: version badge + project-status + current-version + a release-history row; sweep the shipped count (~74) across the four count surfaces.
-5. Reconcile `release-plans/README.md` (this row Planned -> Shipped) and this plan's status.
-6. **Codex review of the cut** (counts/version consistency across all surfaces, CHANGELOG/RELEASE-NOTES accuracy, the new-count sweep) - inline-fallback if not retrievable.
-7. Gated steps (human authorizes): tag `v0.11.0` on the merge commit + push + GitHub release; **marketplace re-pin** on `product-on-purpose/agent-plugins` (use a git worktree off `origin/main`; update the tfs `sha` + `version` + bump `metadata.version`; `validate-registry.mjs` with `GITHUB_TOKEN`). Verify the deploy + footer.
+Per `release-process.md` (the v0.10.0 cut in `plan_v0.10.0` is the worked precedent):
+1. CHANGELOG `[Unreleased]` -> `[0.11.0]` + milestone + fresh `[Unreleased]`; footer.
+2. Version 0.10.0 -> 0.11.0 (`library.json` + `package.json`); regen manifests + INDEX (diff = version + the new roster only).
+3. RELEASE-NOTES v0.11.0 - lead with the honest **cohort framing**: "56 evidence-graded core skills, plus N contested explicit-request lenses we grade honestly and hand you caveat-first," and the cautionary applicator for the famous-but-unrunnable.
+4. README: version badge + status + current-version + history row; sweep the count surfaces with cohort framing (not a merged 74).
+5. Reconcile `release-plans/README.md` (this row Planned -> Shipped) + this plan's status.
+6. **Codex review of the cut** (count/version consistency, CHANGELOG/RELEASE-NOTES accuracy, cohort framing, the count-surface sweep); inline-fallback.
+7. Gated (human authorizes): tag `v0.11.0` + push + GitHub release; **marketplace re-pin** on `product-on-purpose/agent-plugins` (git worktree off `origin/main`; tfs `sha`+`version`, bump `metadata.version`; `validate-registry.mjs` with `GITHUB_TOKEN`). Verify the deploy + footer.
 
-## Reusable lessons carried in (from the 2026-06-19 session)
+## Reusable lessons carried in (2026-06-19 session)
 
-- **Batch agentic fan-outs into serial groups of ~4-5**; a >20-way Opus fan-out trips a server-side burst throttle ("not your usage limit"). `resumeFromRunId` recovers stragglers from cache.
-- **Workflow output is wrapped** (`{summary, logs, result}`) in the task `.output` file; the notification truncates - read the file and parse `.result`.
-- **codex:codex-rescue results are often not retrievable** (encrypted rollout / sandbox); have codex write findings to a repo file AND confirm it exists, or do the review inline. Never claim a review that produced no retrievable findings.
-- **A reviewer Workflow catches what structural checks miss** - it found fabricated arithmetic on a page that passed sections/dashes/links/build. Run an adversarial verify on the built artifacts (here: dishonest/overclaiming caveats).
-- **Prose-doc drift is not gated.** architecture.md had a stale gate-layer count (6, actually 8) and method count (105, actually 135) despite the count gate. Sweep the hand-authored docs by hand on a count change.
-- **gen-manifest is not per-PR**; it catches up the roster at the cut. **recommendable-drift is a separate CI job** (`gen-recommendable --check`). The native-manifest diff at the cut should be version + the new roster only.
-- **Showcase/sample link rules:** sibling showcase links use `../<slug>/` (a page is served at `/showcase/<slug>/`); samples link `../../frameworks/think-<slug>/` and `../../showcase/`.
-- **IP lint:** branded -> attribution + trademark required; descriptive naming.
+- Batch agentic fan-outs into serial groups of ~4-5 (a >20-way Opus fan-out trips a server-side burst throttle); `resumeFromRunId` recovers stragglers; Workflow output is under `.result` in the task `.output` file (notification truncates).
+- **codex:codex-rescue results are often not retrievable** - have codex write findings to a repo file AND confirm it; else review inline. Never claim a review that produced no findings. (This very plan was fixed by a codex review that DID land a file - it is worth the attempt.)
+- A per-page/per-skill reviewer Workflow catches dishonest/overclaiming content that structural checks + spot-reads miss.
+- Prose-doc drift is not gated (architecture.md had a stale 6-layer / 105-method count); sweep hand-authored docs by hand on a count change.
+- `gen-manifest` is not per-PR (catches up at the cut); `recommendable-drift` is a separate CI job; the native-manifest diff at the cut is version + roster only.
+- The generators read `library.json`, not `skills/` or the registry alone; `gen-catalog` throws on a library/registry shipped-count mismatch; it validates URLs against `route-manifest.txt`. Register + route-manifest BEFORE regenerating.
+- Samples live at `site/src/content/docs/samples/<slug>.md`; the coverage ratchet scans `showcase/` + `samples/`; `--update` grandfathers (avoid for new skills).
+- IP lint enforces branded -> attribution + trademark in the REGISTRY only; skill/artifact-level IP and descriptive naming need the new `check-contested` validator.
 
 ## Continuation prompt (paste into the new session)
 
 ```
-Build plan_v0.11.0: ship the distinct-but-weak rejected frameworks as honest, low-tier, CAVEAT-FIRST skills (the "contested lenses"). Repo: E:/Projects/product-on-purpose/thinking-framework-skills. Read FIRST: docs/internal/specs/2026-06-19-contested-lenses.md (the contract) and docs/internal/release-plans/plan_v0.11.0/README.md (this plan). This is an agentic build via dynamic Workflows with codex:codex-rescue adversarial reviews at the brand-critical gates.
+Build plan_v0.11.0: ship the rejected frameworks that are genuinely AGENT-RUNNABLE BUT WEAK (SWOT and a few peers) as honest, low-tier, CAVEAT-FIRST skills, and handle the famous-but-unrunnable instruments (MBTI etc.) with a single cautionary redirect. Repo: E:/Projects/product-on-purpose/thinking-framework-skills. Read FIRST: docs/internal/specs/2026-06-19-contested-lenses.md (the contract, revised after a codex review) and docs/internal/release-plans/plan_v0.11.0/README.md (this plan). The codex findings are in _agent-context/v0.11.0-spec-codex-review.md.
 
-Hard rules: caveat-first is the whole feature (deficiency leads the SKILL.md AND the artifact; reuse each framework's existing why-not dossier as the caveat source). The honest low tier never changes. No em-dashes. Distinct-only (anything that overlaps a shipped skill stays documented-only - it would degrade routing).
+CRITICAL corrections from the review (do not regress): the buildable set is SMALL (~5-12, not ~18-22) - a framework ships only if it passes a THREE-TEST gate: distinct (registry's own verdict) AND agent-runnable (procedure + reusable artifact + a caveated mode that does not reproduce the falsified claim) AND in-charter (not pm-domain, not human-only facilitation, not agent-architecture). MBTI/DISC/Enneagram/learning-styles/cliftonstrengths/belbin FAIL (instrument/overlap) -> cautionary applicator, not skills. Porters/JTBD/blue-ocean/ICE-RICE-WSJF FAIL (pm-domain). dot-voting/note-and-vote/scaled-participation FAIL (human-only). ooda FAILS (agent-architecture). SWOT is the exemplar.
 
-Order (de-risk before scaling): Phase 0 finalize membership (per-framework distinctness call + a light codex challenge) -> Phase 1 infra + ONE hand-authored exemplar (think-swot) + codex review of it BEFORE any batch (this is the template the batch copies) -> Phase 2 batched authoring Workflow (serial groups of ~4-5, one general-purpose subagent per lens, primed with the exemplar + the dossier + the caveat-first rules; registry changes applied centrally) -> Phase 3 integrate + regen all generators + sweep the count surfaces (incl. the un-gated prose docs) + example coverage + gate 0/0 -> Phase 4 run both evals (the output eval ENFORCES the caveat; trigger must hold 0 false-fires) -> Phase 5 codex evidence-honesty + distinctness + IP review of the batch (write findings to a file + confirm, or inline) -> Phase 6 cut v0.11.0 per release-process.md (CHANGELOG/version/manifests/RELEASE-NOTES/README/reconcile), codex-review the cut, then the gated tag + push + GitHub release + agent-plugins marketplace re-pin (worktree off origin/main).
+Caveat-first must be a CHECKED contract: build scripts/check-contested.mjs (new 9th gate layer) before any batch. The advisor must NOT auto-recommend weak lenses: make gen-recommendable + check-registry policy-aware (recommendation_policy: explicit_request_only). Branded survivors get DESCRIPTIVE names (no think-mbti) + artifact-level attribution. Register every new skill in library.json AND update scripts/route-manifest.txt BEFORE regenerating (gen-catalog throws otherwise). Samples go to site/src/content/docs/samples/<slug>.md; do not --update the coverage baseline. Eval thresholds: 0 false-fires hard-block, no contested lens routes a generic prompt away from a shipped skill, every caveat output-check passes; report core-56 and contested as SEPARATE cohorts (do not headline a merged 74).
 
-Do NOT start building skills until Phase 0 membership is final and Phase 1's exemplar passes codex review. Gate mechanics: node scripts/check.mjs (8 layers) + gen-recommendable.mjs --check (separate) + npm test + site build + rendered-links (STRICT_ANCHORS=1) + route-parity. Throttle: batch ~4-5; resumeFromRunId recovers stragglers; Workflow output is under .result in the task .output file.
+Order: Phase 0 finalize membership + the contract decisions (codex challenge) -> Phase 1 build the validator + advisor policy + ONE codex-reviewed exemplar (SWOT) + the cautionary applicator, BEFORE any batch -> Phase 2 batched authoring Workflow (serial groups ~4-5) -> Phase 3 register in library.json + route-manifest + regen all + sweep un-gated prose counts + caveat-first samples + gate 0/0 (9 layers) -> Phase 4 evals with the thresholds above -> Phase 5 codex evidence-honesty/IP/distinctness review (write-to-file or inline) -> Phase 6 cut v0.11.0 (cohort framing) + codex-review the cut + gated tag/push/release + agent-plugins re-pin (worktree off origin/main). Do NOT build until Phase 0 is final and Phase 1's exemplar + validator pass codex review.
 ```

--- a/docs/internal/specs/2026-06-19-contested-lenses.md
+++ b/docs/internal/specs/2026-06-19-contested-lenses.md
@@ -1,56 +1,70 @@
 # Spec: contested lenses - shipping the famous-but-weak frameworks, caveat-first
 
-**Status:** approved (brainstormed 2026-06-19), not started. Execution plan: `docs/internal/release-plans/plan_v0.11.0/`.
-**One line:** ship the distinct-but-weak rejected frameworks (SWOT, MBTI, OODA, Cynefin, ...) as honest, low-tier, **caveat-first** skills, so the plugin helps a user through a lens they asked for while teaching its deficiency - instead of a flat refusal.
+**Status:** approved in principle (brainstormed 2026-06-19), **revised after codex adversarial review** (findings in `_agent-context/v0.11.0-spec-codex-review.md`). Phase 0 must finalize the contract before any build. Execution plan: `docs/internal/release-plans/plan_v0.11.0/`.
+**One line:** ship the small set of rejected frameworks that are genuinely *agent-runnable but weak* (SWOT and a few peers) as honest, low-tier, **caveat-first** skills - and handle the famous-but-unrunnable instruments (MBTI and friends) with a single cautionary redirect rather than pretending they are skills. Help a user through a lens they asked for while teaching its deficiency, instead of a flat refusal.
 
 ## Problem
 
-Today a famous framework the library deliberately did not ship (SWOT, MBTI, five-whys, six-thinking-hats, ...) gets a flat "no" plus a why-not dossier. But users ask for these by name. The honest-grading brand says we should be able to *run the lens and tell the truth about it* rather than refuse. The library already documents every one of them (75 dossiers); the gap is that they are not **runnable**.
+A famous framework the library deliberately did not ship (SWOT, MBTI, five-whys, ...) gets a flat "no" plus a why-not dossier, yet users ask for these by name. The honest-grading brand should let us *run the lens and tell the truth about it* rather than refuse. The library already documents all of them (75 dossiers); the gap is that they are not **runnable**.
 
 ## Decision
 
-Ship the **distinct-but-weak** subset of the rejected set as low-tier skills, built **caveat-first** (the deficiency leads the SKILL.md and the artifact). This was chosen over (a) a single meta-skill applicator (rejected: these are genuinely distinct procedures, a meta-skill would do each shallowly), (b) a separate "contested" class (rejected: the existing S/M/P/V/A/C/X tier system already encodes "low tier = weak evidence"; a second label is redundant), and (c) shipping all 34 excl/flag (rejected: ~half overlap a shipped skill and would re-introduce routing ambiguity).
+Ship the rejected frameworks that pass a **three-test admission gate** (below) as low-tier skills, built **caveat-first** (the deficiency leads the SKILL.md and the artifact). For the famous frameworks that fail the gate because they are not agent-runnable (the person-profiling instruments), ship instead a single **cautionary applicator** that names the limits and redirects to an evidence-based alternative - so we still do not flatly refuse, without pretending a debunked instrument is a runnable skill.
 
-## Scope
+`caveat_first` is **not a second evidence tier** - the S/M/P/V/A/C/X tier already encodes evidential strength. It is a separate, first-class **posture marker** (an execution + routing policy): it controls how the generators render the skill, how the advisor may route to it, and what the gate enforces. (Resolves IC-01: tier = evidence; `caveat_first` = posture.)
 
-**In:** excl/flag frameworks that are (1) **distinct** from every shipped skill (no shipped skill performs the same core move) AND (2) rejected on **evidence / efficacy / branding**, not on overlap.
+## The three-test admission gate (Phase 0 applies this per framework)
 
-Working candidate list (~18-22; finalize per-framework in plan Phase 0 by reading each registry `reasoning`): **swot, mbti, disc-profile, enneagram, learning-styles-inventory, cliftonstrengths, strong-interest-inventory, belbin-team-roles, tuckman-group-development, ooda-loop, cynefin, wardley-mapping, porters-five-forces, blue-ocean-tools, jobs-to-be-done, ice-rice-wsjf, disney-creative-strategy, dot-voting, analysis-of-competing-hypotheses, reflective-equilibrium, qualitative-comparative-analysis** (and a per-framework call on the remaining borderline excl: eisenhower-moscow-pareto, note-and-vote, sensemaking-matrix, insight-statement-generation, concept-knowledge-theory, estimate-talk-estimate, scaled-participation-formats).
+A rejected framework ships as a contested-lens skill only if it passes ALL three:
 
-**Out:** the ~18 **overlap-with-shipped** frameworks (six-thinking-hats -> parallel-perspectives-review; five-whys -> issue-tree; devils-advocacy -> authentic-dissent; key-assumptions-check / double-crux -> what-would-have-to-be-true; cognitive-bias-checklist -> several) - they stay documented-only, because the shipped skill already performs the move and adding them would degrade routing. Also out: the 35 **folds** (subsumed), the 5 **pm** (charter), the 5 **recipes** (already runnable as chains).
+1. **Distinct** - no shipped skill performs its core move. Use the registry's OWN distinctness verdict, not a keyword heuristic. (Excludes six-thinking-hats -> parallel-perspectives-review, five-whys -> issue-tree, devils-advocacy -> authentic-dissent, key-assumptions-check / double-crux -> what-would-have-to-be-true, cognitive-bias-checklist, disney-creative-strategy, cliftonstrengths, belbin-team-roles, ice-rice-wsjf, and any other entry whose reasoning names a shipped home.)
+2. **Agent-runnable** - it has a procedure an agent can actually execute, produces a **reusable artifact**, and has a **caveated mode in which the claim does not reproduce the falsified part**. (Excludes the person-profiling/team instruments that require a proprietary inventory, norm tables, observer ratings, or real human data the agent cannot supply, and whose "valid form" does not exist: MBTI, DISC, Enneagram, learning-styles-inventory, strong-interest-inventory, and the team-stage instruments. These go to the cautionary applicator, not a skill.)
+3. **In charter** - not a pm-domain method (those route to pm-skills: porters-five-forces, jobs-to-be-done, blue-ocean-tools, moat-defensibility, ...) and not a human-only facilitation/group protocol whose value is social dynamics an AI cannot reproduce (dot-voting, note-and-vote, scaled-participation-formats), and not an agent-architecture pattern miscast as a user skill (ooda-loop).
 
-## The mechanism: caveat-first
+**Consequence:** the qualifying set is small - likely ~5-12, not ~18-22. SWOT is the clear, worked example (distinct, agent-runnable 2x2 artifact, weak/contradictory evidence). Phase 0 produces the final list with a one-line pass/fail on each test; everything else stays documented-only or routes to the cautionary applicator.
 
-A normal skill leads with its mechanism. A contested lens **inverts that** - the honest limitation leads, and the user cannot get the lens without it:
+## The mechanism: caveat-first, as a checked contract
 
-- **Status / tier:** registry `excl`/`flag` -> `shipped` at its honest low tier (X / V / C / A / P, unchanged from its current grade).
-- **A `contested` marker** in `skill.meta.yml` (e.g. `quality.caveat_first: true`) so the generators can give it a distinct "use with caution" treatment and the advisor can surface the caveat.
-- **SKILL.md opens with the deficiency** (sourced from the existing why-not dossier): what the evidence actually shows, where it misleads, and the stronger shipped skill to prefer when one exists - *then* the mechanism and procedure.
-- **The artifact carries the caveat.** Its `references/TEMPLATE.md` pre-prints a leading caveat block (like the evidence-caveat element the v0.7.0 tightening added), so a produced SWOT grid opens with "SWOT has weak, contradictory evidence (Hill & Westbrook 1997); this organizes thinking, it does not validate the strategy." Caveat-first by construction.
-- **Reuse the dossier.** The critique is already written (the Framework Library why-not page); the skill consumes it rather than re-researching.
-- Branded lenses (MBTI, Cynefin, Wardley, Porter's, ...) ship **descriptively named + attributed + TM-flagged**, per the open-IP-gate policy (the IP lint already enforces branded -> attribution + trademark).
+Caveat-first is **enforced by a validator**, not left to authoring discipline (resolves DS-01):
 
-## Why this strengthens the brand (not dilutes it)
+- **Registry:** `excl`/`flag` -> `shipped` at its unchanged low tier; a `caveat_first: true` marker (and `recommendation_policy: explicit_request_only`, below) in `skill.meta.yml` (the schema location is fixed in Phase 0).
+- **A new `scripts/check-contested.mjs` validator, wired into `check.mjs`,** identifies contested skills by the marker and asserts: the `SKILL.md` has a leading limitation section *before* the procedure; `references/TEMPLATE.md` opens with a required caveat block; `references/EXAMPLE.md` and the site sample open with the caveat; `eval/cases.md` Output checks include a "leads with the caveat, does not overclaim" item; and (for branded ones) the leading caveat carries the attribution + trademark text. A batch can no longer pass structural checks with a late or missing caveat.
+- **Generators render the marker:** `gen-site.mjs` shows a "use with caution" admonition + a distinct (non-green) badge from the marker; `gen-catalog.mjs` carries the marker so an agent reading the catalog sees the posture.
+- **Reuse the dossier** as the caveat source; do not re-research.
 
-The framing is not "the honest library now ships MBTI." It is: **every skill is evidence-graded - including the famous-but-weak ones, which we grade honestly and hand you caveat-first instead of pretending they do not exist.** That is the purest expression of "honest grading, not breadth." The catalog becomes ~74 skills, *all graded*, the weak ones openly marked. Refusing to run a lens a user explicitly wants is paternalistic; running it with the truth attached is the honest service.
+## Advisor: explicit-request-only (resolves DS-02)
 
-## Integration
+Today `check-registry.mjs` requires the advisor's `recommendable.json` to exactly equal the `shipped` set, and `gen-recommendable.mjs` emits every non-meta shipped skill - so a shipped weak lens would automatically become a default advisor recommendation. That is unacceptable for the brand. Phase 1 changes this:
 
-- **Evals (a feature, not a cost).** The new skills go through the same trigger + output evals. The output-eval "Output checks" for a contested lens **must include "leads with the caveat and does not overclaim"** - which makes the eval *enforce* the caveat-first design by construction. Routing stays clean because the set is distinct (each routes to itself; the trigger eval should hold 0 false-fires).
-- **Advisor.** The recommendable corpus already weights tier (prefer-higher tie-break), so a weak lens surfaces only when genuinely the best fit or explicitly requested; when it does, the caveat must surface. The `contested` marker lets the advisor say "you asked for X; it is weak, here is why, here it is."
-- **Counts / generators.** `excl/flag -> shipped` changes the shipped count (56 -> ~74). Every count surface updates (README's four surfaces, architecture.md, the catalog headers, getting-started/docs-README, the gen-* outputs). `check-counts.mjs` must accept the new shipped total; the catalog families gain the contested members.
-- **Example coverage.** Each new shipped skill needs a worked example (a Showcase appearance or a sample) or a grandfather entry; the samples corpus already gives every shipped skill a sample, so the new ones each get a (caveat-first) sample.
+- `gen-recommendable.mjs` carries `recommendation_policy` + `caveat_first` per entry; contested lenses are marked **explicit-request-only**.
+- `check-registry.mjs`'s shipped == recommendable invariant becomes **policy-aware** (a contested lens is in the corpus but flagged, not a default candidate).
+- The advisor prompt + its eval cases enforce that a contested lens **cannot be Step 1 for a generic strategy/people/prioritization prompt** unless the user names the lens or no stronger shipped skill fits; and when it does surface, the caveat surfaces with it.
+
+## IP: descriptive naming + artifact-level attribution (resolves IP-01, IP-02)
+
+The registry IP lint only checks registry fields. For branded contested lenses:
+
+- **Descriptive slug/name** - do NOT ship `think-mbti` / `think-cynefin` / `think-porters-five-forces`. Use a generic descriptive name (e.g. a SWOT-style grid ships descriptively; a branded term survives only as an attributed alias in the caveat prose), or exclude the method if its trademarked name is inseparable from the user-facing skill.
+- The `check-contested.mjs` validator requires the **attribution + trademark notice in the leading caveat block** of the SKILL.md, TEMPLATE, EXAMPLE, sample, and the rendered page - not only the registry entry.
+
+## Why this strengthens the brand (with honest cohort framing - resolves BR-01)
+
+The framing is not "we now ship 74 skills." It is: **56 evidence-graded core skills, plus N contested, explicit-request lenses we grade honestly and hand you caveat-first.** Count and report the cohorts **separately** (the headline eval numbers stay the 56-core numbers; the contested lenses get their own column). Counting a small, honest, clearly-marked contested cohort separately is the honest expression of "honest grading, not breadth"; folding them into a "74 skills, all graded" headline would read as catalog padding, which the narrow admission gate + cohort framing prevent.
+
+## Integration (the gate-breaking steps the plan must include)
+
+- **`library.json` registration (PC-01):** every new `think-<slug>` must be appended to `library.json` (path, version, tier, status) - `gen-recommendable`/`gen-site`/`gen-catalog` read from it, and `gen-catalog` throws if the library skill count != the registry shipped count.
+- **Route manifest (PC-02):** new framework pages are dead to `gen-catalog` until `scripts/route-manifest.txt` includes `/frameworks/think-<slug>/`; the ordered step is build -> `check-route-parity --update` -> `gen-catalog` -> rebuild + guards.
+- **Samples path (PC-03):** samples live at `site/src/content/docs/samples/<slug>.md` (not a root `samples/`); each new shipped skill gets a caveat-first sample; do NOT run `check-example-coverage --update` to grandfather them.
+- **Eval thresholds (PC-04):** 0 false-fires is hard-blocking; a contested lens must not route a generic prompt away from a stronger shipped skill; every caveat output-check must pass; core-56 and contested scores reported separately.
 
 ## Definition of done
 
-- Each contested lens: `excl/flag -> shipped` at its honest tier; caveat-first SKILL.md (deficiency leads); `references/TEMPLATE.md` pre-prints the caveat; the artifact cannot be produced without it; `skill.meta.yml` carries the `contested`/`caveat_first` marker; branded ones attributed + TM-flagged; a sample (caveat-first) for example coverage; `eval/cases.md` whose Output checks include "caveat leads, no overclaim".
-- Gate 0/0 (all 8 layers, incl. the registry tier/IP/eval-coupling checks); recommendable-drift clean; npm tests; site build + link/route guards.
-- Both evals run on the new skills: routing holds (0 false-fires, top-1 unharmed); output checks pass (the caveat ships).
-- A codex adversarial pass confirms the caveats honestly represent each framework's deficiency per its dossier (no laundering, no overclaim, no false endorsement) and that none competes with a shipped skill in routing.
-- Released as a minor (v0.11.0): the catalog-expansion cut per `release-process.md`, with the brand framing in RELEASE-NOTES.
-
-## Open questions for Phase 0 (resolved during execution, not blockers)
-
-1. **Final membership** - the per-framework distinctness call on the ~6 borderline excl entries.
-2. **The exact `skill.meta.yml` marker name** and how `gen-site.mjs` renders the "use with caution" treatment (a badge variant / a leading admonition).
-3. **Eval reporting** - whether to report the contested lenses' eval scores in a separate column from the graded-56 headline, or as one combined number with the tier visible (recommend: combined, since they are honestly graded skills, but call out the contested subset in the scorecard).
+- Phase 0 produces the final qualifying list with a per-framework three-test pass record; the marker schema, the advisor policy, the site rendering, and the eval-reporting posture are all decided (not "discovered" during the build).
+- `scripts/check-contested.mjs` exists and is a gate layer; the advisor is policy-aware; branded lenses ship descriptively named with artifact-level attribution.
+- Each contested lens: `excl/flag -> shipped` at its honest tier; caveat-first by the validator; registered in `library.json`; a caveat-first sample; `eval/cases.md` with the caveat output-check; route-manifest updated.
+- The cautionary applicator handles the famous-but-unrunnable instruments (explicit-request-only, non-recommendable, redirects to an evidence-based alternative).
+- Gate 0/0 (now 9 layers incl. check-contested); recommendable-drift clean (policy-aware); npm tests; site build + link/route guards.
+- Both evals run; the thresholds above hold; cohorts reported separately.
+- A codex (or inline) adversarial pass confirms the caveats honestly represent each framework's deficiency, no laundering/overclaim/false-endorsement, IP posture correct, and no lens competes with a shipped skill in routing.
+- Released as a minor (v0.11.0) per `release-process.md`, with the cohort framing in RELEASE-NOTES.

--- a/docs/internal/specs/2026-06-19-contested-lenses.md
+++ b/docs/internal/specs/2026-06-19-contested-lenses.md
@@ -1,0 +1,56 @@
+# Spec: contested lenses - shipping the famous-but-weak frameworks, caveat-first
+
+**Status:** approved (brainstormed 2026-06-19), not started. Execution plan: `docs/internal/release-plans/plan_v0.11.0/`.
+**One line:** ship the distinct-but-weak rejected frameworks (SWOT, MBTI, OODA, Cynefin, ...) as honest, low-tier, **caveat-first** skills, so the plugin helps a user through a lens they asked for while teaching its deficiency - instead of a flat refusal.
+
+## Problem
+
+Today a famous framework the library deliberately did not ship (SWOT, MBTI, five-whys, six-thinking-hats, ...) gets a flat "no" plus a why-not dossier. But users ask for these by name. The honest-grading brand says we should be able to *run the lens and tell the truth about it* rather than refuse. The library already documents every one of them (75 dossiers); the gap is that they are not **runnable**.
+
+## Decision
+
+Ship the **distinct-but-weak** subset of the rejected set as low-tier skills, built **caveat-first** (the deficiency leads the SKILL.md and the artifact). This was chosen over (a) a single meta-skill applicator (rejected: these are genuinely distinct procedures, a meta-skill would do each shallowly), (b) a separate "contested" class (rejected: the existing S/M/P/V/A/C/X tier system already encodes "low tier = weak evidence"; a second label is redundant), and (c) shipping all 34 excl/flag (rejected: ~half overlap a shipped skill and would re-introduce routing ambiguity).
+
+## Scope
+
+**In:** excl/flag frameworks that are (1) **distinct** from every shipped skill (no shipped skill performs the same core move) AND (2) rejected on **evidence / efficacy / branding**, not on overlap.
+
+Working candidate list (~18-22; finalize per-framework in plan Phase 0 by reading each registry `reasoning`): **swot, mbti, disc-profile, enneagram, learning-styles-inventory, cliftonstrengths, strong-interest-inventory, belbin-team-roles, tuckman-group-development, ooda-loop, cynefin, wardley-mapping, porters-five-forces, blue-ocean-tools, jobs-to-be-done, ice-rice-wsjf, disney-creative-strategy, dot-voting, analysis-of-competing-hypotheses, reflective-equilibrium, qualitative-comparative-analysis** (and a per-framework call on the remaining borderline excl: eisenhower-moscow-pareto, note-and-vote, sensemaking-matrix, insight-statement-generation, concept-knowledge-theory, estimate-talk-estimate, scaled-participation-formats).
+
+**Out:** the ~18 **overlap-with-shipped** frameworks (six-thinking-hats -> parallel-perspectives-review; five-whys -> issue-tree; devils-advocacy -> authentic-dissent; key-assumptions-check / double-crux -> what-would-have-to-be-true; cognitive-bias-checklist -> several) - they stay documented-only, because the shipped skill already performs the move and adding them would degrade routing. Also out: the 35 **folds** (subsumed), the 5 **pm** (charter), the 5 **recipes** (already runnable as chains).
+
+## The mechanism: caveat-first
+
+A normal skill leads with its mechanism. A contested lens **inverts that** - the honest limitation leads, and the user cannot get the lens without it:
+
+- **Status / tier:** registry `excl`/`flag` -> `shipped` at its honest low tier (X / V / C / A / P, unchanged from its current grade).
+- **A `contested` marker** in `skill.meta.yml` (e.g. `quality.caveat_first: true`) so the generators can give it a distinct "use with caution" treatment and the advisor can surface the caveat.
+- **SKILL.md opens with the deficiency** (sourced from the existing why-not dossier): what the evidence actually shows, where it misleads, and the stronger shipped skill to prefer when one exists - *then* the mechanism and procedure.
+- **The artifact carries the caveat.** Its `references/TEMPLATE.md` pre-prints a leading caveat block (like the evidence-caveat element the v0.7.0 tightening added), so a produced SWOT grid opens with "SWOT has weak, contradictory evidence (Hill & Westbrook 1997); this organizes thinking, it does not validate the strategy." Caveat-first by construction.
+- **Reuse the dossier.** The critique is already written (the Framework Library why-not page); the skill consumes it rather than re-researching.
+- Branded lenses (MBTI, Cynefin, Wardley, Porter's, ...) ship **descriptively named + attributed + TM-flagged**, per the open-IP-gate policy (the IP lint already enforces branded -> attribution + trademark).
+
+## Why this strengthens the brand (not dilutes it)
+
+The framing is not "the honest library now ships MBTI." It is: **every skill is evidence-graded - including the famous-but-weak ones, which we grade honestly and hand you caveat-first instead of pretending they do not exist.** That is the purest expression of "honest grading, not breadth." The catalog becomes ~74 skills, *all graded*, the weak ones openly marked. Refusing to run a lens a user explicitly wants is paternalistic; running it with the truth attached is the honest service.
+
+## Integration
+
+- **Evals (a feature, not a cost).** The new skills go through the same trigger + output evals. The output-eval "Output checks" for a contested lens **must include "leads with the caveat and does not overclaim"** - which makes the eval *enforce* the caveat-first design by construction. Routing stays clean because the set is distinct (each routes to itself; the trigger eval should hold 0 false-fires).
+- **Advisor.** The recommendable corpus already weights tier (prefer-higher tie-break), so a weak lens surfaces only when genuinely the best fit or explicitly requested; when it does, the caveat must surface. The `contested` marker lets the advisor say "you asked for X; it is weak, here is why, here it is."
+- **Counts / generators.** `excl/flag -> shipped` changes the shipped count (56 -> ~74). Every count surface updates (README's four surfaces, architecture.md, the catalog headers, getting-started/docs-README, the gen-* outputs). `check-counts.mjs` must accept the new shipped total; the catalog families gain the contested members.
+- **Example coverage.** Each new shipped skill needs a worked example (a Showcase appearance or a sample) or a grandfather entry; the samples corpus already gives every shipped skill a sample, so the new ones each get a (caveat-first) sample.
+
+## Definition of done
+
+- Each contested lens: `excl/flag -> shipped` at its honest tier; caveat-first SKILL.md (deficiency leads); `references/TEMPLATE.md` pre-prints the caveat; the artifact cannot be produced without it; `skill.meta.yml` carries the `contested`/`caveat_first` marker; branded ones attributed + TM-flagged; a sample (caveat-first) for example coverage; `eval/cases.md` whose Output checks include "caveat leads, no overclaim".
+- Gate 0/0 (all 8 layers, incl. the registry tier/IP/eval-coupling checks); recommendable-drift clean; npm tests; site build + link/route guards.
+- Both evals run on the new skills: routing holds (0 false-fires, top-1 unharmed); output checks pass (the caveat ships).
+- A codex adversarial pass confirms the caveats honestly represent each framework's deficiency per its dossier (no laundering, no overclaim, no false endorsement) and that none competes with a shipped skill in routing.
+- Released as a minor (v0.11.0): the catalog-expansion cut per `release-process.md`, with the brand framing in RELEASE-NOTES.
+
+## Open questions for Phase 0 (resolved during execution, not blockers)
+
+1. **Final membership** - the per-framework distinctness call on the ~6 borderline excl entries.
+2. **The exact `skill.meta.yml` marker name** and how `gen-site.mjs` renders the "use with caution" treatment (a badge variant / a leading admonition).
+3. **Eval reporting** - whether to report the contested lenses' eval scores in a separate column from the graded-56 headline, or as one combined number with the tier visible (recommend: combined, since they are honestly graded skills, but call out the contested subset in the scorecard).


### PR DESCRIPTION
The brainstormed design (2026-06-19) + the agentic release/execution plan a fresh session can run.

**Spec** (`docs/internal/specs/2026-06-19-contested-lenses.md`): ship the *distinct-but-weak* rejected frameworks (SWOT, MBTI, OODA, Cynefin...) as honest, low-tier, **caveat-first** skills. Overlap-with-shipped frameworks stay documented-only (protect routing); folds/pm/recipes out. Mechanism: the deficiency leads the SKILL.md and the artifact, reusing the existing why-not dossier. Framed as a brand *strengthener* (every skill graded, including the famous-but-weak ones).

**Plan** (`plan_v0.11.0/README.md`): de-risk-before-scale phases - finalize membership -> infra + ONE codex-reviewed exemplar (think-swot) -> batched authoring Workflow -> integrate/regen -> evals (the output eval enforces the caveat) -> codex evidence-honesty review -> v0.11.0 cut + marketplace re-pin. Carries this session's throttle/codex-retrievability/prose-drift lessons + a copy-paste continuation prompt.

Planning docs only - no skills built here. **Holding merge for your review** of the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)